### PR TITLE
874: Fixing self links for PaymentFundsConfirmationApiController

### DIFF
--- a/secure-api-gateway-ob-uk-rs-backoffice-api/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/backoffice/api/payment/PaymentFundsConfirmationApi.java
+++ b/secure-api-gateway-ob-uk-rs-backoffice-api/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/backoffice/api/payment/PaymentFundsConfirmationApi.java
@@ -78,6 +78,9 @@ public interface PaymentFundsConfirmationApi {
             @ApiParam(value = "Indicates the user-agent that the PSU is using.")
             @RequestHeader(value = "x-customer-user-agent", required = false) String xCustomerUserAgent,
 
+            @ApiParam(value = "Original Open Banking URL called by the TPP")
+            @RequestHeader(value = "x-ob-url") String xObUrl,
+
             HttpServletRequest request,
 
             Principal principal

--- a/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/backoffice/payment/PaymentFundsConfirmationApiController.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/backoffice/payment/PaymentFundsConfirmationApiController.java
@@ -15,7 +15,7 @@
  */
 package com.forgerock.sapi.gateway.ob.uk.rs.server.api.backoffice.payment;
 
-import com.forgerock.sapi.gateway.ob.uk.rs.server.common.util.link.LinksHelper;
+import com.forgerock.sapi.gateway.ob.uk.rs.server.common.util.PaginationUtil;
 import com.forgerock.sapi.gateway.ob.uk.rs.server.service.balance.FundsAvailabilityService;
 import com.forgerock.sapi.gateway.ob.uk.rs.backoffice.api.payment.PaymentFundsConfirmationApi;
 import lombok.extern.slf4j.Slf4j;
@@ -51,6 +51,7 @@ public class PaymentFundsConfirmationApiController implements PaymentFundsConfir
             String xFapiCustomerIpAddress,
             String xFapiInteractionId,
             String xCustomerUserAgent,
+            String xObUrl,
             HttpServletRequest request,
             Principal principal) {
 
@@ -70,7 +71,7 @@ public class PaymentFundsConfirmationApiController implements PaymentFundsConfir
                                                 )
                                                 .supplementaryData(null)
                                 )
-                                .links(LinksHelper.createDomesticPaymentsConsentFundsConfirmationLink(this.getClass(), version, accountId))
+                                .links(PaginationUtil.generateLinksOnePager(xObUrl))
                                 .meta(new Meta())
                 );
     }

--- a/secure-api-gateway-ob-uk-rs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/backoffice/payment/PaymentFundsConfirmationApiControllerTest.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/backoffice/payment/PaymentFundsConfirmationApiControllerTest.java
@@ -47,7 +47,6 @@ import static org.springframework.boot.test.context.SpringBootTest.WebEnvironmen
 @SpringBootTest(webEnvironment = RANDOM_PORT)
 @ActiveProfiles("test")
 public class PaymentFundsConfirmationApiControllerTest {
-    private static final HttpHeaders HTTP_HEADERS = HttpHeadersTestDataFactory.requiredPaymentFundsConfirmationHttpHeaders();
     private static final String BASE_URL = "http://localhost:";
     private static final String FUNDS_CONFIRMATION_URI = "/backoffice/payment-funds-confirmation";
     private static final String CURRENCY = "GBP";
@@ -86,12 +85,13 @@ public class PaymentFundsConfirmationApiControllerTest {
         ResponseEntity<OBWriteFundsConfirmationResponse1> response = restTemplate.exchange(
                 uri,
                 HttpMethod.GET,
-                new HttpEntity<>(HTTP_HEADERS),
+                new HttpEntity<>(HttpHeadersTestDataFactory.requiredPaymentFundsConfirmationHttpHeaders(uri.toString())),
                 OBWriteFundsConfirmationResponse1.class);
 
         // Then
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
         assertThat(response.getBody().getData().getFundsAvailableResult().getFundsAvailable()).isTrue();
+        assertThat(response.getBody().getLinks().getSelf()).isEqualTo(uri);
     }
 
     @Test
@@ -108,12 +108,13 @@ public class PaymentFundsConfirmationApiControllerTest {
         ResponseEntity<OBWriteFundsConfirmationResponse1> response = restTemplate.exchange(
                 uri,
                 HttpMethod.GET,
-                new HttpEntity<>(HTTP_HEADERS),
+                new HttpEntity<>(HttpHeadersTestDataFactory.requiredPaymentFundsConfirmationHttpHeaders(uri.toString())),
                 OBWriteFundsConfirmationResponse1.class);
 
         // Then
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
         assertThat(response.getBody().getData().getFundsAvailableResult().getFundsAvailable()).isFalse();
+        assertThat(response.getBody().getLinks().getSelf()).isEqualTo(uri);
     }
 
     private FRBalance aValidFRBalance(String accountId) {

--- a/secure-api-gateway-ob-uk-rs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/server/testsupport/api/HttpHeadersTestDataFactory.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/server/testsupport/api/HttpHeadersTestDataFactory.java
@@ -95,7 +95,7 @@ public class HttpHeadersTestDataFactory {
     /**
      * @return an instance of {@link HttpHeaders} with the minimal set of required headers for the Payment Funds Confirmation API.
      */
-    public static HttpHeaders requiredPaymentFundsConfirmationHttpHeaders() {
+    public static HttpHeaders requiredPaymentFundsConfirmationHttpHeaders(String resourceUrl) {
         HttpHeaders headers = new HttpHeaders();
         headers.setAccept(singletonList(MediaType.APPLICATION_JSON));
         headers.setContentType(MediaType.APPLICATION_JSON);
@@ -104,6 +104,7 @@ public class HttpHeadersTestDataFactory {
         headers.add("x-fapi-interaction-id", UUID.randomUUID().toString());
         headers.add("x-idempotency-key", UUID.randomUUID().toString());
         headers.add("x-ob-account-id", UUID.randomUUID().toString());
+        headers.add("x-ob-url", resourceUrl);
         return headers;
     }
 


### PR DESCRIPTION
The existing implementation for the self links is broken as it includes the /backoffice API in the path, it is also missing the /rs/ path element.

All funds confirmation requests get mapped on to the single PaymentFundsConfirmationApiController (that is part of the /backoffice API). In order to build the self links this controller needs to know that original OB URL that was used to call IG.

Adding `x-ob-url` header parameter to the controller and using it to build the self links. This is the same pattern used by the Accounts API.

https://github.com/SecureApiGateway/SecureApiGateway/issues/874