### PR TITLE
969: Update chart version to prepare release 1.0.1

### DIFF
--- a/_infra/helm/securebanking-openbanking-uk-rs/Chart.yaml
+++ b/_infra/helm/securebanking-openbanking-uk-rs/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: test-facility-bank
 description: Test facility bank service Helm chart for Kubernetes
 type: application
-version: 1.0.0
-appVersion: 1.0.0
+version: 1.0.1
+appVersion: 1.0.1


### PR DESCRIPTION
- Updated chart 1.0.0 to 1.0.1
- Prepare to build the release 1.0.1 Issue: https://github.com/SecureApiGateway/SecureApiGateway/issues/969