### PR TITLE
991: Creating Spring Boot module for java module secure-api-gateway-ob-uk-rs-cloud-client

### DIFF
--- a/secure-api-gateway-ob-uk-rs-cloud-client/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/cloud/client/CloudClientModuleConfiguration.java
+++ b/secure-api-gateway-ob-uk-rs-cloud-client/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/cloud/client/CloudClientModuleConfiguration.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.ob.uk.rs.cloud.client;
+
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Spring Boot configuration for the Cloud Client Module.
+ */
+@Configuration
+@ComponentScan(basePackageClasses = CloudClientModuleConfiguration.class)
+public class CloudClientModuleConfiguration {
+}

--- a/secure-api-gateway-ob-uk-rs-cloud-client/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/cloud/client/services/CloudPlatformClientService.java
+++ b/secure-api-gateway-ob-uk-rs-cloud-client/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/cloud/client/services/CloudPlatformClientService.java
@@ -41,8 +41,7 @@ import static org.springframework.http.MediaType.APPLICATION_JSON;
  */
 @Service
 @Slf4j
-@ComponentScan(basePackages = {"com.forgerock.sapi.gateway.ob.uk.rs.cloud.client.configuration"})
-class CloudPlatformClientService implements PlatformClient {
+public class CloudPlatformClientService implements PlatformClient {
 
     private static final String IDM_RESPOND_OB_INTENT_OBJECT_FIELD = "OBIntentObject";
     private final RestTemplate restTemplate;

--- a/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/RSServerApplication.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/RSServerApplication.java
@@ -17,15 +17,13 @@ package com.forgerock.sapi.gateway.ob.uk.rs.server;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Import;
 import org.springframework.data.mongodb.repository.config.EnableMongoRepositories;
 
-@ComponentScan(basePackages =
-        {
-                "com.forgerock.sapi.gateway.ob.uk.rs"
-        }
-)
+import com.forgerock.sapi.gateway.ob.uk.rs.cloud.client.CloudClientModuleConfiguration;
+
 @SpringBootApplication
+@Import(CloudClientModuleConfiguration.class)
 @EnableMongoRepositories(basePackages = "com.forgerock.sapi.gateway.ob.uk.rs.server.persistence.repository")
 public class RSServerApplication {
 


### PR DESCRIPTION
CloudClientModuleConfiguration controls the package scan for the cloud-client module, restricting it only to the subpackages in the java module.

Updated RSServerApplication to remove the broad scan and rely on the default scan done by `@SpringBootApplication` annotation, which uses the annotated class's package as the base package.

Added an `@Import` for the cloud client module to RSServerApplication so that the new module gets loaded.

https://github.com/SecureApiGateway/SecureApiGateway/issues/991