### PR TITLE
980: Generating an Indicative FX rate for InternationalPaymentConsents which omit the ExchangeRateInformation

### DIFF
--- a/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/backoffice/payment/calculation/InternationalPaymentConsentResponseCalculation.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/backoffice/payment/calculation/InternationalPaymentConsentResponseCalculation.java
@@ -127,7 +127,6 @@ public class InternationalPaymentConsentResponseCalculation extends PaymentConse
                                     .amount(getDefaultAmount())
                     );
 
-            // exchange Rate Information is not mandatory and can be null, in that case we not need to calculate any data
             if (Objects.nonNull(((OBWriteInternationalConsent5) consentRequest).getData().getInitiation().getExchangeRateInformation())) {
                 OBExchangeRateType2Code rateType = ((OBWriteInternationalConsentResponse4) consentResponse).getData().getInitiation().getExchangeRateInformation().getRateType();
                 switch (rateType) {
@@ -182,7 +181,6 @@ public class InternationalPaymentConsentResponseCalculation extends PaymentConse
                                     .amount(getDefaultAmount())
                     );
 
-            // exchange Rate Information is not mandatory and can be null, in that case we not need to calculate any data
             if (Objects.nonNull(((OBWriteInternationalConsent5) consentRequest).getData().getInitiation().getExchangeRateInformation())) {
                 OBExchangeRateType2Code rateType = ((OBWriteInternationalConsentResponse5) consentResponse).getData().getInitiation().getExchangeRateInformation().getRateType();
                 switch (rateType) {
@@ -237,7 +235,6 @@ public class InternationalPaymentConsentResponseCalculation extends PaymentConse
                                     .amount(getDefaultAmount())
                     );
 
-            // exchange Rate Information is not mandatory and can be null, in that case we not need to calculate any data
             if (Objects.nonNull(((OBWriteInternationalConsent5) consentRequest).getData().getInitiation().getExchangeRateInformation())) {
                 OBExchangeRateType2Code rateType = ((OBWriteInternationalConsentResponse6) consentResponse).getData().getInitiation().getExchangeRateInformation().getRateType();
                 switch (rateType) {

--- a/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/backoffice/payment/calculation/InternationalPaymentConsentResponseCalculation.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/backoffice/payment/calculation/InternationalPaymentConsentResponseCalculation.java
@@ -73,7 +73,6 @@ public class InternationalPaymentConsentResponseCalculation extends PaymentConse
                                     .amount(getDefaultAmount())
                     );
 
-            // exchange Rate Information is not mandatory and can be null, in that case we not need to calculate any data
             if (Objects.nonNull(((OBWriteInternationalConsent5) consentRequest).getData().getInitiation().getExchangeRateInformation())) {
                 OBExchangeRateType2Code rateType = ((OBWriteInternationalConsentResponse3) consentResponse).getData().getInitiation().getExchangeRateInformation().getRateType();
                 switch (rateType) {
@@ -108,6 +107,14 @@ public class InternationalPaymentConsentResponseCalculation extends PaymentConse
                             String.format("The rate type %s provided isn't valid", rateType)
                     ));
                 }
+            } else {
+                // TPP did not supply ExchangeRateInformation in the request, generate an indicative quote using the InstructedAmount.currency as the UnitCurrency
+                ((OBWriteInternationalConsentResponse3) consentResponse).getData().setExchangeRateInformation(
+                        new OBWriteInternationalConsentResponse3DataExchangeRateInformation()
+                                .exchangeRate(EXCHANGE_RATE)
+                                .rateType(OBExchangeRateType2Code.INDICATIVE)
+                                .unitCurrency(((OBWriteInternationalConsentResponse3) consentResponse).getData().getInitiation().getInstructedAmount().getCurrency()));
+
             }
         } else if (consentResponse instanceof OBWriteInternationalConsentResponse4) {
             log.debug("OBWriteInternationalConsentResponse4 instance");
@@ -155,6 +162,14 @@ public class InternationalPaymentConsentResponseCalculation extends PaymentConse
                             String.format("The rate type %s provided isn't valid", rateType)
                     ));
                 }
+            } else {
+                // TPP did not supply ExchangeRateInformation in the request, generate an indicative quote using the InstructedAmount.currency as the UnitCurrency
+                ((OBWriteInternationalConsentResponse4) consentResponse).getData().setExchangeRateInformation(
+                        new OBWriteInternationalConsentResponse4DataExchangeRateInformation()
+                                .exchangeRate(EXCHANGE_RATE)
+                                .rateType(OBExchangeRateType2Code.INDICATIVE)
+                                .unitCurrency(((OBWriteInternationalConsentResponse4) consentResponse).getData().getInitiation().getInstructedAmount().getCurrency()));
+
             }
         } else if (consentResponse instanceof OBWriteInternationalConsentResponse5) {
             log.debug("OBWriteInternationalConsentResponse5 instance");
@@ -202,6 +217,14 @@ public class InternationalPaymentConsentResponseCalculation extends PaymentConse
                             String.format("The rate type %s provided isn't valid", rateType)
                     ));
                 }
