### PR TITLE
986: International Payments & International Scheduled Payments wrong unitCurrency validation

### DIFF
--- a/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/backoffice/payment/validation/PaymentConsentValidation.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/backoffice/payment/validation/PaymentConsentValidation.java
@@ -97,7 +97,14 @@ public abstract class PaymentConsentValidation {
         OBExchangeRateType2Code rateType = exchangeRateInformation.getRateType();
         switch (rateType) {
             case AGREED -> {
-                return;
+                // validate only mandatory fields for agreed rate type
+                if (Objects.isNull(exchangeRateInformation.getContractIdentification()) || Objects.isNull(exchangeRateInformation.getExchangeRate())) {
+                    errors.add(
+                            OBRIErrorType.DATA_INVALID_REQUEST.toOBError1(
+                                    "ExchangeRate and ContractIdentification must be specify when requesting an Agreed RateType."
+                            )
+                    );
+                }
             }
             case ACTUAL, INDICATIVE -> {
                 if (!(exchangeRateInformation.getExchangeRate() == null && exchangeRateInformation.getContractIdentification() == null)) {
@@ -133,13 +140,7 @@ public abstract class PaymentConsentValidation {
         OBExchangeRateType2Code rateType = exchangeRateInformation.getRateType();
         switch (rateType) {
             case AGREED -> {
-                if (!exchangeRateInformation.getUnitCurrency().equals(currencyOfTransfer)) {
-                    errors.add(
-                            OBRIErrorType.DATA_INVALID_REQUEST.toOBError1(
-                                    "The currency of transfer should be the same with the exchange unit currency."
-                            )
-                    );
-                }
+                return;
             }
             case ACTUAL, INDICATIVE -> {
                 if (!(exchangeRateInformation.getExchangeRate() == null && exchangeRateInformation.getContractIdentification() == null)) {

--- a/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/backoffice/payment/validation/PaymentConsentValidation.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/backoffice/payment/validation/PaymentConsentValidation.java
@@ -59,6 +59,7 @@ public abstract class PaymentConsentValidation {
 
     /**
      * Clear error event list
+     *
      * @return this
      */
     public PaymentConsentValidation clearErrors() {
@@ -96,14 +97,7 @@ public abstract class PaymentConsentValidation {
         OBExchangeRateType2Code rateType = exchangeRateInformation.getRateType();
         switch (rateType) {
             case AGREED -> {
-                // validate only mandatory fields for agreed rate type
-                if (Objects.isNull(exchangeRateInformation.getContractIdentification()) || Objects.isNull(exchangeRateInformation.getExchangeRate())) {
-                    errors.add(
-                            OBRIErrorType.DATA_INVALID_REQUEST.toOBError1(
-                                    "ExchangeRate and ContractIdentification must be specify when requesting an Agreed RateType."
-                            )
-                    );
-                }
+                return;
             }
             case ACTUAL, INDICATIVE -> {
                 if (!(exchangeRateInformation.getExchangeRate() == null && exchangeRateInformation.getContractIdentification() == null)) {

--- a/secure-api-gateway-ob-uk-rs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/backoffice/payment/CalculateResponseElementsControllerTest.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/backoffice/payment/CalculateResponseElementsControllerTest.java
@@ -618,28 +618,6 @@ public class CalculateResponseElementsControllerTest {
     }
 
     @Test
-    public void shouldFailExchangeRateInformationRateType_Agreed() throws JsonProcessingException {
-        String intent = IntentType.PAYMENT_INTERNATIONAL_CONSENT.generateIntentId();
-        OBWriteInternationalConsent5 consentRequest = aValidOBWriteInternationalConsent5();
-        consentRequest.getData().getInitiation().setCurrencyOfTransfer("EUR");
-
-        // When
-        ResponseEntity<OBErrorResponse1> response = restTemplate.exchange(
-                getUri(intent, OBVersion.v3_1_8.getCanonicalName(), PIC_CONTEXT),
-                HttpMethod.POST,
-                new HttpEntity<>(mapper.writeValueAsString(consentRequest), HTTP_HEADERS),
-                OBErrorResponse1.class);
-
-        // Then
-        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
-        assertThat(response.getBody().getCode()).isEqualTo(OBRIErrorResponseCategory.REQUEST_INVALID.getId());
-        assertThat(response.getBody().getMessage()).isEqualTo(OBRIErrorResponseCategory.REQUEST_INVALID.getDescription());
-        assertThat(response.getBody().getErrors()).containsExactly(
-                OBRIErrorType.DATA_INVALID_REQUEST.toOBError1("The currency of transfer should be the same with the exchange unit currency.")
-        );
-    }
-
-    @Test
     public void shouldFailExchangeRateInformationRateType_Actual() throws JsonProcessingException {
         String intent = IntentType.PAYMENT_INTERNATIONAL_CONSENT.generateIntentId();
         OBWriteInternationalConsent5 consentRequest = aValidOBWriteInternationalConsent5();


### PR DESCRIPTION
Issue: https://github.com/SecureApiGateway/SecureApiGateway/issues/986 
Description:
- removed the required condition for the "AGREED" rateType case since it was a wrong validation
According to the OB spec:
  - For an "Agreed" RateType a requested exchange rate is populated in the ExchangeRate field, against the UnitCurrency. I.e, if the UnitCurrency is GBP and CurrencyOfTransfer is USD, then ExchangeRate will be 1.34 (USD to 1 GBP).
  - For an "Agreed" RateType the exchange rate contract identifier is populated in the ContractIdentification field.
  - A PISP must not specify ExchangeRate and/or ContractIdentification when requesting an Actual RateType.
  - A PISP must not specify ExchangeRate and/or ContractIdentification when requesting an Indicative RateType.

  See [international payment consents notes](https://openbankinguk.github.io/read-write-api-site3/v3.1.10/resources-and-data-models/pisp/international-payment-consents.html#notes).

- also, added the "ExchangeRateInformation" object to the request body in Postman on the International Payments API since it was missing
  - OBS: The CurrencyOfTransfer is set to USD and in this case the ExchangeRate is set to 1.34 (USD to 1 GBP) according to the OB spec.