### PR TITLE
880: Removing securebanking-common-cors dependency and configuration

### DIFF
--- a/_infra/helm/securebanking-openbanking-uk-rs/templates/deployment.yaml
+++ b/_infra/helm/securebanking-openbanking-uk-rs/templates/deployment.yaml
@@ -54,8 +54,6 @@ spec:
             value: {{ .Values.mongodb.host }}
           - name: SERVER_PORT
             value: {{ .Values.deployment.server.port | quote }}
-          - name: EXPECTED_ORIGIN_ENDS
-            value: {{ .Values.deployment.cors.originEnds }}
           - name: CONSENT_REPO_HOST
             valueFrom:
               configMapKeyRef:

--- a/_infra/helm/securebanking-openbanking-uk-rs/values.yaml
+++ b/_infra/helm/securebanking-openbanking-uk-rs/values.yaml
@@ -15,9 +15,6 @@ deployment:
     tag: latest
     tagDelimiter: ":"
 
-  cors:
-    originEnds: localhost
-
   server:
     port: 8080
 

--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,6 @@
 
     <properties>
         <uk.bom.version>0.9.0-SNAPSHOT</uk.bom.version>
-        <common.cors.version>0.9.0-SNAPSHOT</common.cors.version>
     </properties>
 
     <dependencyManagement>
@@ -63,11 +62,6 @@
                 <version>${uk.bom.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>com.forgerock.sapi.gateway</groupId>
-                <artifactId>secure-api-gateway-common-cors</artifactId>
-                <version>${common.cors.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/secure-api-gateway-ob-uk-rs-server/docker/config/securebanking-openbanking-uk-rs-docker.yml
+++ b/secure-api-gateway-ob-uk-rs-server/docker/config/securebanking-openbanking-uk-rs-docker.yml
@@ -15,19 +15,6 @@
 #
 
 ### Spring Configuration for securebanking-openbanking-uk-rs-simulator running in Docker
-
-# Configuration properties entries for common libraries
-common: # root key for all common 'securebanking-common-${library-name}' libraries
-  cors: # library name
-#    allowed_origins: # CORS list allowed domains, to check if the origin header domain ends with any allowed origin.
-#      - "*" allow all origins
-#      - localhost # to use from local deployment
-#      - forgerock.financial # valid for *.forgerock.financial
-    allowed_headers: accept-api-version, x-requested-with, authorization, Content-Type, Authorization, credential, X-XSRF-TOKEN, Id-Token # CORS allowed headers
-    allowed_methods: GET, PUT, POST, DELETE, OPTIONS, PATCH # Allowed methods for preflight request
-    allowed_credentials: false #true # Credentials accepted, default value true
-    max_age: 8000 #3600 # Expiration time of preflight request, default value 3600
-
 # Spring data Mongo config
 spring:
   data:

--- a/secure-api-gateway-ob-uk-rs-server/pom.xml
+++ b/secure-api-gateway-ob-uk-rs-server/pom.xml
@@ -51,10 +51,6 @@
         <!-- ForgeRock dependencies -->
         <dependency>
             <groupId>com.forgerock.sapi.gateway</groupId>
-            <artifactId>secure-api-gateway-common-cors</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.forgerock.sapi.gateway</groupId>
             <artifactId>secure-api-gateway-ob-uk-rs-obie-api</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/RSServerApplication.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/RSServerApplication.java
@@ -22,7 +22,6 @@ import org.springframework.data.mongodb.repository.config.EnableMongoRepositorie
 
 @ComponentScan(basePackages =
         {
-                "com.forgerock.sapi.gateway.common.cors",
                 "com.forgerock.sapi.gateway.ob.uk.rs"
         }
 )

--- a/secure-api-gateway-ob-uk-rs-server/src/test/resources/application-test.yml
+++ b/secure-api-gateway-ob-uk-rs-server/src/test/resources/application-test.yml
@@ -27,18 +27,6 @@ rs:
         accounts: 100
         documents: 1000
 
-# Configuration properties entries for common libraries
-common: # root key for all common 'securebanking-common-${library-name}' libraries
-  cors: # library name
-#    allowed_origins: # CORS list allowed domains, to check if the origin header domain ends with any allowed origin.
-#      - "*" Allow all origins
-#      - localhost
-#      - forgerock.financial # valid for *.forgerock.financial
-    allowed_headers: accept-api-version, x-requested-with, authorization, Content-Type, Authorization, credential, X-XSRF-TOKEN, Id-Token # CORS allowed headers
-    allowed_methods: GET, PUT, POST, DELETE, OPTIONS, PATCH # Allowed methods for preflight request
-    allowed_credentials: true # Credentials accepted, default value true
-    max_age: 3600 # Expiration time of preflight request, default value 3600
-
 # Swagger Documentation Specification properties
 swagger:
   title: Secure Banking Access Toolkit


### PR DESCRIPTION
There is no requirement to support CORS for the RS, the RS is never expected to be called from a browser.

Removing the dependency and related configuration

https://github.com/SecureApiGateway/SecureApiGateway/issues/880