+            } else {
+                // TPP did not supply ExchangeRateInformation in the request, generate an indicative quote using the InstructedAmount.currency as the UnitCurrency
+                ((OBWriteInternationalConsentResponse5) consentResponse).getData().setExchangeRateInformation(
+                        new OBWriteInternationalConsentResponse5DataExchangeRateInformation()
+                                .exchangeRate(EXCHANGE_RATE)
+                                .rateType(OBExchangeRateType2Code.INDICATIVE)
+                                .unitCurrency(((OBWriteInternationalConsentResponse5) consentResponse).getData().getInitiation().getInstructedAmount().getCurrency()));
+
             }
         } else {
             log.debug("OBWriteInternationalConsentResponse6 instance");
@@ -249,6 +272,14 @@ public class InternationalPaymentConsentResponseCalculation extends PaymentConse
                             String.format("The rate type %s provided isn't valid", rateType)
                     ));
                 }
+            } else {
+                // TPP did not supply ExchangeRateInformation in the request, generate an indicative quote using the InstructedAmount.currency as the UnitCurrency
+                ((OBWriteInternationalConsentResponse6) consentResponse).getData().setExchangeRateInformation(
+                        new OBWriteInternationalConsentResponse6DataExchangeRateInformation()
+                                .exchangeRate(EXCHANGE_RATE)
+                                .rateType(OBExchangeRateType2Code.INDICATIVE)
+                                .unitCurrency(((OBWriteInternationalConsentResponse6) consentResponse).getData().getInitiation().getInstructedAmount().getCurrency()));
+
             }
         }
 

--- a/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/backoffice/payment/calculation/InternationalScheduledPaymentConsentResponseCalculation.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/backoffice/payment/calculation/InternationalScheduledPaymentConsentResponseCalculation.java
@@ -73,7 +73,6 @@ public class InternationalScheduledPaymentConsentResponseCalculation extends Pay
                                     .amount(getDefaultAmount())
                     );
 
-            // exchange Rate Information is not mandatory and can be null, in that case we not need to calculate any data
             if (Objects.nonNull(((OBWriteInternationalScheduledConsent5) consentRequest).getData().getInitiation().getExchangeRateInformation())) {
                 OBExchangeRateType2Code rateType = ((OBWriteInternationalScheduledConsentResponse3) consentResponse).getData().getInitiation().getExchangeRateInformation().getRateType();
                 switch (rateType) {
@@ -108,6 +107,13 @@ public class InternationalScheduledPaymentConsentResponseCalculation extends Pay
                             String.format("The rate type %s provided isn't valid", rateType)
                     ));
                 }
+            } else {
+                // TPP did not supply ExchangeRateInformation in the request, generate an indicative quote using the InstructedAmount.currency as the UnitCurrency
+                ((OBWriteInternationalScheduledConsentResponse3) consentResponse).getData().setExchangeRateInformation(
+                        new OBWriteInternationalConsentResponse3DataExchangeRateInformation()
+                                .exchangeRate(EXCHANGE_RATE)
+                                .rateType(OBExchangeRateType2Code.INDICATIVE)
+                                .unitCurrency(((OBWriteInternationalScheduledConsentResponse3) consentResponse).getData().getInitiation().getInstructedAmount().getCurrency()));
             }
         } else if (consentResponse instanceof OBWriteInternationalScheduledConsentResponse4) {
             log.debug("OBWriteInternationalScheduledConsentResponse4 instance");
@@ -120,7 +126,6 @@ public class InternationalScheduledPaymentConsentResponseCalculation extends Pay
                                     .amount(getDefaultAmount())
                     );
 
-            // exchange Rate Information is not mandatory and can be null, in that case we not need to calculate any data
             if (Objects.nonNull(((OBWriteInternationalScheduledConsent5) consentRequest).getData().getInitiation().getExchangeRateInformation())) {
                 OBExchangeRateType2Code rateType = ((OBWriteInternationalScheduledConsentResponse4) consentResponse).getData().getInitiation().getExchangeRateInformation().getRateType();
                 switch (rateType) {
@@ -155,6 +160,13 @@ public class InternationalScheduledPaymentConsentResponseCalculation extends Pay
                             String.format("The rate type %s provided isn't valid", rateType)
                     ));
                 }
