### PR TITLE
485: Reviewing FAPI compliance alignment headers section

### DIFF
--- a/secure-api-gateway-ob-uk-rs-obie-api/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/obie/api/account/v3_0/accounts/AccountsApi.java
+++ b/secure-api-gateway-ob-uk-rs-obie-api/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/obie/api/account/v3_0/accounts/AccountsApi.java
@@ -52,11 +52,11 @@ public interface AccountsApi {
             @ApiResponse(code = 405, message = "Method Not Allowed", response = Void.class),
             @ApiResponse(code = 406, message = "Not Acceptable", response = Void.class),
             @ApiResponse(code = 429, message = "Too Many Requests", response = Void.class),
-            @ApiResponse(code = 500, message = "Internal Server Error", response = Void.class) })
+            @ApiResponse(code = 500, message = "Internal Server Error", response = Void.class)})
 
 
     @RequestMapping(value = "/accounts/{AccountId}",
-            produces = { "application/json; charset=utf-8" },
+            produces = {"application/json; charset=utf-8"},
             method = RequestMethod.GET)
     ResponseEntity<OBReadAccount2> getAccount(
             @ApiParam(value = "A unique identifier used to identify the account resource.", required = true)
@@ -67,8 +67,8 @@ public interface AccountsApi {
 
             @ApiParam(value = "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are " +
                     "represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC")
-            @RequestHeader(value="x-fapi-customer-last-logged-time", required=false)
-            @DateTimeFormat(pattern = ApiConstants.HTTP_DATE_FORMAT) DateTime xFapiCustomerLastLoggedTime,
+            @RequestHeader(value = "x-fapi-auth-date", required = false)
+            @DateTimeFormat(pattern = ApiConstants.HTTP_DATE_FORMAT) DateTime xFapiAuthDate,
 
             @ApiParam(value = "The PSU's IP address if the PSU is currently logged in with the TPP.")
             @RequestHeader(value = "x-fapi-customer-ip-address", required = false) String xFapiCustomerIpAddress,
@@ -98,11 +98,11 @@ public interface AccountsApi {
             @ApiResponse(code = 405, message = "Method Not Allowed", response = Void.class),
             @ApiResponse(code = 406, message = "Not Acceptable", response = Void.class),
             @ApiResponse(code = 429, message = "Too Many Requests", response = Void.class),
-            @ApiResponse(code = 500, message = "Internal Server Error", response = Void.class) })
+            @ApiResponse(code = 500, message = "Internal Server Error", response = Void.class)})
 
 
     @RequestMapping(value = "/accounts",
-            produces = { "application/json; charset=utf-8" },
+            produces = {"application/json; charset=utf-8"},
             method = RequestMethod.GET)
     ResponseEntity<OBReadAccount2> getAccounts(
             @ApiParam(value = "Page number.", required = false, defaultValue = "0")
@@ -113,8 +113,8 @@ public interface AccountsApi {
 
             @ApiParam(value = "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are " +
                     "represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC")
-            @RequestHeader(value="x-fapi-customer-last-logged-time", required=false)
-            @DateTimeFormat(pattern = ApiConstants.HTTP_DATE_FORMAT) DateTime xFapiCustomerLastLoggedTime,
+            @RequestHeader(value = "x-fapi-auth-date", required = false)
+            @DateTimeFormat(pattern = ApiConstants.HTTP_DATE_FORMAT) DateTime xFapiAuthDate,
 
             @ApiParam(value = "The PSU's IP address if the PSU is currently logged in with the TPP.")
             @RequestHeader(value = "x-fapi-customer-ip-address", required = false) String xFapiCustomerIpAddress,

--- a/secure-api-gateway-ob-uk-rs-obie-api/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/obie/api/account/v3_0/balances/BalancesApi.java
+++ b/secure-api-gateway-ob-uk-rs-obie-api/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/obie/api/account/v3_0/balances/BalancesApi.java
@@ -69,8 +69,8 @@ public interface BalancesApi {
 
             @ApiParam(value = "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are " +
                     "represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC")
-            @RequestHeader(value="x-fapi-customer-last-logged-time", required=false)
-            @DateTimeFormat(pattern = ApiConstants.HTTP_DATE_FORMAT) DateTime xFapiCustomerLastLoggedTime,
+            @RequestHeader(value = "x-fapi-auth-date", required = false)
+            @DateTimeFormat(pattern = ApiConstants.HTTP_DATE_FORMAT) DateTime xFapiAuthDate,
 
             @ApiParam(value = "The PSU's IP address if the PSU is currently logged in with the TPP.")
             @RequestHeader(value = "x-fapi-customer-ip-address", required = false) String xFapiCustomerIpAddress,
@@ -117,8 +117,8 @@ public interface BalancesApi {
 
             @ApiParam(value = "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are " +
                     "represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC")
-            @RequestHeader(value="x-fapi-customer-last-logged-time", required=false)
-            @DateTimeFormat(pattern = ApiConstants.HTTP_DATE_FORMAT) DateTime xFapiCustomerLastLoggedTime,
+            @RequestHeader(value = "x-fapi-auth-date", required = false)
+            @DateTimeFormat(pattern = ApiConstants.HTTP_DATE_FORMAT) DateTime xFapiAuthDate,
 
             @ApiParam(value = "The PSU's IP address if the PSU is currently logged in with the TPP.")
             @RequestHeader(value = "x-fapi-customer-ip-address", required = false) String xFapiCustomerIpAddress,

--- a/secure-api-gateway-ob-uk-rs-obie-api/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/obie/api/account/v3_0/beneficiaries/BeneficiariesApi.java
+++ b/secure-api-gateway-ob-uk-rs-obie-api/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/obie/api/account/v3_0/beneficiaries/BeneficiariesApi.java
@@ -54,11 +54,11 @@ public interface BeneficiariesApi {
             @ApiResponse(code = 405, message = "Method Not Allowed", response = Void.class),
             @ApiResponse(code = 406, message = "Not Acceptable", response = Void.class),
             @ApiResponse(code = 429, message = "Too Many Requests", response = Void.class),
-            @ApiResponse(code = 500, message = "Internal Server Error", response = Void.class) })
+            @ApiResponse(code = 500, message = "Internal Server Error", response = Void.class)})
 
 
     @RequestMapping(value = "/accounts/{AccountId}/beneficiaries",
-            produces = { "application/json; charset=utf-8" },
+            produces = {"application/json; charset=utf-8"},
             method = RequestMethod.GET)
     ResponseEntity<OBReadBeneficiary2> getAccountBeneficiaries(
 
@@ -73,8 +73,8 @@ public interface BeneficiariesApi {
 
             @ApiParam(value = "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are " +
                     "represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC")
-            @RequestHeader(value="x-fapi-customer-last-logged-time", required=false)
-            @DateTimeFormat(pattern = ApiConstants.HTTP_DATE_FORMAT) DateTime xFapiCustomerLastLoggedTime,
+            @RequestHeader(value = "x-fapi-auth-date", required = false)
+            @DateTimeFormat(pattern = ApiConstants.HTTP_DATE_FORMAT) DateTime xFapiAuthDate,
 
             @ApiParam(value = "The PSU's IP address if the PSU is currently logged in with the TPP.")
             @RequestHeader(value = "x-fapi-customer-ip-address", required = false) String xFapiCustomerIpAddress,
@@ -105,11 +105,11 @@ public interface BeneficiariesApi {
             @ApiResponse(code = 405, message = "Method Not Allowed", response = Void.class),
             @ApiResponse(code = 406, message = "Not Acceptable", response = Void.class),
             @ApiResponse(code = 429, message = "Too Many Requests", response = Void.class),
-            @ApiResponse(code = 500, message = "Internal Server Error", response = Void.class) })
+            @ApiResponse(code = 500, message = "Internal Server Error", response = Void.class)})
 
 
     @RequestMapping(value = "/beneficiaries",
-            produces = { "application/json; charset=utf-8" },
+            produces = {"application/json; charset=utf-8"},
             method = RequestMethod.GET)
     ResponseEntity<OBReadBeneficiary2> getBeneficiaries(
             @ApiParam(value = "Page number.", required = false, defaultValue = "0")
@@ -121,8 +121,8 @@ public interface BeneficiariesApi {
             @ApiParam(value = "The time when the PSU last logged in with the TPP. " +
                     "All dates in the HTTP headers are represented as RFC 7231 Full Dates. " +
                     "An example is below:  Sun, 10 Sep 2017 19:43:31 UTC")
-            @RequestHeader(value="x-fapi-customer-last-logged-time", required=false)
-            @DateTimeFormat(pattern = ApiConstants.HTTP_DATE_FORMAT) DateTime xFapiCustomerLastLoggedTime,
+            @RequestHeader(value = "x-fapi-auth-date", required = false)
+            @DateTimeFormat(pattern = ApiConstants.HTTP_DATE_FORMAT) DateTime xFapiAuthDate,
 
             @ApiParam(value = "The PSU's IP address if the PSU is currently logged in with the TPP.")
             @RequestHeader(value = "x-fapi-customer-ip-address", required = false) String xFapiCustomerIpAddress,

--- a/secure-api-gateway-ob-uk-rs-obie-api/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/obie/api/account/v3_0/directdebits/DirectDebitsApi.java
+++ b/secure-api-gateway-ob-uk-rs-obie-api/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/obie/api/account/v3_0/directdebits/DirectDebitsApi.java
@@ -70,8 +70,8 @@ public interface DirectDebitsApi {
 
             @ApiParam(value = "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are" +
                     " represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC")
-            @RequestHeader(value="x-fapi-customer-last-logged-time", required=false)
-            @DateTimeFormat(pattern = ApiConstants.HTTP_DATE_FORMAT) DateTime xFapiCustomerLastLoggedTime,
+            @RequestHeader(value = "x-fapi-auth-date", required = false)
+            @DateTimeFormat(pattern = ApiConstants.HTTP_DATE_FORMAT) DateTime xFapiAuthDate,
 
             @ApiParam(value = "The PSU's IP address if the PSU is currently logged in with the TPP.")
             @RequestHeader(value = "x-fapi-customer-ip-address", required = false) String xFapiCustomerIpAddress,
@@ -118,8 +118,8 @@ public interface DirectDebitsApi {
 
             @ApiParam(value = "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are " +
                     "represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC")
-            @RequestHeader(value="x-fapi-customer-last-logged-time", required=false)
-            @DateTimeFormat(pattern = ApiConstants.HTTP_DATE_FORMAT) DateTime xFapiCustomerLastLoggedTime,
+            @RequestHeader(value = "x-fapi-auth-date", required = false)
+            @DateTimeFormat(pattern = ApiConstants.HTTP_DATE_FORMAT) DateTime xFapiAuthDate,
 
             @ApiParam(value = "The PSU's IP address if the PSU is currently logged in with the TPP.")
             @RequestHeader(value =

--- a/secure-api-gateway-ob-uk-rs-obie-api/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/obie/api/account/v3_0/offers/OffersApi.java
+++ b/secure-api-gateway-ob-uk-rs-obie-api/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/obie/api/account/v3_0/offers/OffersApi.java
@@ -52,9 +52,9 @@ public interface OffersApi {
             @ApiResponse(code = 405, message = "Method Not Allowed"),
             @ApiResponse(code = 406, message = "Not Acceptable"),
             @ApiResponse(code = 429, message = "Too Many Requests"),
-            @ApiResponse(code = 500, message = "Internal Server Error") })
+            @ApiResponse(code = 500, message = "Internal Server Error")})
     @RequestMapping(value = "/accounts/{AccountId}/offers",
-            produces = { "application/json; charset=utf-8" },
+            produces = {"application/json; charset=utf-8"},
             method = RequestMethod.GET)
     ResponseEntity<OBReadOffer1> getAccountOffers(
             @ApiParam(value = "A unique identifier used to identify the account resource.", required = true)
@@ -70,8 +70,8 @@ public interface OffersApi {
                     "All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  " +
                     "Sun, 10 Sep 2017 19:43:31 UTC")
 
-            @RequestHeader(value="x-fapi-customer-last-logged-time", required=false)
-            @DateTimeFormat(pattern = ApiConstants.HTTP_DATE_FORMAT) DateTime xFapiCustomerLastLoggedTime,
+            @RequestHeader(value = "x-fapi-auth-date", required = false)
+            @DateTimeFormat(pattern = ApiConstants.HTTP_DATE_FORMAT) DateTime xFapiAuthDate,
             @ApiParam(value = "The PSU's IP address if the PSU is currently logged in with the TPP.")
 
             @RequestHeader(value = "x-fapi-customer-ip-address", required = false) String xFapiCustomerIpAddress,
@@ -102,9 +102,9 @@ public interface OffersApi {
             @ApiResponse(code = 405, message = "Method Not Allowed"),
             @ApiResponse(code = 406, message = "Not Acceptable"),
             @ApiResponse(code = 429, message = "Too Many Requests"),
-            @ApiResponse(code = 500, message = "Internal Server Error") })
+            @ApiResponse(code = 500, message = "Internal Server Error")})
     @RequestMapping(value = "/offers",
-            produces = { "application/json; charset=utf-8" },
+            produces = {"application/json; charset=utf-8"},
             method = RequestMethod.GET)
     ResponseEntity<OBReadOffer1> getOffers(
             @ApiParam(value = "Page number.", required = false, defaultValue = "0")
@@ -116,8 +116,8 @@ public interface OffersApi {
             @ApiParam(value = "The time when the PSU last logged in with the TPP.  " +
                     "All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below: " +
                     " Sun, 10 Sep 2017 19:43:31 UTC")
-            @RequestHeader(value="x-fapi-customer-last-logged-time", required=false)
-            @DateTimeFormat(pattern = ApiConstants.HTTP_DATE_FORMAT) DateTime xFapiCustomerLastLoggedTime,
+            @RequestHeader(value = "x-fapi-auth-date", required = false)
+            @DateTimeFormat(pattern = ApiConstants.HTTP_DATE_FORMAT) DateTime xFapiAuthDate,
 
             @ApiParam(value = "The PSU's IP address if the PSU is currently logged in with the TPP.")
             @RequestHeader(value = "x-fapi-customer-ip-address", required = false) String xFapiCustomerIpAddress,

--- a/secure-api-gateway-ob-uk-rs-obie-api/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/obie/api/account/v3_0/party/PartyApi.java
+++ b/secure-api-gateway-ob-uk-rs-obie-api/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/obie/api/account/v3_0/party/PartyApi.java
@@ -69,8 +69,8 @@ public interface PartyApi {
             @ApiParam(value = "The time when the PSU last logged in with the TPP.  " +
                     "All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  " +
                     "Sun, 10 Sep 2017 19:43:31 UTC")
-            @RequestHeader(value="x-fapi-customer-last-logged-time", required=false)
-            @DateTimeFormat(pattern = ApiConstants.HTTP_DATE_FORMAT) DateTime xFapiCustomerLastLoggedTime,
+            @RequestHeader(value = "x-fapi-auth-date", required = false)
+            @DateTimeFormat(pattern = ApiConstants.HTTP_DATE_FORMAT) DateTime xFapiAuthDate,
 
             @ApiParam(value = "The PSU's IP address if the PSU is currently logged in with the TPP.")
             @RequestHeader(value = "x-fapi-customer-ip-address", required = false) String xFapiCustomerIpAddress,
@@ -112,8 +112,8 @@ public interface PartyApi {
             @ApiParam(value = "The time when the PSU last logged in with the TPP. " +
                     "All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below: " +
                     " Sun, 10 Sep 2017 19:43:31 UTC")
-            @RequestHeader(value="x-fapi-customer-last-logged-time", required=false)
-            @DateTimeFormat(pattern = ApiConstants.HTTP_DATE_FORMAT) DateTime xFapiCustomerLastLoggedTime,
+            @RequestHeader(value = "x-fapi-auth-date", required = false)
+            @DateTimeFormat(pattern = ApiConstants.HTTP_DATE_FORMAT) DateTime xFapiAuthDate,
 
             @ApiParam(value = "The PSU's IP address if the PSU is currently logged in with the TPP.")
             @RequestHeader(value = "x-fapi-customer-ip-address", required = false) String xFapiCustomerIpAddress,

--- a/secure-api-gateway-ob-uk-rs-obie-api/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/obie/api/account/v3_0/products/ProductsApi.java
+++ b/secure-api-gateway-ob-uk-rs-obie-api/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/obie/api/account/v3_0/products/ProductsApi.java
@@ -51,11 +51,11 @@ public interface ProductsApi {
             @ApiResponse(code = 405, message = "Method Not Allowed", response = Void.class),
             @ApiResponse(code = 406, message = "Not Acceptable", response = Void.class),
             @ApiResponse(code = 429, message = "Too Many Requests", response = Void.class),
-            @ApiResponse(code = 500, message = "Internal Server Error", response = Void.class) })
+            @ApiResponse(code = 500, message = "Internal Server Error", response = Void.class)})
 
 
     @RequestMapping(value = "/accounts/{AccountId}/product",
-            produces = { "application/json; charset=utf-8" },
+            produces = {"application/json; charset=utf-8"},
             method = RequestMethod.GET)
     ResponseEntity<OBReadProduct2> getAccountProduct(
             @ApiParam(value = "A unique identifier used to identify the account resource.", required = true)
@@ -70,8 +70,8 @@ public interface ProductsApi {
             @ApiParam(value = "The time when the PSU last logged in with the TPP.  " +
                     "All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  " +
                     "Sun, 10 Sep 2017 19:43:31 UTC")
-            @RequestHeader(value="x-fapi-customer-last-logged-time", required=false)
-            @DateTimeFormat(pattern = ApiConstants.HTTP_DATE_FORMAT) DateTime xFapiCustomerLastLoggedTime,
+            @RequestHeader(value = "x-fapi-auth-date", required = false)
+            @DateTimeFormat(pattern = ApiConstants.HTTP_DATE_FORMAT) DateTime xFapiAuthDate,
 
             @ApiParam(value = "The PSU's IP address if the PSU is currently logged in with the TPP.")
             @RequestHeader(value = "x-fapi-customer-ip-address", required = false) String xFapiCustomerIpAddress,
@@ -102,11 +102,11 @@ public interface ProductsApi {
             @ApiResponse(code = 405, message = "Method Not Allowed", response = Void.class),
             @ApiResponse(code = 406, message = "Not Acceptable", response = Void.class),
             @ApiResponse(code = 429, message = "Too Many Requests", response = Void.class),
-            @ApiResponse(code = 500, message = "Internal Server Error", response = Void.class) })
+            @ApiResponse(code = 500, message = "Internal Server Error", response = Void.class)})
 
 
     @RequestMapping(value = "/products",
-            produces = { "application/json; charset=utf-8" },
+            produces = {"application/json; charset=utf-8"},
             method = RequestMethod.GET)
     ResponseEntity<OBReadProduct2> getProducts(
             @ApiParam(value = "Page number.", required = false, defaultValue = "0")
@@ -117,8 +117,8 @@ public interface ProductsApi {
 
             @ApiParam(value = "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are " +
                     "represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC")
-            @RequestHeader(value="x-fapi-customer-last-logged-time", required=false)
-            @DateTimeFormat(pattern = ApiConstants.HTTP_DATE_FORMAT) DateTime xFapiCustomerLastLoggedTime,
+            @RequestHeader(value = "x-fapi-auth-date", required = false)
+            @DateTimeFormat(pattern = ApiConstants.HTTP_DATE_FORMAT) DateTime xFapiAuthDate,
 
             @ApiParam(value = "The PSU's IP address if the PSU is currently logged in with the TPP.")
             @RequestHeader(value = "x-fapi-customer-ip-address", required = false) String xFapiCustomerIpAddress,

--- a/secure-api-gateway-ob-uk-rs-obie-api/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/obie/api/account/v3_0/scheduledpayments/ScheduledPaymentsApi.java
+++ b/secure-api-gateway-ob-uk-rs-obie-api/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/obie/api/account/v3_0/scheduledpayments/ScheduledPaymentsApi.java
@@ -51,9 +51,9 @@ public interface ScheduledPaymentsApi {
             @ApiResponse(code = 405, message = "Method Not Allowed"),
             @ApiResponse(code = 406, message = "Not Acceptable"),
             @ApiResponse(code = 429, message = "Too Many Requests"),
-            @ApiResponse(code = 500, message = "Internal Server Error") })
+            @ApiResponse(code = 500, message = "Internal Server Error")})
     @RequestMapping(value = "/accounts/{AccountId}/scheduled-payments",
-            produces = { "application/json; charset=utf-8" },
+            produces = {"application/json; charset=utf-8"},
             method = RequestMethod.GET)
     ResponseEntity<OBReadScheduledPayment1> getAccountScheduledPayments(
             @ApiParam(value = "A unique identifier used to identify the account resource.", required = true)
@@ -68,8 +68,8 @@ public interface ScheduledPaymentsApi {
             @ApiParam(value = "The time when the PSU last logged in with the TPP.  " +
                     "All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  " +
                     "Sun, 10 Sep 2017 19:43:31 UTC")
-            @RequestHeader(value="x-fapi-customer-last-logged-time", required=false)
-            @DateTimeFormat(pattern = ApiConstants.HTTP_DATE_FORMAT) DateTime xFapiCustomerLastLoggedTime,
+            @RequestHeader(value = "x-fapi-auth-date", required = false)
+            @DateTimeFormat(pattern = ApiConstants.HTTP_DATE_FORMAT) DateTime xFapiAuthDate,
 
             @ApiParam(value = "The PSU's IP address if the PSU is currently logged in with the TPP.")
             @RequestHeader(value = "x-fapi-customer-ip-address", required = false) String xFapiCustomerIpAddress,
@@ -100,9 +100,9 @@ public interface ScheduledPaymentsApi {
             @ApiResponse(code = 405, message = "Method Not Allowed"),
             @ApiResponse(code = 406, message = "Not Acceptable"),
             @ApiResponse(code = 429, message = "Too Many Requests"),
-            @ApiResponse(code = 500, message = "Internal Server Error") })
+            @ApiResponse(code = 500, message = "Internal Server Error")})
     @RequestMapping(value = "/scheduled-payments",
-            produces = { "application/json; charset=utf-8" },
+            produces = {"application/json; charset=utf-8"},
             method = RequestMethod.GET)
     ResponseEntity<OBReadScheduledPayment1> getScheduledPayments(
             @ApiParam(value = "Page number.", required = false, defaultValue = "0")
@@ -114,8 +114,8 @@ public interface ScheduledPaymentsApi {
             @ApiParam(value = "The time when the PSU last logged in with the TPP.  " +
                     "All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  " +
                     "Sun, 10 Sep 2017 19:43:31 UTC")
-            @RequestHeader(value="x-fapi-customer-last-logged-time", required=false)
-            @DateTimeFormat(pattern = ApiConstants.HTTP_DATE_FORMAT) DateTime xFapiCustomerLastLoggedTime,
+            @RequestHeader(value = "x-fapi-auth-date", required = false)
+            @DateTimeFormat(pattern = ApiConstants.HTTP_DATE_FORMAT) DateTime xFapiAuthDate,
 
             @ApiParam(value = "The PSU's IP address if the PSU is currently logged in with the TPP.")
             @RequestHeader(value = "x-fapi-customer-ip-address", required = false) String xFapiCustomerIpAddress,

--- a/secure-api-gateway-ob-uk-rs-obie-api/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/obie/api/account/v3_0/standingorders/StandingOrdersApi.java
+++ b/secure-api-gateway-ob-uk-rs-obie-api/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/obie/api/account/v3_0/standingorders/StandingOrdersApi.java
@@ -52,11 +52,11 @@ public interface StandingOrdersApi {
             @ApiResponse(code = 405, message = "Method Not Allowed", response = Void.class),
             @ApiResponse(code = 406, message = "Not Acceptable", response = Void.class),
             @ApiResponse(code = 429, message = "Too Many Requests", response = Void.class),
-            @ApiResponse(code = 500, message = "Internal Server Error", response = Void.class) })
+            @ApiResponse(code = 500, message = "Internal Server Error", response = Void.class)})
 
 
     @RequestMapping(value = "/accounts/{AccountId}/standing-orders",
-            produces = { "application/json; charset=utf-8" },
+            produces = {"application/json; charset=utf-8"},
             method = RequestMethod.GET)
     ResponseEntity<OBReadStandingOrder3> getAccountStandingOrders(
             @ApiParam(value = "A unique identifier used to identify the account resource.", required = true)
@@ -72,8 +72,8 @@ public interface StandingOrdersApi {
             @ApiParam(value = "The time when the PSU last logged in with the TPP. " +
                     "All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  " +
                     "Sun, 10 Sep 2017 19:43:31 UTC")
-            @RequestHeader(value="x-fapi-customer-last-logged-time", required=false)
-            @DateTimeFormat(pattern = ApiConstants.HTTP_DATE_FORMAT) DateTime xFapiCustomerLastLoggedTime,
+            @RequestHeader(value = "x-fapi-auth-date", required = false)
+            @DateTimeFormat(pattern = ApiConstants.HTTP_DATE_FORMAT) DateTime xFapiAuthDate,
 
             @ApiParam(value = "The PSU's IP address if the PSU is currently logged in with the TPP.")
             @RequestHeader(value = "x-fapi-customer-ip-address", required = false) String xFapiCustomerIpAddress,
@@ -92,24 +92,24 @@ public interface StandingOrdersApi {
     ) throws OBErrorResponseException;
 
     @ApiOperation(value = "Get Standing Orders", notes = "Get Standing Orders", response = OBReadStandingOrder3.class, authorizations = {
-        @Authorization(value = "PSUOAuth2Security", scopes = {
-            @AuthorizationScope(scope = "accounts", description = "Ability to get Accounts information")
+            @Authorization(value = "PSUOAuth2Security", scopes = {
+                    @AuthorizationScope(scope = "accounts", description = "Ability to get Accounts information")
             })
     })
-    @ApiResponses(value = { 
-        @ApiResponse(code = 200, message = "Standing Orders successfully retrieved", response = OBReadStandingOrder3.class),
-        @ApiResponse(code = 400, message = "Bad Request", response = Void.class),
-        @ApiResponse(code = 401, message = "Unauthorized", response = Void.class),
-        @ApiResponse(code = 403, message = "Forbidden", response = Void.class),
-        @ApiResponse(code = 405, message = "Method Not Allowed", response = Void.class),
-        @ApiResponse(code = 406, message = "Not Acceptable", response = Void.class),
-        @ApiResponse(code = 429, message = "Too Many Requests", response = Void.class),
-        @ApiResponse(code = 500, message = "Internal Server Error", response = Void.class) })
+    @ApiResponses(value = {
+            @ApiResponse(code = 200, message = "Standing Orders successfully retrieved", response = OBReadStandingOrder3.class),
+            @ApiResponse(code = 400, message = "Bad Request", response = Void.class),
+            @ApiResponse(code = 401, message = "Unauthorized", response = Void.class),
+            @ApiResponse(code = 403, message = "Forbidden", response = Void.class),
+            @ApiResponse(code = 405, message = "Method Not Allowed", response = Void.class),
+            @ApiResponse(code = 406, message = "Not Acceptable", response = Void.class),
+            @ApiResponse(code = 429, message = "Too Many Requests", response = Void.class),
+            @ApiResponse(code = 500, message = "Internal Server Error", response = Void.class)})
 
 
     @RequestMapping(value = "/standing-orders",
-        produces = { "application/json; charset=utf-8" }, 
-        method = RequestMethod.GET)
+            produces = {"application/json; charset=utf-8"},
+            method = RequestMethod.GET)
     ResponseEntity<OBReadStandingOrder3> getStandingOrders(
             @ApiParam(value = "Page number.", required = false, defaultValue = "0")
             @RequestParam(value = "page", defaultValue = "0") int page,
@@ -119,8 +119,8 @@ public interface StandingOrdersApi {
 
             @ApiParam(value = "The time when the PSU last logged in with the TPP. All dates in the HTTP headers are " +
                     "represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC")
-            @RequestHeader(value="x-fapi-customer-last-logged-time", required=false)
-            @DateTimeFormat(pattern = ApiConstants.HTTP_DATE_FORMAT) DateTime xFapiCustomerLastLoggedTime,
+            @RequestHeader(value = "x-fapi-auth-date", required = false)
+            @DateTimeFormat(pattern = ApiConstants.HTTP_DATE_FORMAT) DateTime xFapiAuthDate,
 
             @ApiParam(value = "The PSU's IP address if the PSU is currently logged in with the TPP.")
             @RequestHeader(value = "x-fapi-customer-ip-address", required = false) String xFapiCustomerIpAddress,

--- a/secure-api-gateway-ob-uk-rs-obie-api/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/obie/api/account/v3_0/statements/StatementsApi.java
+++ b/secure-api-gateway-ob-uk-rs-obie-api/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/obie/api/account/v3_0/statements/StatementsApi.java
@@ -75,8 +75,8 @@ public interface StatementsApi {
             @ApiParam(value = "The time when the PSU last logged in with the TPP.  " +
                     "All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  " +
                     "Sun, 10 Sep 2017 19:43:31 UTC")
-            @RequestHeader(value="x-fapi-customer-last-logged-time", required=false)
-            @DateTimeFormat(pattern = ApiConstants.HTTP_DATE_FORMAT) DateTime xFapiCustomerLastLoggedTime,
+            @RequestHeader(value = "x-fapi-auth-date", required = false)
+            @DateTimeFormat(pattern = ApiConstants.HTTP_DATE_FORMAT) DateTime xFapiAuthDate,
 
             @ApiParam(value = "The PSU's IP address if the PSU is currently logged in with the TPP.")
             @RequestHeader(value = "x-fapi-customer-ip-address", required = false) String xFapiCustomerIpAddress,
@@ -126,8 +126,8 @@ public interface StatementsApi {
             @ApiParam(value = "The time when the PSU last logged in with the TPP. " +
                     "All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below: " +
                     " Sun, 10 Sep 2017 19:43:31 UTC")
-            @RequestHeader(value="x-fapi-customer-last-logged-time", required=false)
-            @DateTimeFormat(pattern = ApiConstants.HTTP_DATE_FORMAT) DateTime xFapiCustomerLastLoggedTime,
+            @RequestHeader(value = "x-fapi-auth-date", required = false)
+            @DateTimeFormat(pattern = ApiConstants.HTTP_DATE_FORMAT) DateTime xFapiAuthDate,
 
             @ApiParam(value = "The PSU's IP address if the PSU is currently logged in with the TPP.")
             @RequestHeader(value = "x-fapi-customer-ip-address", required = false) String xFapiCustomerIpAddress,
@@ -135,9 +135,11 @@ public interface StatementsApi {
             @ApiParam(value = "An RFC4122 UID used as a correlation id.")
             @RequestHeader(value = "x-fapi-interaction-id", required = false) String xFapiInteractionId,
 
-            @ApiParam(value = "HTTP Accept header defining what files will be accepted.", required=true)
-            @RequestHeader(value="Accept", required=true) String accept
-    ) throws OBErrorResponseException;;
+            @ApiParam(value = "HTTP Accept header defining what files will be accepted.", required = true)
+            @RequestHeader(value = "Accept", required = true) String accept
+    ) throws OBErrorResponseException;
+
+    ;
 
     @ApiOperation(value = "Get Statements", nickname = "getStatements", notes = "Get Statements", response = OBReadStatement1.class, authorizations = {
             @Authorization(value = "PSUOAuth2Security", scopes = {
@@ -174,8 +176,8 @@ public interface StatementsApi {
             @ApiParam(value = "The time when the PSU last logged in with the TPP.  " +
                     "All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  " +
                     "Sun, 10 Sep 2017 19:43:31 UTC")
-            @RequestHeader(value="x-fapi-customer-last-logged-time", required=false)
-            @DateTimeFormat(pattern = ApiConstants.HTTP_DATE_FORMAT) DateTime xFapiCustomerLastLoggedTime,
+            @RequestHeader(value = "x-fapi-auth-date", required = false)
+            @DateTimeFormat(pattern = ApiConstants.HTTP_DATE_FORMAT) DateTime xFapiAuthDate,
 
             @ApiParam(value = "The PSU's IP address if the PSU is currently logged in with the TPP.")
             @RequestHeader(value = "x-fapi-customer-ip-address", required = false) String xFapiCustomerIpAddress,
@@ -236,8 +238,8 @@ public interface StatementsApi {
             @ApiParam(value = "The time when the PSU last logged in with the TPP. " +
                     "All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  " +
                     "Sun, 10 Sep 2017 19:43:31 UTC")
-            @RequestHeader(value="x-fapi-customer-last-logged-time", required=false)
-            @DateTimeFormat(pattern = ApiConstants.HTTP_DATE_FORMAT) DateTime xFapiCustomerLastLoggedTime,
+            @RequestHeader(value = "x-fapi-auth-date", required = false)
+            @DateTimeFormat(pattern = ApiConstants.HTTP_DATE_FORMAT) DateTime xFapiAuthDate,
 
             @ApiParam(value = "The PSU's IP address if the PSU is currently logged in with the TPP.")
             @RequestHeader(value = "x-fapi-customer-ip-address", required = false) String xFapiCustomerIpAddress,

--- a/secure-api-gateway-ob-uk-rs-obie-api/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/obie/api/account/v3_0/transactions/TransactionsApi.java
+++ b/secure-api-gateway-ob-uk-rs-obie-api/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/obie/api/account/v3_0/transactions/TransactionsApi.java
@@ -51,11 +51,11 @@ public interface TransactionsApi {
             @ApiResponse(code = 405, message = "Method Not Allowed", response = Void.class),
             @ApiResponse(code = 406, message = "Not Acceptable", response = Void.class),
             @ApiResponse(code = 429, message = "Too Many Requests", response = Void.class),
-            @ApiResponse(code = 500, message = "Internal Server Error", response = Void.class) })
+            @ApiResponse(code = 500, message = "Internal Server Error", response = Void.class)})
 
 
     @RequestMapping(value = "/accounts/{AccountId}/transactions",
-            produces = { "application/json; charset=utf-8" },
+            produces = {"application/json; charset=utf-8"},
             method = RequestMethod.GET)
     ResponseEntity<OBReadTransaction3> getAccountTransactions(
             @ApiParam(value = "A unique identifier used to identify the account resource.", required = true)
@@ -78,8 +78,8 @@ public interface TransactionsApi {
             @ApiParam(value = "The time when the PSU last logged in with the TPP. " +
                     "All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  " +
                     "Sun, 10 Sep 2017 19:43:31 UTC")
-            @RequestHeader(value="x-fapi-customer-last-logged-time", required=false)
-            @DateTimeFormat(pattern = ApiConstants.HTTP_DATE_FORMAT) DateTime xFapiCustomerLastLoggedTime,
+            @RequestHeader(value = "x-fapi-auth-date", required = false)
+            @DateTimeFormat(pattern = ApiConstants.HTTP_DATE_FORMAT) DateTime xFapiAuthDate,
 
             @ApiParam(value = "The PSU's IP address if the PSU is currently logged in with the TPP.")
             @RequestHeader(value = "x-fapi-customer-ip-address", required = false) String xFapiCustomerIpAddress,
@@ -104,24 +104,24 @@ public interface TransactionsApi {
     ) throws OBErrorResponseException;
 
     @ApiOperation(value = "Get Transactions", notes = "Get Transactions", response = OBReadTransaction3.class, authorizations = {
-        @Authorization(value = "PSUOAuth2Security", scopes = {
-            @AuthorizationScope(scope = "accounts", description = "Ability to get Accounts information")
+            @Authorization(value = "PSUOAuth2Security", scopes = {
+                    @AuthorizationScope(scope = "accounts", description = "Ability to get Accounts information")
             })
     })
-    @ApiResponses(value = { 
-        @ApiResponse(code = 200, message = "Transactions successfully retrieved", response = OBReadTransaction3.class),
-        @ApiResponse(code = 400, message = "Bad Request", response = Void.class),
-        @ApiResponse(code = 401, message = "Unauthorized", response = Void.class),
-        @ApiResponse(code = 403, message = "Forbidden", response = Void.class),
-        @ApiResponse(code = 405, message = "Method Not Allowed", response = Void.class),
-        @ApiResponse(code = 406, message = "Not Acceptable", response = Void.class),
-        @ApiResponse(code = 429, message = "Too Many Requests", response = Void.class),
-        @ApiResponse(code = 500, message = "Internal Server Error", response = Void.class) })
+    @ApiResponses(value = {
+            @ApiResponse(code = 200, message = "Transactions successfully retrieved", response = OBReadTransaction3.class),
+            @ApiResponse(code = 400, message = "Bad Request", response = Void.class),
+            @ApiResponse(code = 401, message = "Unauthorized", response = Void.class),
+            @ApiResponse(code = 403, message = "Forbidden", response = Void.class),
+            @ApiResponse(code = 405, message = "Method Not Allowed", response = Void.class),
+            @ApiResponse(code = 406, message = "Not Acceptable", response = Void.class),
+            @ApiResponse(code = 429, message = "Too Many Requests", response = Void.class),
+            @ApiResponse(code = 500, message = "Internal Server Error", response = Void.class)})
 
 
     @RequestMapping(value = "/transactions",
-        produces = { "application/json; charset=utf-8" }, 
-        method = RequestMethod.GET)
+            produces = {"application/json; charset=utf-8"},
+            method = RequestMethod.GET)
     ResponseEntity<OBReadTransaction3> getTransactions(
             @ApiParam(value = "Page number.", required = false, defaultValue = "0")
             @RequestParam(value = "page", defaultValue = "0") int page,
@@ -131,8 +131,8 @@ public interface TransactionsApi {
 
             @ApiParam(value = "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are " +
                     "represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC")
-            @RequestHeader(value="x-fapi-customer-last-logged-time", required=false)
-            @DateTimeFormat(pattern = ApiConstants.HTTP_DATE_FORMAT) DateTime xFapiCustomerLastLoggedTime,
+            @RequestHeader(value = "x-fapi-auth-date", required = false)
+            @DateTimeFormat(pattern = ApiConstants.HTTP_DATE_FORMAT) DateTime xFapiAuthDate,
 
             @ApiParam(value = "The PSU's IP address if the PSU is currently logged in with the TPP.")
             @RequestHeader(value = "x-fapi-customer-ip-address", required = false) String xFapiCustomerIpAddress,
@@ -178,9 +178,9 @@ public interface TransactionsApi {
             @ApiResponse(code = 405, message = "Method Not Allowed"),
             @ApiResponse(code = 406, message = "Not Acceptable"),
             @ApiResponse(code = 429, message = "Too Many Requests"),
-            @ApiResponse(code = 500, message = "Internal Server Error") })
+            @ApiResponse(code = 500, message = "Internal Server Error")})
     @RequestMapping(value = "/accounts/{AccountId}/statements/{StatementId}/transactions",
-            produces = { "application/json; charset=utf-8" },
+            produces = {"application/json; charset=utf-8"},
             method = RequestMethod.GET)
     ResponseEntity<OBReadTransaction3> getAccountStatementTransactions(
             @ApiParam(value = "A unique identifier used to identify the account resource.", required = true)
@@ -206,8 +206,8 @@ public interface TransactionsApi {
             @ApiParam(value = "The time when the PSU last logged in with the TPP.  " +
                     "All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  " +
                     "Sun, 10 Sep 2017 19:43:31 UTC")
-            @RequestHeader(value="x-fapi-customer-last-logged-time", required=false)
-            @DateTimeFormat(pattern = ApiConstants.HTTP_DATE_FORMAT) DateTime xFapiCustomerLastLoggedTime,
+            @RequestHeader(value = "x-fapi-auth-date", required = false)
+            @DateTimeFormat(pattern = ApiConstants.HTTP_DATE_FORMAT) DateTime xFapiAuthDate,
 
             @ApiParam(value = "The PSU's IP address if the PSU is currently logged in with the TPP.")
             @RequestHeader(value = "x-fapi-customer-ip-address", required = false) String xFapiCustomerIpAddress,

--- a/secure-api-gateway-ob-uk-rs-obie-api/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/obie/api/account/v3_1/standingorders/StandingOrdersApi.java
+++ b/secure-api-gateway-ob-uk-rs-obie-api/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/obie/api/account/v3_1/standingorders/StandingOrdersApi.java
@@ -52,11 +52,11 @@ public interface StandingOrdersApi {
             @ApiResponse(code = 405, message = "Method Not Allowed", response = Void.class),
             @ApiResponse(code = 406, message = "Not Acceptable", response = Void.class),
             @ApiResponse(code = 429, message = "Too Many Requests", response = Void.class),
-            @ApiResponse(code = 500, message = "Internal Server Error", response = Void.class) })
+            @ApiResponse(code = 500, message = "Internal Server Error", response = Void.class)})
 
 
     @RequestMapping(value = "/accounts/{AccountId}/standing-orders",
-            produces = { "application/json; charset=utf-8" },
+            produces = {"application/json; charset=utf-8"},
             method = RequestMethod.GET)
     ResponseEntity<OBReadStandingOrder4> getAccountStandingOrders(
             @ApiParam(value = "A unique identifier used to identify the account resource.", required = true)
@@ -72,8 +72,8 @@ public interface StandingOrdersApi {
             @ApiParam(value = "The time when the PSU last logged in with the TPP. " +
                     "All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  " +
                     "Sun, 10 Sep 2017 19:43:31 UTC")
-            @RequestHeader(value="x-fapi-customer-last-logged-time", required=false)
-            @DateTimeFormat(pattern = ApiConstants.HTTP_DATE_FORMAT) DateTime xFapiCustomerLastLoggedTime,
+            @RequestHeader(value = "x-fapi-auth-date", required = false)
+            @DateTimeFormat(pattern = ApiConstants.HTTP_DATE_FORMAT) DateTime xFapiAuthDate,
 
             @ApiParam(value = "The PSU's IP address if the PSU is currently logged in with the TPP.")
             @RequestHeader(value = "x-fapi-customer-ip-address", required = false) String xFapiCustomerIpAddress,
@@ -92,24 +92,24 @@ public interface StandingOrdersApi {
     ) throws OBErrorResponseException;
 
     @ApiOperation(value = "Get Standing Orders", notes = "Get Standing Orders", response = OBReadStandingOrder4.class, authorizations = {
-        @Authorization(value = "PSUOAuth2Security", scopes = {
-            @AuthorizationScope(scope = "accounts", description = "Ability to get Accounts information")
+            @Authorization(value = "PSUOAuth2Security", scopes = {
+                    @AuthorizationScope(scope = "accounts", description = "Ability to get Accounts information")
             })
     })
-    @ApiResponses(value = { 
-        @ApiResponse(code = 200, message = "Standing Orders successfully retrieved", response = OBReadStandingOrder4.class),
-        @ApiResponse(code = 400, message = "Bad Request", response = Void.class),
-        @ApiResponse(code = 401, message = "Unauthorized", response = Void.class),
-        @ApiResponse(code = 403, message = "Forbidden", response = Void.class),
-        @ApiResponse(code = 405, message = "Method Not Allowed", response = Void.class),
-        @ApiResponse(code = 406, message = "Not Acceptable", response = Void.class),
-        @ApiResponse(code = 429, message = "Too Many Requests", response = Void.class),
-        @ApiResponse(code = 500, message = "Internal Server Error", response = Void.class) })
+    @ApiResponses(value = {
+            @ApiResponse(code = 200, message = "Standing Orders successfully retrieved", response = OBReadStandingOrder4.class),
+            @ApiResponse(code = 400, message = "Bad Request", response = Void.class),
+            @ApiResponse(code = 401, message = "Unauthorized", response = Void.class),
+            @ApiResponse(code = 403, message = "Forbidden", response = Void.class),
+            @ApiResponse(code = 405, message = "Method Not Allowed", response = Void.class),
+            @ApiResponse(code = 406, message = "Not Acceptable", response = Void.class),
+            @ApiResponse(code = 429, message = "Too Many Requests", response = Void.class),
+            @ApiResponse(code = 500, message = "Internal Server Error", response = Void.class)})
 
 
     @RequestMapping(value = "/standing-orders",
-        produces = { "application/json; charset=utf-8" }, 
-        method = RequestMethod.GET)
+            produces = {"application/json; charset=utf-8"},
+            method = RequestMethod.GET)
     ResponseEntity<OBReadStandingOrder4> getStandingOrders(
             @ApiParam(value = "Page number.", required = false, defaultValue = "0")
             @RequestParam(value = "page", defaultValue = "0") int page,
@@ -119,8 +119,8 @@ public interface StandingOrdersApi {
 
             @ApiParam(value = "The time when the PSU last logged in with the TPP. All dates in the HTTP headers are " +
                     "represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC")
-            @RequestHeader(value="x-fapi-customer-last-logged-time", required=false)
-            @DateTimeFormat(pattern = ApiConstants.HTTP_DATE_FORMAT) DateTime xFapiCustomerLastLoggedTime,
+            @RequestHeader(value = "x-fapi-auth-date", required = false)
+            @DateTimeFormat(pattern = ApiConstants.HTTP_DATE_FORMAT) DateTime xFapiAuthDate,
 
             @ApiParam(value = "The PSU's IP address if the PSU is currently logged in with the TPP.")
             @RequestHeader(value = "x-fapi-customer-ip-address", required = false) String xFapiCustomerIpAddress,

--- a/secure-api-gateway-ob-uk-rs-obie-api/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/obie/api/account/v3_1/transactions/TransactionsApi.java
+++ b/secure-api-gateway-ob-uk-rs-obie-api/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/obie/api/account/v3_1/transactions/TransactionsApi.java
@@ -51,11 +51,11 @@ public interface TransactionsApi {
             @ApiResponse(code = 405, message = "Method Not Allowed", response = Void.class),
             @ApiResponse(code = 406, message = "Not Acceptable", response = Void.class),
             @ApiResponse(code = 429, message = "Too Many Requests", response = Void.class),
-            @ApiResponse(code = 500, message = "Internal Server Error", response = Void.class) })
+            @ApiResponse(code = 500, message = "Internal Server Error", response = Void.class)})
 
 
     @RequestMapping(value = "/accounts/{AccountId}/transactions",
-            produces = { "application/json; charset=utf-8" },
+            produces = {"application/json; charset=utf-8"},
             method = RequestMethod.GET)
     ResponseEntity<OBReadTransaction4> getAccountTransactions(
             @ApiParam(value = "A unique identifier used to identify the account resource.", required = true)
@@ -78,8 +78,8 @@ public interface TransactionsApi {
             @ApiParam(value = "The time when the PSU last logged in with the TPP. " +
                     "All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  " +
                     "Sun, 10 Sep 2017 19:43:31 UTC")
-            @RequestHeader(value="x-fapi-customer-last-logged-time", required=false)
-            @DateTimeFormat(pattern = ApiConstants.HTTP_DATE_FORMAT) DateTime xFapiCustomerLastLoggedTime,
+            @RequestHeader(value = "x-fapi-auth-date", required = false)
+            @DateTimeFormat(pattern = ApiConstants.HTTP_DATE_FORMAT) DateTime xFapiAuthDate,
 
             @ApiParam(value = "The PSU's IP address if the PSU is currently logged in with the TPP.")
             @RequestHeader(value = "x-fapi-customer-ip-address", required = false) String xFapiCustomerIpAddress,
@@ -104,24 +104,24 @@ public interface TransactionsApi {
     ) throws OBErrorResponseException;
 
     @ApiOperation(value = "Get Transactions", notes = "Get Transactions", response = OBReadTransaction4.class, authorizations = {
-        @Authorization(value = "PSUOAuth2Security", scopes = {
-            @AuthorizationScope(scope = "accounts", description = "Ability to get Accounts information")
+            @Authorization(value = "PSUOAuth2Security", scopes = {
+                    @AuthorizationScope(scope = "accounts", description = "Ability to get Accounts information")
             })
     })
-    @ApiResponses(value = { 
-        @ApiResponse(code = 200, message = "Transactions successfully retrieved", response = OBReadTransaction4.class),
-        @ApiResponse(code = 400, message = "Bad Request", response = Void.class),
-        @ApiResponse(code = 401, message = "Unauthorized", response = Void.class),
-        @ApiResponse(code = 403, message = "Forbidden", response = Void.class),
-        @ApiResponse(code = 405, message = "Method Not Allowed", response = Void.class),
-        @ApiResponse(code = 406, message = "Not Acceptable", response = Void.class),
-        @ApiResponse(code = 429, message = "Too Many Requests", response = Void.class),
-        @ApiResponse(code = 500, message = "Internal Server Error", response = Void.class) })
+    @ApiResponses(value = {
+            @ApiResponse(code = 200, message = "Transactions successfully retrieved", response = OBReadTransaction4.class),
+            @ApiResponse(code = 400, message = "Bad Request", response = Void.class),
+            @ApiResponse(code = 401, message = "Unauthorized", response = Void.class),
+            @ApiResponse(code = 403, message = "Forbidden", response = Void.class),
+            @ApiResponse(code = 405, message = "Method Not Allowed", response = Void.class),
+            @ApiResponse(code = 406, message = "Not Acceptable", response = Void.class),
+            @ApiResponse(code = 429, message = "Too Many Requests", response = Void.class),
+            @ApiResponse(code = 500, message = "Internal Server Error", response = Void.class)})
 
 
     @RequestMapping(value = "/transactions",
-        produces = { "application/json; charset=utf-8" }, 
-        method = RequestMethod.GET)
+            produces = {"application/json; charset=utf-8"},
+            method = RequestMethod.GET)
     ResponseEntity<OBReadTransaction4> getTransactions(
             @ApiParam(value = "Page number.", required = false, defaultValue = "0")
             @RequestParam(value = "page", defaultValue = "0") int page,
@@ -131,8 +131,8 @@ public interface TransactionsApi {
 
             @ApiParam(value = "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are " +
                     "represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC")
-            @RequestHeader(value="x-fapi-customer-last-logged-time", required=false)
-            @DateTimeFormat(pattern = ApiConstants.HTTP_DATE_FORMAT) DateTime xFapiCustomerLastLoggedTime,
+            @RequestHeader(value = "x-fapi-auth-date", required = false)
+            @DateTimeFormat(pattern = ApiConstants.HTTP_DATE_FORMAT) DateTime xFapiAuthDate,
 
             @ApiParam(value = "The PSU's IP address if the PSU is currently logged in with the TPP.")
             @RequestHeader(value = "x-fapi-customer-ip-address", required = false) String xFapiCustomerIpAddress,
@@ -178,9 +178,9 @@ public interface TransactionsApi {
             @ApiResponse(code = 405, message = "Method Not Allowed"),
             @ApiResponse(code = 406, message = "Not Acceptable"),
             @ApiResponse(code = 429, message = "Too Many Requests"),
-            @ApiResponse(code = 500, message = "Internal Server Error") })
+            @ApiResponse(code = 500, message = "Internal Server Error")})
     @RequestMapping(value = "/accounts/{AccountId}/statements/{StatementId}/transactions",
-            produces = { "application/json; charset=utf-8" },
+            produces = {"application/json; charset=utf-8"},
             method = RequestMethod.GET)
     ResponseEntity<OBReadTransaction4> getAccountStatementTransactions(
             @ApiParam(value = "A unique identifier used to identify the account resource.", required = true)
@@ -206,8 +206,8 @@ public interface TransactionsApi {
             @ApiParam(value = "The time when the PSU last logged in with the TPP.  " +
                     "All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  " +
                     "Sun, 10 Sep 2017 19:43:31 UTC")
-            @RequestHeader(value="x-fapi-customer-last-logged-time", required=false)
-            @DateTimeFormat(pattern = ApiConstants.HTTP_DATE_FORMAT) DateTime xFapiCustomerLastLoggedTime,
+            @RequestHeader(value = "x-fapi-auth-date", required = false)
+            @DateTimeFormat(pattern = ApiConstants.HTTP_DATE_FORMAT) DateTime xFapiAuthDate,
 
             @ApiParam(value = "The PSU's IP address if the PSU is currently logged in with the TPP.")
             @RequestHeader(value = "x-fapi-customer-ip-address", required = false) String xFapiCustomerIpAddress,

--- a/secure-api-gateway-ob-uk-rs-obie-api/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/obie/api/account/v3_1_1/accounts/AccountsApi.java
+++ b/secure-api-gateway-ob-uk-rs-obie-api/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/obie/api/account/v3_1_1/accounts/AccountsApi.java
@@ -35,7 +35,7 @@ import java.util.List;
 
 @Api(tags = {"v3.1.1", SwaggerApiTags.ACCOUNTS_AND_TRANSACTION_TAG})
 @RequestMapping(value = "/open-banking/v3.1.1/aisp")
-public interface AccountsApi  {
+public interface AccountsApi {
 
     @ApiOperation(value = "Get Account", notes = "Get an account", response = OBReadAccount3.class, authorizations = {
             @Authorization(value = "PSUOAuth2Security", scopes = {
@@ -50,11 +50,11 @@ public interface AccountsApi  {
             @ApiResponse(code = 405, message = "Method Not Allowed", response = Void.class),
             @ApiResponse(code = 406, message = "Not Acceptable", response = Void.class),
             @ApiResponse(code = 429, message = "Too Many Requests", response = Void.class),
-            @ApiResponse(code = 500, message = "Internal Server Error", response = Void.class) })
+            @ApiResponse(code = 500, message = "Internal Server Error", response = Void.class)})
 
 
     @RequestMapping(value = "/accounts/{AccountId}",
-            produces = { "application/json; charset=utf-8" },
+            produces = {"application/json; charset=utf-8"},
             method = RequestMethod.GET)
     ResponseEntity<OBReadAccount3> getAccount(
             @ApiParam(value = "A unique identifier used to identify the account resource.", required = true)
@@ -65,8 +65,8 @@ public interface AccountsApi  {
 
             @ApiParam(value = "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are " +
                     "represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC")
-            @RequestHeader(value="x-fapi-customer-last-logged-time", required=false)
-            @DateTimeFormat(pattern = ApiConstants.HTTP_DATE_FORMAT) DateTime xFapiCustomerLastLoggedTime,
+            @RequestHeader(value = "x-fapi-auth-date", required = false)
+            @DateTimeFormat(pattern = ApiConstants.HTTP_DATE_FORMAT) DateTime xFapiAuthDate,
 
             @ApiParam(value = "The PSU's IP address if the PSU is currently logged in with the TPP.")
             @RequestHeader(value = "x-fapi-customer-ip-address", required = false) String xFapiCustomerIpAddress,
@@ -96,11 +96,11 @@ public interface AccountsApi  {
             @ApiResponse(code = 405, message = "Method Not Allowed", response = Void.class),
             @ApiResponse(code = 406, message = "Not Acceptable", response = Void.class),
             @ApiResponse(code = 429, message = "Too Many Requests", response = Void.class),
-            @ApiResponse(code = 500, message = "Internal Server Error", response = Void.class) })
+            @ApiResponse(code = 500, message = "Internal Server Error", response = Void.class)})
 
 
     @RequestMapping(value = "/accounts",
-            produces = { "application/json; charset=utf-8" },
+            produces = {"application/json; charset=utf-8"},
             method = RequestMethod.GET)
     ResponseEntity<OBReadAccount3> getAccounts(
             @ApiParam(value = "Page number.", required = false, defaultValue = "0")
@@ -111,8 +111,8 @@ public interface AccountsApi  {
 
             @ApiParam(value = "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are " +
                     "represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC")
-            @RequestHeader(value="x-fapi-customer-last-logged-time", required=false)
-            @DateTimeFormat(pattern = ApiConstants.HTTP_DATE_FORMAT) DateTime xFapiCustomerLastLoggedTime,
+            @RequestHeader(value = "x-fapi-auth-date", required = false)
+            @DateTimeFormat(pattern = ApiConstants.HTTP_DATE_FORMAT) DateTime xFapiAuthDate,
 
             @ApiParam(value = "The PSU's IP address if the PSU is currently logged in with the TPP.")
             @RequestHeader(value = "x-fapi-customer-ip-address", required = false) String xFapiCustomerIpAddress,

--- a/secure-api-gateway-ob-uk-rs-obie-api/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/obie/api/account/v3_1_1/beneficiaries/BeneficiariesApi.java
+++ b/secure-api-gateway-ob-uk-rs-obie-api/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/obie/api/account/v3_1_1/beneficiaries/BeneficiariesApi.java
@@ -52,11 +52,11 @@ public interface BeneficiariesApi {
             @ApiResponse(code = 405, message = "Method Not Allowed", response = Void.class),
             @ApiResponse(code = 406, message = "Not Acceptable", response = Void.class),
             @ApiResponse(code = 429, message = "Too Many Requests", response = Void.class),
-            @ApiResponse(code = 500, message = "Internal Server Error", response = Void.class) })
+            @ApiResponse(code = 500, message = "Internal Server Error", response = Void.class)})
 
 
     @RequestMapping(value = "/accounts/{AccountId}/beneficiaries",
-            produces = { "application/json; charset=utf-8" },
+            produces = {"application/json; charset=utf-8"},
             method = RequestMethod.GET)
     ResponseEntity<OBReadBeneficiary3> getAccountBeneficiaries(
 
@@ -71,8 +71,8 @@ public interface BeneficiariesApi {
 
             @ApiParam(value = "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are " +
                     "represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC")
-            @RequestHeader(value="x-fapi-customer-last-logged-time", required=false)
-            @DateTimeFormat(pattern = ApiConstants.HTTP_DATE_FORMAT) DateTime xFapiCustomerLastLoggedTime,
+            @RequestHeader(value = "x-fapi-auth-date", required = false)
+            @DateTimeFormat(pattern = ApiConstants.HTTP_DATE_FORMAT) DateTime xFapiAuthDate,
 
             @ApiParam(value = "The PSU's IP address if the PSU is currently logged in with the TPP.")
             @RequestHeader(value = "x-fapi-customer-ip-address", required = false) String xFapiCustomerIpAddress,
@@ -103,11 +103,11 @@ public interface BeneficiariesApi {
             @ApiResponse(code = 405, message = "Method Not Allowed", response = Void.class),
             @ApiResponse(code = 406, message = "Not Acceptable", response = Void.class),
             @ApiResponse(code = 429, message = "Too Many Requests", response = Void.class),
-            @ApiResponse(code = 500, message = "Internal Server Error", response = Void.class) })
+            @ApiResponse(code = 500, message = "Internal Server Error", response = Void.class)})
 
 
     @RequestMapping(value = "/beneficiaries",
-            produces = { "application/json; charset=utf-8" },
+            produces = {"application/json; charset=utf-8"},
             method = RequestMethod.GET)
     ResponseEntity<OBReadBeneficiary3> getBeneficiaries(
             @ApiParam(value = "Page number.", required = false, defaultValue = "0")
@@ -119,8 +119,8 @@ public interface BeneficiariesApi {
             @ApiParam(value = "The time when the PSU last logged in with the TPP. " +
                     "All dates in the HTTP headers are represented as RFC 7231 Full Dates. " +
                     "An example is below:  Sun, 10 Sep 2017 19:43:31 UTC")
-            @RequestHeader(value="x-fapi-customer-last-logged-time", required=false)
-            @DateTimeFormat(pattern = ApiConstants.HTTP_DATE_FORMAT) DateTime xFapiCustomerLastLoggedTime,
+            @RequestHeader(value = "x-fapi-auth-date", required = false)
+            @DateTimeFormat(pattern = ApiConstants.HTTP_DATE_FORMAT) DateTime xFapiAuthDate,
 
             @ApiParam(value = "The PSU's IP address if the PSU is currently logged in with the TPP.")
             @RequestHeader(value = "x-fapi-customer-ip-address", required = false) String xFapiCustomerIpAddress,

--- a/secure-api-gateway-ob-uk-rs-obie-api/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/obie/api/account/v3_1_1/party/PartyApi.java
+++ b/secure-api-gateway-ob-uk-rs-obie-api/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/obie/api/account/v3_1_1/party/PartyApi.java
@@ -68,8 +68,8 @@ public interface PartyApi {
             @ApiParam(value = "The time when the PSU last logged in with the TPP.  " +
                     "All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  " +
                     "Sun, 10 Sep 2017 19:43:31 UTC")
-            @RequestHeader(value="x-fapi-customer-last-logged-time", required=false)
-            @DateTimeFormat(pattern = ApiConstants.HTTP_DATE_FORMAT) DateTime xFapiCustomerLastLoggedTime,
+            @RequestHeader(value = "x-fapi-auth-date", required = false)
+            @DateTimeFormat(pattern = ApiConstants.HTTP_DATE_FORMAT) DateTime xFapiAuthDate,
 
             @ApiParam(value = "The PSU's IP address if the PSU is currently logged in with the TPP.")
             @RequestHeader(value = "x-fapi-customer-ip-address", required = false) String xFapiCustomerIpAddress,
@@ -115,8 +115,8 @@ public interface PartyApi {
                     "All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  " +
                     "Sun, 10 Sep 2017 19:43:31 UTC")
 
-            @RequestHeader(value="x-fapi-customer-last-logged-time", required=false)
-            @DateTimeFormat(pattern = ApiConstants.HTTP_DATE_FORMAT) DateTime xFapiCustomerLastLoggedTime,
+            @RequestHeader(value = "x-fapi-auth-date", required = false)
+            @DateTimeFormat(pattern = ApiConstants.HTTP_DATE_FORMAT) DateTime xFapiAuthDate,
 
             @ApiParam(value = "The PSU's IP address if the PSU is currently logged in with the TPP.")
             @RequestHeader(value = "x-fapi-customer-ip-address", required = false) String xFapiCustomerIpAddress,
@@ -135,7 +135,7 @@ public interface PartyApi {
 
             @ApiParam(value = "The origin http url")
             @RequestHeader(value = "x-ob-url", required = true) String httpUrl
-            ) throws OBErrorResponseException;
+    ) throws OBErrorResponseException;
 
     @ApiOperation(value = "Get Party", nickname = "getParty", notes = "Get Party", response = OBReadParty2.class, authorizations = {
             @Authorization(value = "PSUOAuth2Security", scopes = {
@@ -161,8 +161,8 @@ public interface PartyApi {
             @ApiParam(value = "The time when the PSU last logged in with the TPP. " +
                     "All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below: " +
                     " Sun, 10 Sep 2017 19:43:31 UTC")
-            @RequestHeader(value="x-fapi-customer-last-logged-time", required=false)
-            @DateTimeFormat(pattern = ApiConstants.HTTP_DATE_FORMAT) DateTime xFapiCustomerLastLoggedTime,
+            @RequestHeader(value = "x-fapi-auth-date", required = false)
+            @DateTimeFormat(pattern = ApiConstants.HTTP_DATE_FORMAT) DateTime xFapiAuthDate,
 
             @ApiParam(value = "The PSU's IP address if the PSU is currently logged in with the TPP.")
             @RequestHeader(value = "x-fapi-customer-ip-address", required = false) String xFapiCustomerIpAddress,

--- a/secure-api-gateway-ob-uk-rs-obie-api/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/obie/api/account/v3_1_1/scheduledpayments/ScheduledPaymentsApi.java
+++ b/secure-api-gateway-ob-uk-rs-obie-api/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/obie/api/account/v3_1_1/scheduledpayments/ScheduledPaymentsApi.java
@@ -36,7 +36,7 @@ import java.util.List;
 @Api(tags = {"v3.1.1", SwaggerApiTags.ACCOUNTS_AND_TRANSACTION_TAG})
 @RequestMapping(value = "/open-banking/v3.1.1/aisp")
 public interface ScheduledPaymentsApi {
-    
+
     @ApiOperation(value = "Get Account Scheduled Payments", nickname = "getAccountScheduledPayments",
             notes = "Get Scheduled Payments related to an account", response = OBReadScheduledPayment2.class, authorizations = {
             @Authorization(value = "PSUOAuth2Security", scopes = {
@@ -51,9 +51,9 @@ public interface ScheduledPaymentsApi {
             @ApiResponse(code = 405, message = "Method Not Allowed"),
             @ApiResponse(code = 406, message = "Not Acceptable"),
             @ApiResponse(code = 429, message = "Too Many Requests"),
-            @ApiResponse(code = 500, message = "Internal Server Error") })
+            @ApiResponse(code = 500, message = "Internal Server Error")})
     @RequestMapping(value = "/accounts/{AccountId}/scheduled-payments",
-            produces = { "application/json; charset=utf-8" },
+            produces = {"application/json; charset=utf-8"},
             method = RequestMethod.GET)
     ResponseEntity<OBReadScheduledPayment2> getAccountScheduledPayments(
             @ApiParam(value = "A unique identifier used to identify the account resource.", required = true)
@@ -68,8 +68,8 @@ public interface ScheduledPaymentsApi {
             @ApiParam(value = "The time when the PSU last logged in with the TPP.  " +
                     "All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  " +
                     "Sun, 10 Sep 2017 19:43:31 UTC")
-            @RequestHeader(value="x-fapi-customer-last-logged-time", required=false)
-            @DateTimeFormat(pattern = ApiConstants.HTTP_DATE_FORMAT) DateTime xFapiCustomerLastLoggedTime,
+            @RequestHeader(value = "x-fapi-auth-date", required = false)
+            @DateTimeFormat(pattern = ApiConstants.HTTP_DATE_FORMAT) DateTime xFapiAuthDate,
 
             @ApiParam(value = "The PSU's IP address if the PSU is currently logged in with the TPP.")
             @RequestHeader(value = "x-fapi-customer-ip-address", required = false) String xFapiCustomerIpAddress,
@@ -100,9 +100,9 @@ public interface ScheduledPaymentsApi {
             @ApiResponse(code = 405, message = "Method Not Allowed"),
             @ApiResponse(code = 406, message = "Not Acceptable"),
             @ApiResponse(code = 429, message = "Too Many Requests"),
-            @ApiResponse(code = 500, message = "Internal Server Error") })
+            @ApiResponse(code = 500, message = "Internal Server Error")})
     @RequestMapping(value = "/scheduled-payments",
-            produces = { "application/json; charset=utf-8" },
+            produces = {"application/json; charset=utf-8"},
             method = RequestMethod.GET)
     ResponseEntity<OBReadScheduledPayment2> getScheduledPayments(
             @ApiParam(value = "Page number.", required = false, defaultValue = "0")
@@ -114,8 +114,8 @@ public interface ScheduledPaymentsApi {
             @ApiParam(value = "The time when the PSU last logged in with the TPP.  " +
                     "All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  " +
                     "Sun, 10 Sep 2017 19:43:31 UTC")
-            @RequestHeader(value="x-fapi-customer-last-logged-time", required=false)
-            @DateTimeFormat(pattern = ApiConstants.HTTP_DATE_FORMAT) DateTime xFapiCustomerLastLoggedTime,
+            @RequestHeader(value = "x-fapi-auth-date", required = false)
+            @DateTimeFormat(pattern = ApiConstants.HTTP_DATE_FORMAT) DateTime xFapiAuthDate,
 
             @ApiParam(value = "The PSU's IP address if the PSU is currently logged in with the TPP.")
             @RequestHeader(value = "x-fapi-customer-ip-address", required = false) String xFapiCustomerIpAddress,

--- a/secure-api-gateway-ob-uk-rs-obie-api/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/obie/api/account/v3_1_1/standingorders/StandingOrdersApi.java
+++ b/secure-api-gateway-ob-uk-rs-obie-api/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/obie/api/account/v3_1_1/standingorders/StandingOrdersApi.java
@@ -52,11 +52,11 @@ public interface StandingOrdersApi {
             @ApiResponse(code = 405, message = "Method Not Allowed", response = Void.class),
             @ApiResponse(code = 406, message = "Not Acceptable", response = Void.class),
             @ApiResponse(code = 429, message = "Too Many Requests", response = Void.class),
-            @ApiResponse(code = 500, message = "Internal Server Error", response = Void.class) })
+            @ApiResponse(code = 500, message = "Internal Server Error", response = Void.class)})
 
 
     @RequestMapping(value = "/accounts/{AccountId}/standing-orders",
-            produces = { "application/json; charset=utf-8" },
+            produces = {"application/json; charset=utf-8"},
             method = RequestMethod.GET)
     ResponseEntity<OBReadStandingOrder5> getAccountStandingOrders(
             @ApiParam(value = "A unique identifier used to identify the account resource.", required = true)
@@ -72,8 +72,8 @@ public interface StandingOrdersApi {
             @ApiParam(value = "The time when the PSU last logged in with the TPP. " +
                     "All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  " +
                     "Sun, 10 Sep 2017 19:43:31 UTC")
-            @RequestHeader(value = "x-fapi-customer-last-logged-time", required = false)
-            @DateTimeFormat(pattern = ApiConstants.HTTP_DATE_FORMAT) DateTime xFapiCustomerLastLoggedTime,
+            @RequestHeader(value = "x-fapi-auth-date", required = false)
+            @DateTimeFormat(pattern = ApiConstants.HTTP_DATE_FORMAT) DateTime xFapiAuthDate,
 
             @ApiParam(value = "The PSU's IP address if the PSU is currently logged in with the TPP.")
             @RequestHeader(value = "x-fapi-customer-ip-address", required = false) String xFapiCustomerIpAddress,
@@ -92,24 +92,24 @@ public interface StandingOrdersApi {
     ) throws OBErrorResponseException;
 
     @ApiOperation(value = "Get Standing Orders", notes = "Get Standing Orders", response = OBReadStandingOrder5.class, authorizations = {
-        @Authorization(value = "PSUOAuth2Security", scopes = {
-            @AuthorizationScope(scope = "accounts", description = "Ability to get Accounts information")
+            @Authorization(value = "PSUOAuth2Security", scopes = {
+                    @AuthorizationScope(scope = "accounts", description = "Ability to get Accounts information")
             })
     })
     @ApiResponses(value = {
-        @ApiResponse(code = 200, message = "Standing Orders successfully retrieved", response = OBReadStandingOrder5.class),
-        @ApiResponse(code = 400, message = "Bad Request", response = Void.class),
-        @ApiResponse(code = 401, message = "Unauthorized", response = Void.class),
-        @ApiResponse(code = 403, message = "Forbidden", response = Void.class),
-        @ApiResponse(code = 405, message = "Method Not Allowed", response = Void.class),
-        @ApiResponse(code = 406, message = "Not Acceptable", response = Void.class),
-        @ApiResponse(code = 429, message = "Too Many Requests", response = Void.class),
-        @ApiResponse(code = 500, message = "Internal Server Error", response = Void.class) })
+            @ApiResponse(code = 200, message = "Standing Orders successfully retrieved", response = OBReadStandingOrder5.class),
+            @ApiResponse(code = 400, message = "Bad Request", response = Void.class),
+            @ApiResponse(code = 401, message = "Unauthorized", response = Void.class),
+            @ApiResponse(code = 403, message = "Forbidden", response = Void.class),
+            @ApiResponse(code = 405, message = "Method Not Allowed", response = Void.class),
+            @ApiResponse(code = 406, message = "Not Acceptable", response = Void.class),
+            @ApiResponse(code = 429, message = "Too Many Requests", response = Void.class),
+            @ApiResponse(code = 500, message = "Internal Server Error", response = Void.class)})
 
 
     @RequestMapping(value = "/standing-orders",
-        produces = { "application/json; charset=utf-8" },
-        method = RequestMethod.GET)
+            produces = {"application/json; charset=utf-8"},
+            method = RequestMethod.GET)
     ResponseEntity<OBReadStandingOrder5> getStandingOrders(
             @ApiParam(value = "Page number.", required = false, defaultValue = "0")
             @RequestParam(value = "page", defaultValue = "0") int page,
@@ -119,8 +119,8 @@ public interface StandingOrdersApi {
 
             @ApiParam(value = "The time when the PSU last logged in with the TPP. All dates in the HTTP headers are " +
                     "represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC")
-            @RequestHeader(value = "x-fapi-customer-last-logged-time", required = false)
-            @DateTimeFormat(pattern = ApiConstants.HTTP_DATE_FORMAT) DateTime xFapiCustomerLastLoggedTime,
+            @RequestHeader(value = "x-fapi-auth-date", required = false)
+            @DateTimeFormat(pattern = ApiConstants.HTTP_DATE_FORMAT) DateTime xFapiAuthDate,
 
             @ApiParam(value = "The PSU's IP address if the PSU is currently logged in with the TPP.")
             @RequestHeader(value = "x-fapi-customer-ip-address", required = false) String xFapiCustomerIpAddress,

--- a/secure-api-gateway-ob-uk-rs-obie-api/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/obie/api/account/v3_1_1/transactions/TransactionsApi.java
+++ b/secure-api-gateway-ob-uk-rs-obie-api/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/obie/api/account/v3_1_1/transactions/TransactionsApi.java
@@ -51,11 +51,11 @@ public interface TransactionsApi {
             @ApiResponse(code = 405, message = "Method Not Allowed", response = Void.class),
             @ApiResponse(code = 406, message = "Not Acceptable", response = Void.class),
             @ApiResponse(code = 429, message = "Too Many Requests", response = Void.class),
-            @ApiResponse(code = 500, message = "Internal Server Error", response = Void.class) })
+            @ApiResponse(code = 500, message = "Internal Server Error", response = Void.class)})
 
 
     @RequestMapping(value = "/accounts/{AccountId}/transactions",
-            produces = { "application/json; charset=utf-8" },
+            produces = {"application/json; charset=utf-8"},
             method = RequestMethod.GET)
     ResponseEntity<OBReadTransaction5> getAccountTransactions(
             @ApiParam(value = "A unique identifier used to identify the account resource.", required = true)
@@ -78,8 +78,8 @@ public interface TransactionsApi {
             @ApiParam(value = "The time when the PSU last logged in with the TPP. " +
                     "All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  " +
                     "Sun, 10 Sep 2017 19:43:31 UTC")
-            @RequestHeader(value = "x-fapi-customer-last-logged-time", required = false)
-            @DateTimeFormat(pattern = ApiConstants.HTTP_DATE_FORMAT) DateTime xFapiCustomerLastLoggedTime,
+            @RequestHeader(value = "x-fapi-auth-date", required = false)
+            @DateTimeFormat(pattern = ApiConstants.HTTP_DATE_FORMAT) DateTime xFapiAuthDate,
 
             @ApiParam(value = "The PSU's IP address if the PSU is currently logged in with the TPP.")
             @RequestHeader(value = "x-fapi-customer-ip-address", required = false) String xFapiCustomerIpAddress,
@@ -104,24 +104,24 @@ public interface TransactionsApi {
     ) throws OBErrorResponseException;
 
     @ApiOperation(value = "Get Transactions", notes = "Get Transactions", response = OBReadTransaction5.class, authorizations = {
-        @Authorization(value = "PSUOAuth2Security", scopes = {
-            @AuthorizationScope(scope = "accounts", description = "Ability to get Accounts information")
+            @Authorization(value = "PSUOAuth2Security", scopes = {
+                    @AuthorizationScope(scope = "accounts", description = "Ability to get Accounts information")
             })
     })
     @ApiResponses(value = {
-        @ApiResponse(code = 200, message = "Transactions successfully retrieved", response = OBReadTransaction5.class),
-        @ApiResponse(code = 400, message = "Bad Request", response = Void.class),
-        @ApiResponse(code = 401, message = "Unauthorized", response = Void.class),
-        @ApiResponse(code = 403, message = "Forbidden", response = Void.class),
-        @ApiResponse(code = 405, message = "Method Not Allowed", response = Void.class),
-        @ApiResponse(code = 406, message = "Not Acceptable", response = Void.class),
-        @ApiResponse(code = 429, message = "Too Many Requests", response = Void.class),
-        @ApiResponse(code = 500, message = "Internal Server Error", response = Void.class) })
+            @ApiResponse(code = 200, message = "Transactions successfully retrieved", response = OBReadTransaction5.class),
+            @ApiResponse(code = 400, message = "Bad Request", response = Void.class),
+            @ApiResponse(code = 401, message = "Unauthorized", response = Void.class),
+            @ApiResponse(code = 403, message = "Forbidden", response = Void.class),
+            @ApiResponse(code = 405, message = "Method Not Allowed", response = Void.class),
+            @ApiResponse(code = 406, message = "Not Acceptable", response = Void.class),
+            @ApiResponse(code = 429, message = "Too Many Requests", response = Void.class),
+            @ApiResponse(code = 500, message = "Internal Server Error", response = Void.class)})
 
 
     @RequestMapping(value = "/transactions",
-        produces = { "application/json; charset=utf-8" },
-        method = RequestMethod.GET)
+            produces = {"application/json; charset=utf-8"},
+            method = RequestMethod.GET)
     ResponseEntity<OBReadTransaction5> getTransactions(
             @ApiParam(value = "Page number.", required = false, defaultValue = "0")
             @RequestParam(value = "page", defaultValue = "0") int page,
@@ -131,8 +131,8 @@ public interface TransactionsApi {
 
             @ApiParam(value = "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are " +
                     "represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC")
-            @RequestHeader(value = "x-fapi-customer-last-logged-time", required = false)
-            @DateTimeFormat(pattern = ApiConstants.HTTP_DATE_FORMAT) DateTime xFapiCustomerLastLoggedTime,
+            @RequestHeader(value = "x-fapi-auth-date", required = false)
+            @DateTimeFormat(pattern = ApiConstants.HTTP_DATE_FORMAT) DateTime xFapiAuthDate,
 
             @ApiParam(value = "The PSU's IP address if the PSU is currently logged in with the TPP.")
             @RequestHeader(value = "x-fapi-customer-ip-address", required = false) String xFapiCustomerIpAddress,
@@ -178,9 +178,9 @@ public interface TransactionsApi {
             @ApiResponse(code = 405, message = "Method Not Allowed"),
             @ApiResponse(code = 406, message = "Not Acceptable"),
             @ApiResponse(code = 429, message = "Too Many Requests"),
-            @ApiResponse(code = 500, message = "Internal Server Error") })
+            @ApiResponse(code = 500, message = "Internal Server Error")})
     @RequestMapping(value = "/accounts/{AccountId}/statements/{StatementId}/transactions",
-            produces = { "application/json; charset=utf-8" },
+            produces = {"application/json; charset=utf-8"},
             method = RequestMethod.GET)
     ResponseEntity<OBReadTransaction5> getAccountStatementTransactions(
             @ApiParam(value = "A unique identifier used to identify the account resource.", required = true)
@@ -206,8 +206,8 @@ public interface TransactionsApi {
             @ApiParam(value = "The time when the PSU last logged in with the TPP.  " +
                     "All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  " +
                     "Sun, 10 Sep 2017 19:43:31 UTC")
-            @RequestHeader(value = "x-fapi-customer-last-logged-time", required = false)
-            @DateTimeFormat(pattern = ApiConstants.HTTP_DATE_FORMAT) DateTime xFapiCustomerLastLoggedTime,
+            @RequestHeader(value = "x-fapi-auth-date", required = false)
+            @DateTimeFormat(pattern = ApiConstants.HTTP_DATE_FORMAT) DateTime xFapiAuthDate,
 
             @ApiParam(value = "The PSU's IP address if the PSU is currently logged in with the TPP.")
             @RequestHeader(value = "x-fapi-customer-ip-address", required = false) String xFapiCustomerIpAddress,

--- a/secure-api-gateway-ob-uk-rs-obie-api/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/obie/api/funds/v3_0/FundsConfirmationsApi.java
+++ b/secure-api-gateway-ob-uk-rs-obie-api/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/obie/api/funds/v3_0/FundsConfirmationsApi.java
@@ -69,8 +69,8 @@ public interface FundsConfirmationsApi {
             @RequestHeader(value = "Authorization", required = true) String authorization,
 
             @ApiParam(value = "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC")
-            @RequestHeader(value="x-fapi-customer-last-logged-time", required=false)
-            @DateTimeFormat(pattern = ApiConstants.HTTP_DATE_FORMAT) DateTime xFapiCustomerLastLoggedTime,
+            @RequestHeader(value = "x-fapi-auth-date", required = false)
+            @DateTimeFormat(pattern = ApiConstants.HTTP_DATE_FORMAT) DateTime xFapiAuthDate,
 
             @ApiParam(value = "The PSU's IP address if the PSU is currently logged in with the TPP.")
             @RequestHeader(value = "x-fapi-customer-ip-address", required = false) String xFapiCustomerIpAddress,
@@ -102,7 +102,7 @@ public interface FundsConfirmationsApi {
             @ApiResponse(code = 429, message = "Too Many Requests"),
             @ApiResponse(code = 500, message = "Internal Server Error", response = OBErrorResponse1.class)})
 
-    @RequestMapping(value = FUNDS_CONFIRMATION_PATH+"/{FundsConfirmationId}",
+    @RequestMapping(value = FUNDS_CONFIRMATION_PATH + "/{FundsConfirmationId}",
             produces = {"application/json; charset=utf-8"},
             method = RequestMethod.GET)
     ResponseEntity<OBFundsConfirmationResponse1> getFundsConfirmationId(
@@ -113,8 +113,8 @@ public interface FundsConfirmationsApi {
             @RequestHeader(value = "Authorization", required = true) String authorization,
 
             @ApiParam(value = "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC")
-            @RequestHeader(value="x-fapi-customer-last-logged-time", required=false)
-            @DateTimeFormat(pattern = ApiConstants.HTTP_DATE_FORMAT) DateTime xFapiCustomerLastLoggedTime,
+            @RequestHeader(value = "x-fapi-auth-date", required = false)
+            @DateTimeFormat(pattern = ApiConstants.HTTP_DATE_FORMAT) DateTime xFapiAuthDate,
 
             @ApiParam(value = "The PSU's IP address if the PSU is currently logged in with the TPP.")
             @RequestHeader(value = "x-fapi-customer-ip-address", required = false) String xFapiCustomerIpAddress,

--- a/secure-api-gateway-ob-uk-rs-obie-api/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/obie/api/payment/v3_0/domesticpayments/DomesticPaymentsApi.java
+++ b/secure-api-gateway-ob-uk-rs-obie-api/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/obie/api/payment/v3_0/domesticpayments/DomesticPaymentsApi.java
@@ -77,8 +77,8 @@ public interface DomesticPaymentsApi {
             @RequestHeader(value = "x-jws-signature", required = true) String xJwsSignature,
 
             @ApiParam(value = "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC")
-            @RequestHeader(value = "x-fapi-customer-last-logged-time", required = false)
-            @DateTimeFormat(pattern = ApiConstants.HTTP_DATE_FORMAT) DateTime xFapiCustomerLastLoggedTime,
+            @RequestHeader(value = "x-fapi-auth-date", required = false)
+            @DateTimeFormat(pattern = ApiConstants.HTTP_DATE_FORMAT) DateTime xFapiAuthDate,
 
             @ApiParam(value = "The PSU's IP address if the PSU is currently logged in with the TPP.")
             @RequestHeader(value = "x-fapi-customer-ip-address", required = false) String xFapiCustomerIpAddress,
@@ -121,8 +121,8 @@ public interface DomesticPaymentsApi {
             @RequestHeader(value = "Authorization", required = true) String authorization,
 
             @ApiParam(value = "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC")
-            @RequestHeader(value = "x-fapi-customer-last-logged-time", required = false)
-            @DateTimeFormat(pattern = ApiConstants.HTTP_DATE_FORMAT) DateTime xFapiCustomerLastLoggedTime,
+            @RequestHeader(value = "x-fapi-auth-date", required = false)
+            @DateTimeFormat(pattern = ApiConstants.HTTP_DATE_FORMAT) DateTime xFapiAuthDate,
 
             @ApiParam(value = "The PSU's IP address if the PSU is currently logged in with the TPP.")
             @RequestHeader(value = "x-fapi-customer-ip-address", required = false) String xFapiCustomerIpAddress,

--- a/secure-api-gateway-ob-uk-rs-obie-api/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/obie/api/payment/v3_0/domesticscheduledpayments/DomesticScheduledPaymentsApi.java
+++ b/secure-api-gateway-ob-uk-rs-obie-api/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/obie/api/payment/v3_0/domesticscheduledpayments/DomesticScheduledPaymentsApi.java
@@ -81,8 +81,8 @@ public interface DomesticScheduledPaymentsApi {
             @RequestHeader(value = "x-ob-account-id", required = true) String xAccountId,
 
             @ApiParam(value = "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC")
-            @RequestHeader(value = "x-fapi-customer-last-logged-time", required = false)
-            @DateTimeFormat(pattern = ApiConstants.HTTP_DATE_FORMAT) DateTime xFapiCustomerLastLoggedTime,
+            @RequestHeader(value = "x-fapi-auth-date", required = false)
+            @DateTimeFormat(pattern = ApiConstants.HTTP_DATE_FORMAT) DateTime xFapiAuthDate,
 
             @ApiParam(value = "The PSU's IP address if the PSU is currently logged in with the TPP.")
             @RequestHeader(value = "x-fapi-customer-ip-address", required = false) String xFapiCustomerIpAddress,
@@ -126,8 +126,8 @@ public interface DomesticScheduledPaymentsApi {
             @RequestHeader(value = "Authorization", required = true) String authorization,
 
             @ApiParam(value = "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC")
-            @RequestHeader(value = "x-fapi-customer-last-logged-time", required = false)
-            @DateTimeFormat(pattern = ApiConstants.HTTP_DATE_FORMAT) DateTime xFapiCustomerLastLoggedTime,
+            @RequestHeader(value = "x-fapi-auth-date", required = false)
+            @DateTimeFormat(pattern = ApiConstants.HTTP_DATE_FORMAT) DateTime xFapiAuthDate,
 
             @ApiParam(value = "The PSU's IP address if the PSU is currently logged in with the TPP.")
             @RequestHeader(value = "x-fapi-customer-ip-address", required = false) String xFapiCustomerIpAddress,

--- a/secure-api-gateway-ob-uk-rs-obie-api/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/obie/api/payment/v3_0/domesticstandingorders/DomesticStandingOrdersApi.java
+++ b/secure-api-gateway-ob-uk-rs-obie-api/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/obie/api/payment/v3_0/domesticstandingorders/DomesticStandingOrdersApi.java
@@ -81,8 +81,8 @@ public interface DomesticStandingOrdersApi {
             @RequestHeader(value = "x-ob-account-id", required = true) String xAccountId,
 
             @ApiParam(value = "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC")
-            @RequestHeader(value = "x-fapi-customer-last-logged-time", required = false)
-            @DateTimeFormat(pattern = ApiConstants.HTTP_DATE_FORMAT) DateTime xFapiCustomerLastLoggedTime,
+            @RequestHeader(value = "x-fapi-auth-date", required = false)
+            @DateTimeFormat(pattern = ApiConstants.HTTP_DATE_FORMAT) DateTime xFapiAuthDate,
 
             @ApiParam(value = "The PSU's IP address if the PSU is currently logged in with the TPP.")
             @RequestHeader(value = "x-fapi-customer-ip-address", required = false) String xFapiCustomerIpAddress,
@@ -126,8 +126,8 @@ public interface DomesticStandingOrdersApi {
             @RequestHeader(value = "Authorization", required = true) String authorization,
 
             @ApiParam(value = "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC")
-            @RequestHeader(value = "x-fapi-customer-last-logged-time", required = false)
-            @DateTimeFormat(pattern = ApiConstants.HTTP_DATE_FORMAT) DateTime xFapiCustomerLastLoggedTime,
+            @RequestHeader(value = "x-fapi-auth-date", required = false)
+            @DateTimeFormat(pattern = ApiConstants.HTTP_DATE_FORMAT) DateTime xFapiAuthDate,
 
             @ApiParam(value = "The PSU's IP address if the PSU is currently logged in with the TPP.")
             @RequestHeader(value = "x-fapi-customer-ip-address", required = false) String xFapiCustomerIpAddress,

--- a/secure-api-gateway-ob-uk-rs-obie-api/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/obie/api/payment/v3_0/file/FilePaymentsApi.java
+++ b/secure-api-gateway-ob-uk-rs-obie-api/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/obie/api/payment/v3_0/file/FilePaymentsApi.java
@@ -79,8 +79,8 @@ public interface FilePaymentsApi {
             @RequestHeader(value = "x-jws-signature", required = true) String xJwsSignature,
 
             @ApiParam(value = "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC")
-            @RequestHeader(value = "x-fapi-customer-last-logged-time", required = false)
-            @DateTimeFormat(pattern = ApiConstants.HTTP_DATE_FORMAT) DateTime xFapiCustomerLastLoggedTime,
+            @RequestHeader(value = "x-fapi-auth-date", required = false)
+            @DateTimeFormat(pattern = ApiConstants.HTTP_DATE_FORMAT) DateTime xFapiAuthDate,
 
             @ApiParam(value = "The PSU's IP address if the PSU is currently logged in with the TPP.")
             @RequestHeader(value = "x-fapi-customer-ip-address", required = false) String xFapiCustomerIpAddress,
@@ -123,8 +123,8 @@ public interface FilePaymentsApi {
             @RequestHeader(value = "Authorization", required = true) String authorization,
 
             @ApiParam(value = "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC")
-            @RequestHeader(value = "x-fapi-customer-last-logged-time", required = false)
-            @DateTimeFormat(pattern = ApiConstants.HTTP_DATE_FORMAT) DateTime xFapiCustomerLastLoggedTime,
+            @RequestHeader(value = "x-fapi-auth-date", required = false)
+            @DateTimeFormat(pattern = ApiConstants.HTTP_DATE_FORMAT) DateTime xFapiAuthDate,
 
             @ApiParam(value = "The PSU's IP address if the PSU is currently logged in with the TPP.")
             @RequestHeader(value = "x-fapi-customer-ip-address", required = false) String xFapiCustomerIpAddress,
@@ -168,8 +168,8 @@ public interface FilePaymentsApi {
             @RequestHeader(value = "Authorization", required = true) String authorization,
 
             @ApiParam(value = "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC")
-            @RequestHeader(value = "x-fapi-customer-last-logged-time", required = false)
-            @DateTimeFormat(pattern = ApiConstants.HTTP_DATE_FORMAT) DateTime xFapiCustomerLastLoggedTime,
+            @RequestHeader(value = "x-fapi-auth-date", required = false)
+            @DateTimeFormat(pattern = ApiConstants.HTTP_DATE_FORMAT) DateTime xFapiAuthDate,
 
             @ApiParam(value = "The PSU's IP address if the PSU is currently logged in with the TPP.")
             @RequestHeader(value = "x-fapi-customer-ip-address", required = false) String xFapiCustomerIpAddress,

--- a/secure-api-gateway-ob-uk-rs-obie-api/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/obie/api/payment/v3_0/internationalpayments/InternationalPaymentsApi.java
+++ b/secure-api-gateway-ob-uk-rs-obie-api/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/obie/api/payment/v3_0/internationalpayments/InternationalPaymentsApi.java
@@ -78,8 +78,8 @@ public interface InternationalPaymentsApi {
             @RequestHeader(value = "x-jws-signature", required = true) String xJwsSignature,
 
             @ApiParam(value = "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC")
-            @RequestHeader(value = "x-fapi-customer-last-logged-time", required = false)
-            @DateTimeFormat(pattern = ApiConstants.HTTP_DATE_FORMAT) DateTime xFapiCustomerLastLoggedTime,
+            @RequestHeader(value = "x-fapi-auth-date", required = false)
+            @DateTimeFormat(pattern = ApiConstants.HTTP_DATE_FORMAT) DateTime xFapiAuthDate,
 
             @ApiParam(value = "The PSU's IP address if the PSU is currently logged in with the TPP.")
             @RequestHeader(value = "x-fapi-customer-ip-address", required = false) String xFapiCustomerIpAddress,
@@ -123,8 +123,8 @@ public interface InternationalPaymentsApi {
             @RequestHeader(value = "Authorization", required = true) String authorization,
 
             @ApiParam(value = "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC")
-            @RequestHeader(value = "x-fapi-customer-last-logged-time", required = false)
-            @DateTimeFormat(pattern = ApiConstants.HTTP_DATE_FORMAT) DateTime xFapiCustomerLastLoggedTime,
+            @RequestHeader(value = "x-fapi-auth-date", required = false)
+            @DateTimeFormat(pattern = ApiConstants.HTTP_DATE_FORMAT) DateTime xFapiAuthDate,
 
             @ApiParam(value = "The PSU's IP address if the PSU is currently logged in with the TPP.")
             @RequestHeader(value = "x-fapi-customer-ip-address", required = false) String xFapiCustomerIpAddress,

--- a/secure-api-gateway-ob-uk-rs-obie-api/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/obie/api/payment/v3_0/internationalscheduledpayments/InternationalScheduledPaymentsApi.java
+++ b/secure-api-gateway-ob-uk-rs-obie-api/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/obie/api/payment/v3_0/internationalscheduledpayments/InternationalScheduledPaymentsApi.java
@@ -81,8 +81,8 @@ public interface InternationalScheduledPaymentsApi {
             @RequestHeader(value = "x-ob-account-id", required = true) String xAccountId,
 
             @ApiParam(value = "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC")
-            @RequestHeader(value = "x-fapi-customer-last-logged-time", required = false)
-            @DateTimeFormat(pattern = ApiConstants.HTTP_DATE_FORMAT) DateTime xFapiCustomerLastLoggedTime,
+            @RequestHeader(value = "x-fapi-auth-date", required = false)
+            @DateTimeFormat(pattern = ApiConstants.HTTP_DATE_FORMAT) DateTime xFapiAuthDate,
 
             @ApiParam(value = "The PSU's IP address if the PSU is currently logged in with the TPP.")
             @RequestHeader(value = "x-fapi-customer-ip-address", required = false) String xFapiCustomerIpAddress,
@@ -126,8 +126,8 @@ public interface InternationalScheduledPaymentsApi {
             @RequestHeader(value = "Authorization", required = true) String authorization,
 
             @ApiParam(value = "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC")
-            @RequestHeader(value = "x-fapi-customer-last-logged-time", required = false)
-            @DateTimeFormat(pattern = ApiConstants.HTTP_DATE_FORMAT) DateTime xFapiCustomerLastLoggedTime,
+            @RequestHeader(value = "x-fapi-auth-date", required = false)
+            @DateTimeFormat(pattern = ApiConstants.HTTP_DATE_FORMAT) DateTime xFapiAuthDate,
 
             @ApiParam(value = "The PSU's IP address if the PSU is currently logged in with the TPP.")
             @RequestHeader(value = "x-fapi-customer-ip-address", required = false) String xFapiCustomerIpAddress,

--- a/secure-api-gateway-ob-uk-rs-obie-api/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/obie/api/payment/v3_0/internationalstandingorders/InternationalStandingOrdersApi.java
+++ b/secure-api-gateway-ob-uk-rs-obie-api/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/obie/api/payment/v3_0/internationalstandingorders/InternationalStandingOrdersApi.java
@@ -81,8 +81,8 @@ public interface InternationalStandingOrdersApi {
             @RequestHeader(value = "x-ob-account-id", required = true) String xAccountId,
 
             @ApiParam(value = "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC")
-            @RequestHeader(value = "x-fapi-customer-last-logged-time", required = false)
-            @DateTimeFormat(pattern = ApiConstants.HTTP_DATE_FORMAT) DateTime xFapiCustomerLastLoggedTime,
+            @RequestHeader(value = "x-fapi-auth-date", required = false)
+            @DateTimeFormat(pattern = ApiConstants.HTTP_DATE_FORMAT) DateTime xFapiAuthDate,
 
             @ApiParam(value = "The PSU's IP address if the PSU is currently logged in with the TPP.")
             @RequestHeader(value = "x-fapi-customer-ip-address", required = false) String xFapiCustomerIpAddress,
@@ -126,8 +126,8 @@ public interface InternationalStandingOrdersApi {
             @RequestHeader(value = "Authorization", required = true) String authorization,
 
             @ApiParam(value = "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC")
-            @RequestHeader(value = "x-fapi-customer-last-logged-time", required = false)
-            @DateTimeFormat(pattern = ApiConstants.HTTP_DATE_FORMAT) DateTime xFapiCustomerLastLoggedTime,
+            @RequestHeader(value = "x-fapi-auth-date", required = false)
+            @DateTimeFormat(pattern = ApiConstants.HTTP_DATE_FORMAT) DateTime xFapiAuthDate,
 
             @ApiParam(value = "The PSU's IP address if the PSU is currently logged in with the TPP.")
             @RequestHeader(value = "x-fapi-customer-ip-address", required = false) String xFapiCustomerIpAddress,

--- a/secure-api-gateway-ob-uk-rs-obie-api/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/obie/api/payment/v3_1/domesticpayments/DomesticPaymentsApi.java
+++ b/secure-api-gateway-ob-uk-rs-obie-api/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/obie/api/payment/v3_1/domesticpayments/DomesticPaymentsApi.java
@@ -78,8 +78,8 @@ public interface DomesticPaymentsApi {
             @RequestHeader(value = "x-jws-signature", required = true) String xJwsSignature,
 
             @ApiParam(value = "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC")
-            @RequestHeader(value = "x-fapi-customer-last-logged-time", required = false)
-            @DateTimeFormat(pattern = ApiConstants.HTTP_DATE_FORMAT) DateTime xFapiCustomerLastLoggedTime,
+            @RequestHeader(value = "x-fapi-auth-date", required = false)
+            @DateTimeFormat(pattern = ApiConstants.HTTP_DATE_FORMAT) DateTime xFapiAuthDate,
 
             @ApiParam(value = "The PSU's IP address if the PSU is currently logged in with the TPP.")
             @RequestHeader(value = "x-fapi-customer-ip-address", required = false) String xFapiCustomerIpAddress,
@@ -122,8 +122,8 @@ public interface DomesticPaymentsApi {
             @RequestHeader(value = "Authorization", required = true) String authorization,
 
             @ApiParam(value = "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC")
-            @RequestHeader(value = "x-fapi-customer-last-logged-time", required = false)
-            @DateTimeFormat(pattern = ApiConstants.HTTP_DATE_FORMAT) DateTime xFapiCustomerLastLoggedTime,
+            @RequestHeader(value = "x-fapi-auth-date", required = false)
+            @DateTimeFormat(pattern = ApiConstants.HTTP_DATE_FORMAT) DateTime xFapiAuthDate,
 
             @ApiParam(value = "The PSU's IP address if the PSU is currently logged in with the TPP.")
             @RequestHeader(value = "x-fapi-customer-ip-address", required = false) String xFapiCustomerIpAddress,

--- a/secure-api-gateway-ob-uk-rs-obie-api/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/obie/api/payment/v3_1/domesticscheduledpayments/DomesticScheduledPaymentsApi.java
+++ b/secure-api-gateway-ob-uk-rs-obie-api/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/obie/api/payment/v3_1/domesticscheduledpayments/DomesticScheduledPaymentsApi.java
@@ -81,8 +81,8 @@ public interface DomesticScheduledPaymentsApi {
             @RequestHeader(value = "x-ob-account-id", required = true) String xAccountId,
 
             @ApiParam(value = "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC")
-            @RequestHeader(value = "x-fapi-customer-last-logged-time", required = false)
-            @DateTimeFormat(pattern = ApiConstants.HTTP_DATE_FORMAT) DateTime xFapiCustomerLastLoggedTime,
+            @RequestHeader(value = "x-fapi-auth-date", required = false)
+            @DateTimeFormat(pattern = ApiConstants.HTTP_DATE_FORMAT) DateTime xFapiAuthDate,
 
             @ApiParam(value = "The PSU's IP address if the PSU is currently logged in with the TPP.")
             @RequestHeader(value = "x-fapi-customer-ip-address", required = false) String xFapiCustomerIpAddress,
@@ -126,8 +126,8 @@ public interface DomesticScheduledPaymentsApi {
             @RequestHeader(value = "Authorization", required = true) String authorization,
 
             @ApiParam(value = "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC")
-            @RequestHeader(value = "x-fapi-customer-last-logged-time", required = false)
-            @DateTimeFormat(pattern = ApiConstants.HTTP_DATE_FORMAT) DateTime xFapiCustomerLastLoggedTime,
+            @RequestHeader(value = "x-fapi-auth-date", required = false)
+            @DateTimeFormat(pattern = ApiConstants.HTTP_DATE_FORMAT) DateTime xFapiAuthDate,
 
             @ApiParam(value = "The PSU's IP address if the PSU is currently logged in with the TPP.")
             @RequestHeader(value = "x-fapi-customer-ip-address", required = false) String xFapiCustomerIpAddress,

--- a/secure-api-gateway-ob-uk-rs-obie-api/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/obie/api/payment/v3_1/domesticstandingorders/DomesticStandingOrdersApi.java
+++ b/secure-api-gateway-ob-uk-rs-obie-api/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/obie/api/payment/v3_1/domesticstandingorders/DomesticStandingOrdersApi.java
@@ -81,8 +81,8 @@ public interface DomesticStandingOrdersApi {
             @RequestHeader(value = "x-ob-account-id", required = true) String xAccountId,
 
             @ApiParam(value = "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC")
-            @RequestHeader(value = "x-fapi-customer-last-logged-time", required = false)
-            @DateTimeFormat(pattern = ApiConstants.HTTP_DATE_FORMAT) DateTime xFapiCustomerLastLoggedTime,
+            @RequestHeader(value = "x-fapi-auth-date", required = false)
+            @DateTimeFormat(pattern = ApiConstants.HTTP_DATE_FORMAT) DateTime xFapiAuthDate,
 
             @ApiParam(value = "The PSU's IP address if the PSU is currently logged in with the TPP.")
             @RequestHeader(value = "x-fapi-customer-ip-address", required = false) String xFapiCustomerIpAddress,
@@ -126,8 +126,8 @@ public interface DomesticStandingOrdersApi {
             @RequestHeader(value = "Authorization", required = true) String authorization,
 
             @ApiParam(value = "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC")
-            @RequestHeader(value = "x-fapi-customer-last-logged-time", required = false)
-            @DateTimeFormat(pattern = ApiConstants.HTTP_DATE_FORMAT) DateTime xFapiCustomerLastLoggedTime,
+            @RequestHeader(value = "x-fapi-auth-date", required = false)
+            @DateTimeFormat(pattern = ApiConstants.HTTP_DATE_FORMAT) DateTime xFapiAuthDate,
 
             @ApiParam(value = "The PSU's IP address if the PSU is currently logged in with the TPP.")
             @RequestHeader(value = "x-fapi-customer-ip-address", required = false) String xFapiCustomerIpAddress,

--- a/secure-api-gateway-ob-uk-rs-obie-api/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/obie/api/payment/v3_1/file/FilePaymentsApi.java
+++ b/secure-api-gateway-ob-uk-rs-obie-api/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/obie/api/payment/v3_1/file/FilePaymentsApi.java
@@ -80,8 +80,8 @@ public interface FilePaymentsApi {
             @RequestHeader(value = "x-jws-signature", required = true) String xJwsSignature,
 
             @ApiParam(value = "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC")
-            @RequestHeader(value = "x-fapi-customer-last-logged-time", required = false)
-            @DateTimeFormat(pattern = ApiConstants.HTTP_DATE_FORMAT) DateTime xFapiCustomerLastLoggedTime,
+            @RequestHeader(value = "x-fapi-auth-date", required = false)
+            @DateTimeFormat(pattern = ApiConstants.HTTP_DATE_FORMAT) DateTime xFapiAuthDate,
 
             @ApiParam(value = "The PSU's IP address if the PSU is currently logged in with the TPP.")
             @RequestHeader(value = "x-fapi-customer-ip-address", required = false) String xFapiCustomerIpAddress,
@@ -124,8 +124,8 @@ public interface FilePaymentsApi {
             @RequestHeader(value = "Authorization", required = true) String authorization,
 
             @ApiParam(value = "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC")
-            @RequestHeader(value = "x-fapi-customer-last-logged-time", required = false)
-            @DateTimeFormat(pattern = ApiConstants.HTTP_DATE_FORMAT) DateTime xFapiCustomerLastLoggedTime,
+            @RequestHeader(value = "x-fapi-auth-date", required = false)
+            @DateTimeFormat(pattern = ApiConstants.HTTP_DATE_FORMAT) DateTime xFapiAuthDate,
 
             @ApiParam(value = "The PSU's IP address if the PSU is currently logged in with the TPP.")
             @RequestHeader(value = "x-fapi-customer-ip-address", required = false) String xFapiCustomerIpAddress,
@@ -169,8 +169,8 @@ public interface FilePaymentsApi {
             @RequestHeader(value = "Authorization", required = true) String authorization,
 
             @ApiParam(value = "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC")
-            @RequestHeader(value = "x-fapi-customer-last-logged-time", required = false)
-            @DateTimeFormat(pattern = ApiConstants.HTTP_DATE_FORMAT) DateTime xFapiCustomerLastLoggedTime,
+            @RequestHeader(value = "x-fapi-auth-date", required = false)
+            @DateTimeFormat(pattern = ApiConstants.HTTP_DATE_FORMAT) DateTime xFapiAuthDate,
 
             @ApiParam(value = "The PSU's IP address if the PSU is currently logged in with the TPP.")
             @RequestHeader(value = "x-fapi-customer-ip-address", required = false) String xFapiCustomerIpAddress,

--- a/secure-api-gateway-ob-uk-rs-obie-api/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/obie/api/payment/v3_1/internationalpayments/InternationalPaymentsApi.java
+++ b/secure-api-gateway-ob-uk-rs-obie-api/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/obie/api/payment/v3_1/internationalpayments/InternationalPaymentsApi.java
@@ -78,8 +78,8 @@ public interface InternationalPaymentsApi {
             @RequestHeader(value = "x-jws-signature", required = true) String xJwsSignature,
 
             @ApiParam(value = "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC")
-            @RequestHeader(value = "x-fapi-customer-last-logged-time", required = false)
-            @DateTimeFormat(pattern = ApiConstants.HTTP_DATE_FORMAT) DateTime xFapiCustomerLastLoggedTime,
+            @RequestHeader(value = "x-fapi-auth-date", required = false)
+            @DateTimeFormat(pattern = ApiConstants.HTTP_DATE_FORMAT) DateTime xFapiAuthDate,
 
             @ApiParam(value = "The PSU's IP address if the PSU is currently logged in with the TPP.")
             @RequestHeader(value = "x-fapi-customer-ip-address", required = false) String xFapiCustomerIpAddress,
@@ -123,8 +123,8 @@ public interface InternationalPaymentsApi {
             @RequestHeader(value = "Authorization", required = true) String authorization,
 
             @ApiParam(value = "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC")
-            @RequestHeader(value = "x-fapi-customer-last-logged-time", required = false)
-            @DateTimeFormat(pattern = ApiConstants.HTTP_DATE_FORMAT) DateTime xFapiCustomerLastLoggedTime,
+            @RequestHeader(value = "x-fapi-auth-date", required = false)
+            @DateTimeFormat(pattern = ApiConstants.HTTP_DATE_FORMAT) DateTime xFapiAuthDate,
 
             @ApiParam(value = "The PSU's IP address if the PSU is currently logged in with the TPP.")
             @RequestHeader(value = "x-fapi-customer-ip-address", required = false) String xFapiCustomerIpAddress,

--- a/secure-api-gateway-ob-uk-rs-obie-api/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/obie/api/payment/v3_1/internationalscheduledpayments/InternationalScheduledPaymentsApi.java
+++ b/secure-api-gateway-ob-uk-rs-obie-api/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/obie/api/payment/v3_1/internationalscheduledpayments/InternationalScheduledPaymentsApi.java
@@ -81,8 +81,8 @@ public interface InternationalScheduledPaymentsApi {
             @RequestHeader(value = "x-ob-account-id", required = true) String xAccountId,
 
             @ApiParam(value = "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC")
-            @RequestHeader(value = "x-fapi-customer-last-logged-time", required = false)
-            @DateTimeFormat(pattern = ApiConstants.HTTP_DATE_FORMAT) DateTime xFapiCustomerLastLoggedTime,
+            @RequestHeader(value = "x-fapi-auth-date", required = false)
+            @DateTimeFormat(pattern = ApiConstants.HTTP_DATE_FORMAT) DateTime xFapiAuthDate,
 
             @ApiParam(value = "The PSU's IP address if the PSU is currently logged in with the TPP.")
             @RequestHeader(value = "x-fapi-customer-ip-address", required = false) String xFapiCustomerIpAddress,
@@ -126,8 +126,8 @@ public interface InternationalScheduledPaymentsApi {
             @RequestHeader(value = "Authorization", required = true) String authorization,
 
             @ApiParam(value = "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC")
-            @RequestHeader(value = "x-fapi-customer-last-logged-time", required = false)
-            @DateTimeFormat(pattern = ApiConstants.HTTP_DATE_FORMAT) DateTime xFapiCustomerLastLoggedTime,
+            @RequestHeader(value = "x-fapi-auth-date", required = false)
+            @DateTimeFormat(pattern = ApiConstants.HTTP_DATE_FORMAT) DateTime xFapiAuthDate,
 
             @ApiParam(value = "The PSU's IP address if the PSU is currently logged in with the TPP.")
             @RequestHeader(value = "x-fapi-customer-ip-address", required = false) String xFapiCustomerIpAddress,

--- a/secure-api-gateway-ob-uk-rs-obie-api/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/obie/api/payment/v3_1/internationalstandingorders/InternationalStandingOrdersApi.java
+++ b/secure-api-gateway-ob-uk-rs-obie-api/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/obie/api/payment/v3_1/internationalstandingorders/InternationalStandingOrdersApi.java
@@ -83,8 +83,8 @@ public interface InternationalStandingOrdersApi {
             @RequestHeader(value = "x-ob-account-id", required = true) String xAccountId,
 
             @ApiParam(value = "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC")
-            @RequestHeader(value = "x-fapi-customer-last-logged-time", required = false)
-            @DateTimeFormat(pattern = ApiConstants.HTTP_DATE_FORMAT) DateTime xFapiCustomerLastLoggedTime,
+            @RequestHeader(value = "x-fapi-auth-date", required = false)
+            @DateTimeFormat(pattern = ApiConstants.HTTP_DATE_FORMAT) DateTime xFapiAuthDate,
 
             @ApiParam(value = "The PSU's IP address if the PSU is currently logged in with the TPP.")
             @RequestHeader(value = "x-fapi-customer-ip-address", required = false) String xFapiCustomerIpAddress,
@@ -128,8 +128,8 @@ public interface InternationalStandingOrdersApi {
             @RequestHeader(value = "Authorization", required = true) String authorization,
 
             @ApiParam(value = "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC")
-            @RequestHeader(value = "x-fapi-customer-last-logged-time", required = false)
-            @DateTimeFormat(pattern = ApiConstants.HTTP_DATE_FORMAT) DateTime xFapiCustomerLastLoggedTime,
+            @RequestHeader(value = "x-fapi-auth-date", required = false)
+            @DateTimeFormat(pattern = ApiConstants.HTTP_DATE_FORMAT) DateTime xFapiAuthDate,
 
             @ApiParam(value = "The PSU's IP address if the PSU is currently logged in with the TPP.")
             @RequestHeader(value = "x-fapi-customer-ip-address", required = false) String xFapiCustomerIpAddress,

--- a/secure-api-gateway-ob-uk-rs-obie-api/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/obie/api/payment/v3_1_1/domesticstandingorders/DomesticStandingOrdersApi.java
+++ b/secure-api-gateway-ob-uk-rs-obie-api/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/obie/api/payment/v3_1_1/domesticstandingorders/DomesticStandingOrdersApi.java
@@ -81,8 +81,8 @@ public interface DomesticStandingOrdersApi {
             @RequestHeader(value = "x-ob-account-id", required = true) String xAccountId,
 
             @ApiParam(value = "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC")
-            @RequestHeader(value = "x-fapi-customer-last-logged-time", required = false)
-            @DateTimeFormat(pattern = ApiConstants.HTTP_DATE_FORMAT) DateTime xFapiCustomerLastLoggedTime,
+            @RequestHeader(value = "x-fapi-auth-date", required = false)
+            @DateTimeFormat(pattern = ApiConstants.HTTP_DATE_FORMAT) DateTime xFapiAuthDate,
 
             @ApiParam(value = "The PSU's IP address if the PSU is currently logged in with the TPP.")
             @RequestHeader(value = "x-fapi-customer-ip-address", required = false) String xFapiCustomerIpAddress,
@@ -126,8 +126,8 @@ public interface DomesticStandingOrdersApi {
             @RequestHeader(value = "Authorization", required = true) String authorization,
 
             @ApiParam(value = "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC")
-            @RequestHeader(value = "x-fapi-customer-last-logged-time", required = false)
-            @DateTimeFormat(pattern = ApiConstants.HTTP_DATE_FORMAT) DateTime xFapiCustomerLastLoggedTime,
+            @RequestHeader(value = "x-fapi-auth-date", required = false)
+            @DateTimeFormat(pattern = ApiConstants.HTTP_DATE_FORMAT) DateTime xFapiAuthDate,
 
             @ApiParam(value = "The PSU's IP address if the PSU is currently logged in with the TPP.")
             @RequestHeader(value = "x-fapi-customer-ip-address", required = false) String xFapiCustomerIpAddress,

--- a/secure-api-gateway-ob-uk-rs-obie-api/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/obie/api/payment/v3_1_1/internationalstandingorders/InternationalStandingOrdersApi.java
+++ b/secure-api-gateway-ob-uk-rs-obie-api/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/obie/api/payment/v3_1_1/internationalstandingorders/InternationalStandingOrdersApi.java
@@ -79,8 +79,8 @@ public interface InternationalStandingOrdersApi {
             @RequestHeader(value = "x-ob-account-id", required = true) String xAccountId,
 
             @ApiParam(value = "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC")
-            @RequestHeader(value = "x-fapi-customer-last-logged-time", required = false)
-            @DateTimeFormat(pattern = ApiConstants.HTTP_DATE_FORMAT) DateTime xFapiCustomerLastLoggedTime,
+            @RequestHeader(value = "x-fapi-auth-date", required = false)
+            @DateTimeFormat(pattern = ApiConstants.HTTP_DATE_FORMAT) DateTime xFapiAuthDate,
 
             @ApiParam(value = "The PSU's IP address if the PSU is currently logged in with the TPP.")
             @RequestHeader(value = "x-fapi-customer-ip-address", required = false) String xFapiCustomerIpAddress,
@@ -124,8 +124,8 @@ public interface InternationalStandingOrdersApi {
             @RequestHeader(value = "Authorization", required = true) String authorization,
 
             @ApiParam(value = "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC")
-            @RequestHeader(value = "x-fapi-customer-last-logged-time", required = false)
-            @DateTimeFormat(pattern = ApiConstants.HTTP_DATE_FORMAT) DateTime xFapiCustomerLastLoggedTime,
+            @RequestHeader(value = "x-fapi-auth-date", required = false)
+            @DateTimeFormat(pattern = ApiConstants.HTTP_DATE_FORMAT) DateTime xFapiAuthDate,
 
             @ApiParam(value = "The PSU's IP address if the PSU is currently logged in with the TPP.")
             @RequestHeader(value = "x-fapi-customer-ip-address", required = false) String xFapiCustomerIpAddress,


### PR DESCRIPTION
Issue: https://github.com/SecureApiGateway/SecureApiGateway/issues/485 
Description: RS Backend FAPI compliance alignment
- Replaced references of `x-fapi-customer-last-logged-time` with `x-fapi-auth-date`
- References of `x-fapi-financial-id` have been previously removed. See [#817](https://github.com/SecureApiGateway/SecureApiGateway/issues/817)