### PR TITLE
1040: prepare versions to build release 1.0.3

### DIFF
--- a/_infra/helm/securebanking-openbanking-uk-rs/Chart.yaml
+++ b/_infra/helm/securebanking-openbanking-uk-rs/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: test-facility-bank
 description: Test facility bank service Helm chart for Kubernetes
 type: application
-version: 1.0.2
-appVersion: 1.0.2
+version: 1.0.3
+appVersion: 1.0.3

--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
     </parent>
 
     <properties>
-        <uk.bom.version>1.0.4</uk.bom.version>
+        <uk.bom.version>1.0.5</uk.bom.version>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
- Updated helm charts version to 1.0.3
- Bumped common version 1.0.5

Issue: https://github.com/SecureApiGateway/SecureApiGateway/issues/1040