+            } else {
+                // TPP did not supply ExchangeRateInformation in the request, generate an indicative quote using the InstructedAmount.currency as the UnitCurrency
+                ((OBWriteInternationalScheduledConsentResponse4) consentResponse).getData().setExchangeRateInformation(
+                        new OBWriteInternationalConsentResponse4DataExchangeRateInformation()
+                                .exchangeRate(EXCHANGE_RATE)
+                                .rateType(OBExchangeRateType2Code.INDICATIVE)
+                                .unitCurrency(((OBWriteInternationalScheduledConsentResponse4) consentResponse).getData().getInitiation().getInstructedAmount().getCurrency()));
             }
         } else if (consentResponse instanceof OBWriteInternationalScheduledConsentResponse5) {
             log.debug("OBWriteInternationalScheduledConsentResponse5 instance");
@@ -167,7 +179,6 @@ public class InternationalScheduledPaymentConsentResponseCalculation extends Pay
                                     .amount(getDefaultAmount())
                     );
 
-            // exchange Rate Information is not mandatory and can be null, in that case we not need to calculate any data
             if (Objects.nonNull(((OBWriteInternationalScheduledConsent5) consentRequest).getData().getInitiation().getExchangeRateInformation())) {
                 OBExchangeRateType2Code rateType = ((OBWriteInternationalScheduledConsentResponse5) consentResponse).getData().getInitiation().getExchangeRateInformation().getRateType();
                 switch (rateType) {
@@ -202,6 +213,13 @@ public class InternationalScheduledPaymentConsentResponseCalculation extends Pay
                             String.format("The rate type %s provided isn't valid", rateType)
                     ));
                 }
+            } else {
+                // TPP did not supply ExchangeRateInformation in the request, generate an indicative quote using the InstructedAmount.currency as the UnitCurrency
+                ((OBWriteInternationalScheduledConsentResponse5) consentResponse).getData().setExchangeRateInformation(
+                        new OBWriteInternationalConsentResponse5DataExchangeRateInformation()
+                                .exchangeRate(EXCHANGE_RATE)
+                                .rateType(OBExchangeRateType2Code.INDICATIVE)
+                                .unitCurrency(((OBWriteInternationalScheduledConsentResponse5) consentResponse).getData().getInitiation().getInstructedAmount().getCurrency()));
             }
         } else {
             log.debug("OBWriteInternationalScheduledConsentResponse6 instance");
@@ -214,7 +232,6 @@ public class InternationalScheduledPaymentConsentResponseCalculation extends Pay
                                     .amount(getDefaultAmount())
                     );
 
-            // exchange Rate Information is not mandatory and can be null, in that case we not need to calculate any data
             if (Objects.nonNull(((OBWriteInternationalScheduledConsent5) consentRequest).getData().getInitiation().getExchangeRateInformation())) {
                 OBExchangeRateType2Code rateType = ((OBWriteInternationalScheduledConsentResponse6) consentResponse).getData().getInitiation().getExchangeRateInformation().getRateType();
                 switch (rateType) {
@@ -249,6 +266,13 @@ public class InternationalScheduledPaymentConsentResponseCalculation extends Pay
                             String.format("The rate type %s provided isn't valid", rateType)
                     ));
                 }
+            } else {
+                // TPP did not supply ExchangeRateInformation in the request, generate an indicative quote using the InstructedAmount.currency as the UnitCurrency
+                ((OBWriteInternationalScheduledConsentResponse6) consentResponse).getData().setExchangeRateInformation(
+                        new OBWriteInternationalConsentResponse6DataExchangeRateInformation()
+                                .exchangeRate(EXCHANGE_RATE)
+                                .rateType(OBExchangeRateType2Code.INDICATIVE)
+                                .unitCurrency(((OBWriteInternationalScheduledConsentResponse6) consentResponse).getData().getInitiation().getInstructedAmount().getCurrency()));
             }
         }
         return consentResponse;


### PR DESCRIPTION
ExchangeRateInformation field is optional, if it is not supplied then the bank will generate an ExchangeRateInformation in the response.

The generated data will use an Indicative RateType and use the consent's InstructedAmount.currency as the UnitCurrency.

Note: we are not making any changes to the consent request object, so will not be reintroducing the bug which caused payment validation to fail due to initiation data mismatch (fixed in PR: https://github.com/SecureApiGateway/secure-api-gateway-ob-uk-rs/pull/172). 

Functional tests have been improved to verify the behaviour, see this PR: https://github.com/SecureApiGateway/secure-api-gateway-ob-uk-functional-tests/pull/125

https://github.com/SecureApiGateway/SecureApiGateway/issues/980