### PR TITLE
578: Enabling Java Bean validation

### DIFF
--- a/secure-api-gateway-ob-uk-rs-server/pom.xml
+++ b/secure-api-gateway-ob-uk-rs-server/pom.xml
@@ -88,6 +88,10 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-data-mongodb</artifactId>
         </dependency>
         <dependency>

--- a/secure-api-gateway-ob-uk-rs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/backoffice/payment/CalculateResponseElementsControllerTest.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/backoffice/payment/CalculateResponseElementsControllerTest.java
@@ -54,7 +54,7 @@ public class CalculateResponseElementsControllerTest {
 
     private static final HttpHeaders HTTP_HEADERS = HttpHeadersTestDataFactory.requiredBackofficeHttpHeaders();
     private static final String BASE_URL = "http://localhost:";
-    private static final String INVALID_CURRENCY = "Invalid currency";
+    private static final String INVALID_CURRENCY = "XYZ";
     private static final String REST_CONTEXT = "/backoffice/{0}/{1}/calculate-elements";
 
     private static final String PDC_CONTEXT = "domestic-payment-consents";
@@ -462,13 +462,10 @@ public class CalculateResponseElementsControllerTest {
 
         // Then
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
-        assertThat(response.getBody().getCode()).isEqualTo(OBRIErrorResponseCategory.REQUEST_INVALID.getId());
-        assertThat(response.getBody().getMessage()).isEqualTo(OBRIErrorResponseCategory.REQUEST_INVALID.getDescription());
+        assertThat(response.getBody().getCode()).isEqualTo(OBRIErrorResponseCategory.ARGUMENT_INVALID.getId());
+        assertThat(response.getBody().getMessage()).isEqualTo(OBRIErrorResponseCategory.ARGUMENT_INVALID.getDescription());
         assertThat(response.getBody().getErrors()).containsExactly(
-                OBRIErrorType.DATA_INVALID_REQUEST.toOBError1(
-                        String.format("'%s' cannot be null to be validate", "InstructedAmount")
-                )
-        );
+                OBRIErrorType.REQUEST_FIELD_INVALID.toOBError1("must not be null").path("data.initiation.instructedAmount"));
     }
 
     @Test
@@ -570,13 +567,10 @@ public class CalculateResponseElementsControllerTest {
 
         // Then
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
-        assertThat(response.getBody().getCode()).isEqualTo(OBRIErrorResponseCategory.REQUEST_INVALID.getId());
-        assertThat(response.getBody().getMessage()).isEqualTo(OBRIErrorResponseCategory.REQUEST_INVALID.getDescription());
+        assertThat(response.getBody().getCode()).isEqualTo(OBRIErrorResponseCategory.ARGUMENT_INVALID.getId());
+        assertThat(response.getBody().getMessage()).isEqualTo(OBRIErrorResponseCategory.ARGUMENT_INVALID.getDescription());
         assertThat(response.getBody().getErrors()).containsExactly(
-                OBRIErrorType.DATA_INVALID_REQUEST.toOBError1(
-                        String.format("'%s' cannot be null to be validate", "RateType")
-                )
-        );
+                OBRIErrorType.REQUEST_FIELD_INVALID.toOBError1("must not be null").path("data.initiation.exchangeRateInformation.rateType"));
     }
 
     @Test
@@ -593,13 +587,10 @@ public class CalculateResponseElementsControllerTest {
 
         // Then
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
-        assertThat(response.getBody().getCode()).isEqualTo(OBRIErrorResponseCategory.REQUEST_INVALID.getId());
-        assertThat(response.getBody().getMessage()).isEqualTo(OBRIErrorResponseCategory.REQUEST_INVALID.getDescription());
+        assertThat(response.getBody().getCode()).isEqualTo(OBRIErrorResponseCategory.ARGUMENT_INVALID.getId());
+        assertThat(response.getBody().getMessage()).isEqualTo(OBRIErrorResponseCategory.ARGUMENT_INVALID.getDescription());
         assertThat(response.getBody().getErrors()).containsExactly(
-                OBRIErrorType.DATA_INVALID_REQUEST.toOBError1(
-                        String.format("'%s' cannot be null to be validate", "UnitCurrency")
-                )
-        );
+                OBRIErrorType.REQUEST_FIELD_INVALID.toOBError1("must not be null").path("data.initiation.exchangeRateInformation.unitCurrency"));
     }
 
     @Test


### PR DESCRIPTION
Adding spring-boot-starter-validation dependency to rs-server pom. This change enables Java Bean validation, this means that all validation constraints defined in the OBIE schema will automatically be applied to request objects.

Fixing CalculateResponseElementsControllerTest assertions to validate error responses caused by bean validation.

Adding test to VRP controller to verify that bean validation is enabled by submitting an empty request body and checking that the error response indicates which fields need to be supplied.

https://github.com/SecureApiGateway/SecureApiGateway/issues/578