### PR TITLE
927: Update dependency and chart version for 1.0.0

### DIFF
--- a/_infra/helm/securebanking-openbanking-uk-rs/Chart.yaml
+++ b/_infra/helm/securebanking-openbanking-uk-rs/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: test-facility-bank
 description: Test facility bank service Helm chart for Kubernetes
 type: application
-version: 0.9.1
-appVersion: 0.9.1
+version: 1.0.0
+appVersion: 1.0.0

--- a/pom.xml
+++ b/pom.xml
@@ -45,11 +45,11 @@
     <parent>
         <groupId>com.forgerock.sapi.gateway</groupId>
         <artifactId>secure-api-gateway-parent</artifactId>
-        <version>0.9.1</version>
+        <version>1.0.0</version>
     </parent>
 
     <properties>
-        <uk.bom.version>0.9.1</uk.bom.version>
+        <uk.bom.version>1.0.0</uk.bom.version>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
Preparing for v1.0.0 release.
- Update helm chart version
- update dependency versions of parent and bom

Issue: https://github.com/secureapigateway/secureapigateway/issues/927