### PR TITLE
888: Allowing Spring config to be overridden by helm values

### DIFF
--- a/_infra/helm/securebanking-openbanking-uk-rs/templates/configmap.yaml
+++ b/_infra/helm/securebanking-openbanking-uk-rs/templates/configmap.yaml
@@ -1,0 +1,10 @@
+{{- if .Values.springConfig -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Chart.Name }}-spring-config
+  labels:
+    app: {{ .Chart.Name }}
+data:
+  application.yml: {{ tpl (toYaml .Values.springConfig) . | nindent 4 }}
+{{- end }}

--- a/_infra/helm/securebanking-openbanking-uk-rs/templates/configmap.yaml
+++ b/_infra/helm/securebanking-openbanking-uk-rs/templates/configmap.yaml
@@ -6,5 +6,5 @@ metadata:
   labels:
     app: {{ .Chart.Name }}
 data:
-  application.yml: {{ tpl (toYaml .Values.springConfig) . | nindent 4 }}
+  application.yml: | {{ tpl (toYaml .Values.springConfig) . | nindent 4 }}
 {{- end }}

--- a/_infra/helm/securebanking-openbanking-uk-rs/templates/deployment.yaml
+++ b/_infra/helm/securebanking-openbanking-uk-rs/templates/deployment.yaml
@@ -49,6 +49,9 @@ spec:
             failureThreshold: 5
             successThreshold: 1
             timeoutSeconds: 5
+          volumeMounts:
+            - name: spring-config
+              mountPath: /app/config
           env:
           - name: SPRING_DATA_MONGODB_HOST
             value: {{ .Values.mongodb.host }}
@@ -70,3 +73,13 @@ spec:
             value: {{ .Values.deployment.java.opts }}
           resources:
             {{- toYaml .Values.deployment.resources | nindent 12 }}
+      volumes:
+        {{- if .Values.springConfig }}
+          - name: spring-config
+            configMap:
+              name: {{ .Chart.Name }}-spring-config
+        {{- else }}
+          - name: spring-config
+            emptyDir: { }
+        {{- end }}
+

--- a/_infra/helm/securebanking-openbanking-uk-rs/values.yaml
+++ b/_infra/helm/securebanking-openbanking-uk-rs/values.yaml
@@ -36,3 +36,5 @@ service:
   apiVersion: v1
   type: ClusterIP
 
+# Addition Spring properties can be provided as a yaml block here, this will be mounted into the container and override / extend the config found in the application.yml inside the jar
+springConfig: {}

--- a/secure-api-gateway-ob-uk-rs-server/src/main/resources/application.yml
+++ b/secure-api-gateway-ob-uk-rs-server/src/main/resources/application.yml
@@ -50,16 +50,3 @@ rs:
       limit:
         accounts: 100
         documents: 1000
-
-# Configuration for testdata used by the Bank Simulator
-testdata:
-  # Configure Account Identifier for test users, if config is not provided for a particular user then randomised data is used
-  # See com.forgerock.sapi.gateway.ob.uk.rs.server.configuration.TestUserAccountIds
-  userAccountIds:
-    psu4test:
-      - sortCode: "012332"
-        accountNumber: "43245676"
-      - sortCode: "012332"
-        accountNumber: "54312390"
-      - sortCode: "334412"
-        accountNumber: "30187862"

--- a/secure-api-gateway-ob-uk-rs-server/src/test/resources/application-test.yml
+++ b/secure-api-gateway-ob-uk-rs-server/src/test/resources/application-test.yml
@@ -13,3 +13,15 @@ consent:
 rs:
   discovery:
     financialId: 0015800001041REAAY
+
+testdata:
+  # Configure Account Identifier for test users, if config is not provided for a particular user then randomised data is used
+  # See com.forgerock.sapi.gateway.ob.uk.rs.server.configuration.TestUserAccountIds
+  userAccountIds:
+    psu4test:
+      - sortCode: "012332"
+        accountNumber: "43245676"
+      - sortCode: "012332"
+        accountNumber: "54312390"
+      - sortCode: "334412"
+        accountNumber: "30187862"


### PR DESCRIPTION
Deployment specific Spring configuration can be provided by adding the properties as yaml to the `springConfig` object in the helm values file. By default this object will be empty.

If Spring Config is provided in this manner, then a ConfigMap is created which contains the configuration block. This is then mounted into the RS docker container under /app/config/application.yml. Spring property resolution will check for config in this file before it falls back to the application.yml found within the JAR.

Removed FR deployment specific `testdata` configuration from application.yml (moved it into applicaiton-test.yml as unit tests use it); for dev deployments this will be supplied via ArgoCD. See PR: https://github.com/SecureApiGateway/sbat-cd/pull/101

https://github.com/SecureApiGateway/SecureApiGateway/issues/888