### PR TITLE
934 fix argocd application values prefix on PR pushes to an environment

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -69,7 +69,7 @@ jobs:
       - name: 'run functional tests'
         uses: codefresh-io/codefresh-pipeline-runner@master
         with:
-          args: '-v SERVICE_NAME=test-facility-bank'
+          args: '-v ARGO_VALUES_PREFIX=testFacilityBank -v SERVICE_NAME=test-facility-bank'
         env:
           PIPELINE_NAME: 'ForgeCloud/sbat-infra/service-build'
           CF_API_KEY: ${{ secrets.CF_API_KEY }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -88,7 +88,7 @@ jobs:
       - name: 'run functional tests'
         uses: codefresh-io/codefresh-pipeline-runner@master
         with:
-          args: '-v TAG=${{ env.PR_NUMBER }} -v SERVICE_NAME=test-facility-bank -v ENVIRONMENT=${{ env.GITHUB_USER }} -v BRANCH=${{ github.head_ref }}'
+          args: '-v TAG=${{ env.PR_NUMBER }} -v ARGO_VALUES_PREFIX=testFacilityBank -v SERVICE_NAME=test-facility-bank -v ENVIRONMENT=${{ env.GITHUB_USER }} -v BRANCH=${{ github.head_ref }}'
         env:
           PIPELINE_NAME: 'ForgeCloud/sbat-infra/service-build'
           CF_API_KEY: ${{ secrets.CF_API_KEY }}


### PR DESCRIPTION
- Updated pr workflow to pass the variable 'ARGO_VALUES_PREFIX=testFacilityBank'
- Updated merge master workflow to pass the variable 'ARGO_VALUES_PREFIX=testFacilityBank'

Issue: https://github.com/secureapigateway/secureapigateway/issues/934