### PR TITLE
889: Correct path for docker dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,6 @@ updates:
     schedule:
       interval: "weekly"
   - package-ecosystem: "docker"
-    directory: "/docker"
+    directory: "/secure-api-gateway-ob-uk-rs-server/docker"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
Issue: https://github.com/secureapigateway/secureapigateway/issues/889