### PR TITLE
993: Renaming the MongoDB database used by the test-facility-bank

### DIFF
--- a/secure-api-gateway-ob-uk-rs-server/src/main/resources/application.yml
+++ b/secure-api-gateway-ob-uk-rs-server/src/main/resources/application.yml
@@ -20,7 +20,7 @@
 spring:
   data:
     mongodb:
-      database: mongo
+      database: test-facility-bank
 
 management:
   endpoints:


### PR DESCRIPTION
The database name is currently mongo, which is confusing. Renaming it to test-facility-bank.

This will also make it easier to determine the purpose of the database if we have multiple databases running in the same MongoDB instance (Consent Store for example).

Auth credentials can now be created for use by the test-facility-bank service to connect to this database.

https://github.com/SecureApiGateway/SecureApiGateway/issues/993