### PR TITLE
1067: Configuring spring-boot-maven-plugin to repackage the jar with an "exec" classifier

### DIFF
--- a/secure-api-gateway-ob-uk-rs-server/pom.xml
+++ b/secure-api-gateway-ob-uk-rs-server/pom.xml
@@ -220,6 +220,9 @@
                         <goals>
                             <goal>repackage</goal>
                         </goals>
+                        <configuration>
+                            <classifier>exec</classifier>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>
@@ -231,7 +234,7 @@
                     <skipPush>false</skipPush>
                     <repository>eu.gcr.io/${gcrRepo}/securebanking/securebanking-openbanking-uk-rs</repository>
                     <buildArgs>
-                        <JAR_FILE>target/${project.build.finalName}.jar</JAR_FILE>
+                        <JAR_FILE>target/${project.build.finalName}-exec.jar</JAR_FILE>
                     </buildArgs>
                     <tag>${tag}</tag>
                 </configuration>


### PR DESCRIPTION
Executable jar will be: secure-api-gateway-ob-uk-rs-server-$VERSION-exec.jar

Updated docker plugin to the use exec jar

The jar with no classifier will be a standard jar, which can be used as a library in extension projects.

https://github.com/SecureApiGateway/SecureApiGateway/issues/1067