### PR TITLE
983: Fixing bug in DomesticVrpValidationService preventing VRPs from being submitted due to incorrect MaxIndividualAmount validation being applied

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
     </parent>
 
     <properties>
-        <uk.bom.version>1.0.2</uk.bom.version>
+        <uk.bom.version>1.0.3-SNAPSHOT</uk.bom.version>
     </properties>
 
     <dependencyManagement>

--- a/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/services/validation/DomesticVrpValidationService.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/services/validation/DomesticVrpValidationService.java
@@ -41,6 +41,7 @@ public class DomesticVrpValidationService {
 
     private static final String INSTRUCTED_AMOUNT_FIELD = "InstructedAmount";
     private static final String MAX_INDIVIDUAL_AMOUNT_FIELD = "MaximumIndividualAmount";
+
     private OBRisk1Validator riskValidator;
 
     /**

--- a/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/services/validation/DomesticVrpValidationService.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/services/validation/DomesticVrpValidationService.java
@@ -32,12 +32,15 @@ import uk.org.openbanking.datamodel.vrp.OBDomesticVRPInitiation;
 import static com.forgerock.sapi.gateway.ob.uk.common.datamodel.converter.common.FRRiskConverter.toOBRisk1;
 import static com.forgerock.sapi.gateway.ob.uk.common.datamodel.converter.vrp.FRDomesticVrpConverters.toOBDomesticVRPInitiation;
 
+import java.math.BigDecimal;
+
 
 @Service
 @Slf4j
 public class DomesticVrpValidationService {
 
-    private static final String MAX_INDIVIDUAL_AMOUNT = "MaximumIndividualAmount";
+    private static final String INSTRUCTED_AMOUNT_FIELD = "InstructedAmount";
+    private static final String MAX_INDIVIDUAL_AMOUNT_FIELD = "MaximumIndividualAmount";
     private OBRisk1Validator riskValidator;
 
     /**
@@ -148,16 +151,29 @@ public class DomesticVrpValidationService {
         validateMaximumIndividualAmount(instruction, controlParameters);
     }
 
-    private void validateMaximumIndividualAmount(FRDomesticVrpInstruction instruction, OBDomesticVRPControlParameters controlParameters) throws OBErrorException {
-        String instructionAmount = instruction.getInstructedAmount().getAmount();
-        String instructionCurrency = instruction.getInstructedAmount().getCurrency();
+    /**
+     * Validates that payment InstructionAmount is less than or equal to the MaxIndividualAmount controlParameter
+     * and that the currency of both amounts is the same.
+     *
+     * @param paymentInstruction FRDomesticVrpInstruction to validate
+     * @param controlParameters OBDomesticVRPControlParameters from the consent to validate against
+     * @throws OBErrorException if the paymentInstruction breaches the maxIndividualAmount
+     */
+    void validateMaximumIndividualAmount(FRDomesticVrpInstruction paymentInstruction, OBDomesticVRPControlParameters controlParameters) throws OBErrorException {
+        final BigDecimal instructionAmount = new BigDecimal(paymentInstruction.getInstructedAmount().getAmount());
+        final BigDecimal consentAmount = new BigDecimal(controlParameters.getMaximumIndividualAmount().getAmount());
 
-        Double consentAmount = Double.valueOf(controlParameters.getMaximumIndividualAmount().getAmount());
-        String consentCurrency = controlParameters.getMaximumIndividualAmount().getCurrency();
-        if (!(Double.valueOf(instructionAmount).compareTo(consentAmount) == 0) || !(instructionCurrency.compareTo(consentCurrency) == 0)) {
-            throw new OBErrorException(
-                    OBRIErrorType.REQUEST_VRP_CONTROL_PARAMETERS_RULES,
-                    MAX_INDIVIDUAL_AMOUNT, MAX_INDIVIDUAL_AMOUNT);
+        // InstructionAmount must be less than or equal to the MaximumIndividualAmount consented to
+        if (instructionAmount.compareTo(consentAmount) == 1) {
+            throw new OBErrorException(OBRIErrorType.REQUEST_VRP_CONTROL_PARAMETERS_RULES,
+                                       INSTRUCTED_AMOUNT_FIELD, MAX_INDIVIDUAL_AMOUNT_FIELD);
+        }
+
+        final String consentCurrency = controlParameters.getMaximumIndividualAmount().getCurrency();
+        final String instructionCurrency = paymentInstruction.getInstructedAmount().getCurrency();
+        if (!consentCurrency.equals(instructionCurrency)) {
+            throw new OBErrorException(OBRIErrorType.REQUEST_VRP_CONTROL_PARAMETER_CURRENCY_MISMATCH,
+                    INSTRUCTED_AMOUNT_FIELD, MAX_INDIVIDUAL_AMOUNT_FIELD);
         }
     }
 

--- a/secure-api-gateway-ob-uk-rs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/services/validation/DomesticVrpValidationServiceTest.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/services/validation/DomesticVrpValidationServiceTest.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.ob.uk.rs.server.api.obie.payment.services.validation;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+import com.forgerock.sapi.gateway.ob.uk.common.datamodel.common.FRAmount;
+import com.forgerock.sapi.gateway.ob.uk.common.datamodel.vrp.FRDomesticVrpInstruction;
+import com.forgerock.sapi.gateway.ob.uk.common.datamodel.vrp.FRDomesticVrpInstruction.FRDomesticVrpInstructionBuilder;
+import com.forgerock.sapi.gateway.ob.uk.common.error.OBErrorException;
+
+import uk.org.openbanking.datamodel.common.OBActiveOrHistoricCurrencyAndAmount;
+import uk.org.openbanking.datamodel.vrp.OBDomesticVRPControlParameters;
+
+class DomesticVrpValidationServiceTest {
+
+    @Test
+    void testMaxIndividualAmountValid() throws Exception {
+        final String maxIndividualAmount = "1.01";
+        final String[] validPaymentInstructionAmounts = new String[]{
+                maxIndividualAmount,
+                "1.00",
+                "0.99",
+                "0.51",
+                "0.01"
+        };
+        final String currency = "GBP";
+        final OBDomesticVRPControlParameters vrpControlParameters = createControlParameters(maxIndividualAmount, currency);
+
+        final DomesticVrpValidationService vrpValidationService = new DomesticVrpValidationService();
+        for (String validPaymentInstructionAmount : validPaymentInstructionAmounts) {
+            final FRDomesticVrpInstructionBuilder vrpInstructionBuilder = FRDomesticVrpInstruction.builder().instructedAmount(
+                    FRAmount.builder().amount(validPaymentInstructionAmount).currency(currency).build());
+
+            // Valid - no exception thrown
+            vrpValidationService.validateMaximumIndividualAmount(vrpInstructionBuilder.build(), vrpControlParameters);
+        }
+    }
+
+    @Test
+    void testBreachMaxIndividualAmountThrowsException() {
+        final String maxIndividualAmount = "100.99";
+        final String[] validPaymentInstructionAmounts = new String[]{
+                "101.00",
+                "121212.33",
+                "3333333.99"
+        };
+        final String currency = "GBP";
+        final OBDomesticVRPControlParameters vrpControlParameters = createControlParameters(maxIndividualAmount, currency);
+
+        final DomesticVrpValidationService vrpValidationService = new DomesticVrpValidationService();
+        for (String validPaymentInstructionAmount : validPaymentInstructionAmounts) {
+            final FRDomesticVrpInstructionBuilder vrpInstructionBuilder = FRDomesticVrpInstruction.builder().instructedAmount(
+                    FRAmount.builder().amount(validPaymentInstructionAmount).currency(currency).build());
+
+            final OBErrorException obErrorException = assertThrows(OBErrorException.class,
+                    () -> vrpValidationService.validateMaximumIndividualAmount(vrpInstructionBuilder.build(), vrpControlParameters));
+            assertEquals("The field 'InstructedAmount' breaches a limitation set by 'MaximumIndividualAmount'",
+                         obErrorException.getMessage());
+        }
+    }
+
+    @Test
+    void testMaxIndividualAmountCurrencyMismatchThrowsException() {
+        final String maxIndividualAmount = "100.99";
+        final OBDomesticVRPControlParameters vrpControlParameters = createControlParameters(maxIndividualAmount, "GBP");
+
+        final DomesticVrpValidationService vrpValidationService = new DomesticVrpValidationService();
+        final FRDomesticVrpInstructionBuilder vrpInstructionBuilder = FRDomesticVrpInstruction.builder().instructedAmount(
+                FRAmount.builder().amount(maxIndividualAmount).currency("EUR").build());
+
+        final OBErrorException obErrorException = assertThrows(OBErrorException.class,
+                () -> vrpValidationService.validateMaximumIndividualAmount(vrpInstructionBuilder.build(), vrpControlParameters));
+        assertEquals("The currency of field 'InstructedAmount' must match the currency of consent control parameter field 'MaximumIndividualAmount'",
+                     obErrorException.getMessage());
+    }
+
+    private static OBDomesticVRPControlParameters createControlParameters(String maxIndividualAmount, String currency) {
+        final OBDomesticVRPControlParameters vrpControlParameters = new OBDomesticVRPControlParameters();
+        final OBActiveOrHistoricCurrencyAndAmount maximumIndividualAmount = new OBActiveOrHistoricCurrencyAndAmount();
+        maximumIndividualAmount.setCurrency(currency);
+        maximumIndividualAmount.amount(maxIndividualAmount);
+        vrpControlParameters.setMaximumIndividualAmount(maximumIndividualAmount);
+        return vrpControlParameters;
+    }
+}

--- a/secure-api-gateway-ob-uk-rs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/services/validation/DomesticVrpValidationServiceTest.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/services/validation/DomesticVrpValidationServiceTest.java
@@ -56,7 +56,7 @@ class DomesticVrpValidationServiceTest {
     @Test
     void testBreachMaxIndividualAmountThrowsException() {
         final String maxIndividualAmount = "100.99";
-        final String[] validPaymentInstructionAmounts = new String[]{
+        final String[] invalidPaymentInstructionAmounts = new String[]{
                 "101.00",
                 "121212.33",
                 "3333333.99"
@@ -65,9 +65,9 @@ class DomesticVrpValidationServiceTest {
         final OBDomesticVRPControlParameters vrpControlParameters = createControlParameters(maxIndividualAmount, currency);
 
         final DomesticVrpValidationService vrpValidationService = new DomesticVrpValidationService();
-        for (String validPaymentInstructionAmount : validPaymentInstructionAmounts) {
+        for (String invalidAmount : invalidPaymentInstructionAmounts) {
             final FRDomesticVrpInstructionBuilder vrpInstructionBuilder = FRDomesticVrpInstruction.builder().instructedAmount(
-                    FRAmount.builder().amount(validPaymentInstructionAmount).currency(currency).build());
+                    FRAmount.builder().amount(invalidAmount).currency(currency).build());
 
             final OBErrorException obErrorException = assertThrows(OBErrorException.class,
                     () -> vrpValidationService.validateMaximumIndividualAmount(vrpInstructionBuilder.build(), vrpControlParameters));


### PR DESCRIPTION
The bug was enforcing that the payment InstructedAmount matched the MaximumIndividualAmount control param.

Fixed to validate that InstructedAmount <= MaximumIndividualAmount.

Added unit tests and improved error message for currency validation.

Updated uk.bom.version to 1.0.3-SNAPSHOT to pickup new error code.

https://github.com/SecureApiGateway/SecureApiGateway/issues/983