### PR TITLE
993: Configuring Spring Data MongoDB properties

### DIFF
--- a/_infra/helm/securebanking-openbanking-uk-rs/templates/deployment.yaml
+++ b/_infra/helm/securebanking-openbanking-uk-rs/templates/deployment.yaml
@@ -54,6 +54,21 @@ spec:
           env:
           - name: SPRING_DATA_MONGODB_HOST
             value: {{ .Values.deployment.mongodb.host }}
+          - name: SPRING_DATA_MONGODB_DATABASE
+            valueFrom:
+              secretKeyRef:
+                name: openig-secrets-env
+                key: MONGODB_CONSENT_USERNAME
+          - name: SPRING_DATA_MONGODB_USERNAME
+            valueFrom:
+              secretKeyRef:
+                name: openig-secrets-env
+                key: MONGODB_CONSENT_USERNAME
+          - name: SPRING_DATA_MONGODB_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: openig-secrets-env
+                key: MONGODB_CONSENT_PASSWORD
           - name: SERVER_PORT
             value: {{ .Values.deployment.containerPort | quote }}
           - name: CONSENT_REPO_URI


### PR DESCRIPTION
Configuring the properties via environment variables supplied from a secret. The properties configure the database, username and password to use in the MongoDB connection string.

Note: we have a convention of using the same database name and username, hence both env vars using the same key.

https://github.com/SecureApiGateway/SecureApiGateway/issues/993