### PR TITLE
1060: Domestic Scheduled Payment Consent API

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ clean:
 	mvn clean
 
 verify: clean
-	mvn verify
+	mvn -U verify
 
 docker: clean
 	mvn install dockerfile:build dockerfile:push -DskipTests -DskipITs -Dtag=${tag} \

--- a/secure-api-gateway-ob-uk-rs-obie-api/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/obie/api/payment/v3_1_10/domesticscheduledpayments/DomesticScheduledPaymentConsentsApi.java
+++ b/secure-api-gateway-ob-uk-rs-obie-api/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/obie/api/payment/v3_1_10/domesticscheduledpayments/DomesticScheduledPaymentConsentsApi.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.ob.uk.rs.obie.api.payment.v3_1_10.domesticscheduledpayments;
+
+import static com.forgerock.sapi.gateway.ob.uk.rs.obie.api.ApiConstants.HTTP_DATE_FORMAT;
+
+import java.security.Principal;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.validation.Valid;
+
+import org.joda.time.DateTime;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+
+import com.forgerock.sapi.gateway.ob.uk.common.error.OBErrorResponseException;
+
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
+import io.swagger.annotations.Authorization;
+import io.swagger.annotations.AuthorizationScope;
+import uk.org.openbanking.datamodel.error.OBErrorResponse1;
+import uk.org.openbanking.datamodel.payment.OBWriteDomesticScheduledConsent4;
+import uk.org.openbanking.datamodel.payment.OBWriteDomesticScheduledConsentResponse5;
+
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2020-05-22T14:20:48.770Z")
+
+@Api(value = "domestic-scheduled-payment-consents", description = "the domestic-scheduled-payment-consents API")
+@RequestMapping(value = "/open-banking/v3.1.10/pisp")
+public interface DomesticScheduledPaymentConsentsApi {
+
+    @ApiOperation(value = "Create Domestic Scheduled Payment Consents", nickname = "createDomesticScheduledPaymentConsents", notes = "", response = OBWriteDomesticScheduledConsentResponse5.class, authorizations = {
+            @Authorization(value = "TPPOAuth2Security", scopes = {
+                    @AuthorizationScope(scope = "payments", description = "Generic payment scope")
+            })
+    }, tags = {"Domestic Scheduled Payments",})
+    @ApiResponses(value = {
+            @ApiResponse(code = 201, message = "Domestic Scheduled Payment Consents Created", response = OBWriteDomesticScheduledConsentResponse5.class),
+            @ApiResponse(code = 400, message = "Bad request", response = OBErrorResponse1.class),
+            @ApiResponse(code = 401, message = "Unauthorized"),
+            @ApiResponse(code = 403, message = "Forbidden", response = OBErrorResponse1.class),
+            @ApiResponse(code = 404, message = "Not found"),
+            @ApiResponse(code = 405, message = "Method Not Allowed"),
+            @ApiResponse(code = 406, message = "Not Acceptable"),
+            @ApiResponse(code = 429, message = "Too Many Requests"),
+            @ApiResponse(code = 500, message = "Internal Server Error", response = OBErrorResponse1.class)})
+    @RequestMapping(value = "/domestic-scheduled-payment-consents",
+            produces = {"application/json; charset=utf-8", "application/jose+jwe"},
+            consumes = {"application/json; charset=utf-8", "application/jose+jwe"},
+            method = RequestMethod.POST)
+    ResponseEntity<OBWriteDomesticScheduledConsentResponse5> createDomesticScheduledPaymentConsents(
+            @ApiParam(value = "Default", required = true)
+            @Valid
+            @RequestBody OBWriteDomesticScheduledConsent4 obWriteDomesticScheduledConsent4,
+
+            @ApiParam(value = "An Authorisation Token as per https://tools.ietf.org/html/rfc6750", required = true)
+            @RequestHeader(value = "Authorization", required = true) String authorization,
+
+            @ApiParam(value = "Every request will be processed only once per x-idempotency-key.  The Idempotency Key will be valid for 24 hours. ", required = true)
+            @RequestHeader(value = "x-idempotency-key", required = true) String xIdempotencyKey,
+
+            @ApiParam(value = "A detached JWS signature of the body of the payload.", required = true)
+            @RequestHeader(value = "x-jws-signature", required = true) String xJwsSignature,
+
+            @ApiParam(value = "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC")
+            @RequestHeader(value = "x-fapi-auth-date", required = false)
+            @DateTimeFormat(pattern = HTTP_DATE_FORMAT) DateTime xFapiAuthDate,
+
+            @ApiParam(value = "The PSU's IP address if the PSU is currently logged in with the TPP.")
+            @RequestHeader(value = "x-fapi-customer-ip-address", required = false) String xFapiCustomerIpAddress,
+
+            @ApiParam(value = "An RFC4122 UID used as a correlation id.")
+            @RequestHeader(value = "x-fapi-interaction-id", required = false) String xFapiInteractionId,
+
+            @ApiParam(value = "Indicates the user-agent that the PSU is using.")
+            @RequestHeader(value = "x-customer-user-agent", required = false) String xCustomerUserAgent,
+
+            @ApiParam(value = "OAuth2.0 client_id of the ApiClient making the request")
+            @RequestHeader(value = "x-api-client-id") String apiClientId,
+
+            HttpServletRequest request,
+
+            Principal principal) throws OBErrorResponseException;
+
+    @ApiOperation(value = "Get Domestic Scheduled Payment Consents", nickname = "getDomesticScheduledPaymentConsentsConsentId", notes = "", response = OBWriteDomesticScheduledConsentResponse5.class, authorizations = {
+            @Authorization(value = "TPPOAuth2Security", scopes = {
+                    @AuthorizationScope(scope = "payments", description = "Generic payment scope")
+            })
+    }, tags = {"Domestic Scheduled Payments",})
+    @ApiResponses(value = {
+            @ApiResponse(code = 200, message = "Domestic Scheduled Payment Consents Read", response = OBWriteDomesticScheduledConsentResponse5.class),
+            @ApiResponse(code = 400, message = "Bad request", response = OBErrorResponse1.class),
+            @ApiResponse(code = 401, message = "Unauthorized"),
+            @ApiResponse(code = 403, message = "Forbidden", response = OBErrorResponse1.class),
+            @ApiResponse(code = 404, message = "Not found"),
+            @ApiResponse(code = 405, message = "Method Not Allowed"),
+            @ApiResponse(code = 406, message = "Not Acceptable"),
+            @ApiResponse(code = 429, message = "Too Many Requests"),
+            @ApiResponse(code = 500, message = "Internal Server Error", response = OBErrorResponse1.class)})
+    @RequestMapping(value = "/domestic-scheduled-payment-consents/{ConsentId}",
+            produces = {"application/json; charset=utf-8", "application/jose+jwe"},
+            method = RequestMethod.GET)
+    ResponseEntity<OBWriteDomesticScheduledConsentResponse5> getDomesticScheduledPaymentConsentsConsentId(
+            @ApiParam(value = "ConsentId", required = true)
+            @PathVariable("ConsentId") String consentId,
+
+            @ApiParam(value = "An Authorisation Token as per https://tools.ietf.org/html/rfc6750", required = true)
+            @RequestHeader(value = "Authorization", required = true) String authorization,
+
+            @ApiParam(value = "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC")
+            @RequestHeader(value = "x-fapi-auth-date", required = false)
+            @DateTimeFormat(pattern = HTTP_DATE_FORMAT) DateTime xFapiAuthDate,
+
+            @ApiParam(value = "The PSU's IP address if the PSU is currently logged in with the TPP.")
+            @RequestHeader(value = "x-fapi-customer-ip-address", required = false) String xFapiCustomerIpAddress,
+
+            @ApiParam(value = "An RFC4122 UID used as a correlation id.")
+            @RequestHeader(value = "x-fapi-interaction-id", required = false) String xFapiInteractionId,
+
+            @ApiParam(value = "Indicates the user-agent that the PSU is using.")
+            @RequestHeader(value = "x-customer-user-agent", required = false) String xCustomerUserAgent,
+
+            @ApiParam(value = "OAuth2.0 client_id of the ApiClient making the request")
+            @RequestHeader(value = "x-api-client-id") String apiClientId,
+
+            HttpServletRequest request,
+
+            Principal principal) throws OBErrorResponseException;
+
+}

--- a/secure-api-gateway-ob-uk-rs-obie-api/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/obie/api/payment/v3_1_5/domesticscheduledpayments/DomesticScheduledPaymentsApi.java
+++ b/secure-api-gateway-ob-uk-rs-obie-api/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/obie/api/payment/v3_1_5/domesticscheduledpayments/DomesticScheduledPaymentsApi.java
@@ -77,9 +77,6 @@ public interface DomesticScheduledPaymentsApi {
             @ApiParam(value = "A detached JWS signature of the body of the payload.", required = true)
             @RequestHeader(value = "x-jws-signature", required = true) String xJwsSignature,
 
-            @ApiParam(value = "The ID of the account that the payment is being made from.")
-            @RequestHeader(value = "x-ob-account-id", required = true) String xAccountId,
-
             @ApiParam(value = "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC")
             @RequestHeader(value = "x-fapi-auth-date", required = false)
             @DateTimeFormat(pattern = ApiConstants.HTTP_DATE_FORMAT) DateTime xFapiAuthDate,

--- a/secure-api-gateway-ob-uk-rs-obie-api/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/obie/api/payment/v3_1_5/domesticscheduledpayments/DomesticScheduledPaymentsApi.java
+++ b/secure-api-gateway-ob-uk-rs-obie-api/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/obie/api/payment/v3_1_5/domesticscheduledpayments/DomesticScheduledPaymentsApi.java
@@ -93,6 +93,9 @@ public interface DomesticScheduledPaymentsApi {
             @ApiParam(value = "Indicates the user-agent that the PSU is using.")
             @RequestHeader(value = "x-customer-user-agent", required = false) String xCustomerUserAgent,
 
+            @ApiParam(value = "OAuth2.0 client_id of the ApiClient making the request")
+            @RequestHeader(value = "x-api-client-id") String apiClientId,
+
             HttpServletRequest request,
 
             Principal principal) throws OBErrorResponseException;
@@ -137,6 +140,9 @@ public interface DomesticScheduledPaymentsApi {
             @ApiParam(value = "Indicates the user-agent that the PSU is using.")
             @RequestHeader(value = "x-customer-user-agent", required = false) String xCustomerUserAgent,
 
+            @ApiParam(value = "OAuth2.0 client_id of the ApiClient making the request")
+            @RequestHeader(value = "x-api-client-id") String apiClientId,
+
             HttpServletRequest request,
 
             Principal principal) throws OBErrorResponseException;
@@ -180,6 +186,9 @@ public interface DomesticScheduledPaymentsApi {
 
             @ApiParam(value = "Indicates the user-agent that the PSU is using.")
             @RequestHeader(value = "x-customer-user-agent", required = false) String xCustomerUserAgent,
+
+            @ApiParam(value = "OAuth2.0 client_id of the ApiClient making the request")
+            @RequestHeader(value = "x-api-client-id") String apiClientId,
 
             HttpServletRequest request,
 

--- a/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/factories/OBWriteDomesticScheduledConsentResponse5Factory.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/factories/OBWriteDomesticScheduledConsentResponse5Factory.java
@@ -42,6 +42,7 @@ public class OBWriteDomesticScheduledConsentResponse5Factory {
         final OBWriteDomesticScheduledConsent4 obWriteDomesticScheduledConsent4 = FRWriteDomesticScheduledConsentConverter.toOBWriteDomesticScheduledConsent4(consent.getRequestObj());
         final OBWriteDomesticScheduledConsent4Data obConsentData = obWriteDomesticScheduledConsent4.getData();
         data.authorisation(obConsentData.getAuthorisation());
+        data.permission(obConsentData.getPermission());
         data.readRefundAccount(obConsentData.getReadRefundAccount());
         data.scASupportData(obConsentData.getScASupportData());
         data.initiation(obConsentData.getInitiation());

--- a/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/factories/OBWriteDomesticScheduledConsentResponse5Factory.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/factories/OBWriteDomesticScheduledConsentResponse5Factory.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.ob.uk.rs.server.api.obie.payment.factories;
+
+
+import static com.forgerock.sapi.gateway.ob.uk.rs.server.common.util.link.LinksHelper.createDomesticScheduledPaymentConsentsLink;
+
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Component;
+
+import com.forgerock.sapi.gateway.ob.uk.common.datamodel.converter.common.FRChargeConverter;
+import com.forgerock.sapi.gateway.ob.uk.common.datamodel.converter.payment.FRWriteDomesticScheduledConsentConverter;
+import com.forgerock.sapi.gateway.rcs.conent.store.datamodel.payment.domesticscheduled.v3_1_10.DomesticScheduledPaymentConsent;
+
+import uk.org.openbanking.datamodel.common.Meta;
+import uk.org.openbanking.datamodel.payment.OBWriteDomesticScheduledConsent4;
+import uk.org.openbanking.datamodel.payment.OBWriteDomesticScheduledConsent4Data;
+import uk.org.openbanking.datamodel.payment.OBWriteDomesticScheduledConsentResponse5;
+import uk.org.openbanking.datamodel.payment.OBWriteDomesticScheduledConsentResponse5Data;
+import uk.org.openbanking.datamodel.payment.OBWriteDomesticScheduledConsentResponse5Data.StatusEnum;
+
+@Component
+public class OBWriteDomesticScheduledConsentResponse5Factory {
+
+    public OBWriteDomesticScheduledConsentResponse5 buildConsentResponse(DomesticScheduledPaymentConsent consent, Class<?> controllerClass) {
+        final OBWriteDomesticScheduledConsentResponse5Data data = new OBWriteDomesticScheduledConsentResponse5Data();
+
+        final OBWriteDomesticScheduledConsent4 obWriteDomesticScheduledConsent4 = FRWriteDomesticScheduledConsentConverter.toOBWriteDomesticScheduledConsent4(consent.getRequestObj());
+        final OBWriteDomesticScheduledConsent4Data obConsentData = obWriteDomesticScheduledConsent4.getData();
+        data.authorisation(obConsentData.getAuthorisation());
+        data.readRefundAccount(obConsentData.getReadRefundAccount());
+        data.scASupportData(obConsentData.getScASupportData());
+        data.initiation(obConsentData.getInitiation());
+        data.charges(consent.getCharges() == null ? null : consent.getCharges().stream()
+                .map(FRChargeConverter::toOBWriteDomesticConsentResponse5DataCharges).collect(Collectors.toUnmodifiableList()));
+        data.consentId(consent.getId());
+        data.status(StatusEnum.fromValue(consent.getStatus()));
+        data.creationDateTime(consent.getCreationDateTime());
+        data.statusUpdateDateTime(consent.getStatusUpdateDateTime());
+
+        return new OBWriteDomesticScheduledConsentResponse5().data(data)
+                .risk(obWriteDomesticScheduledConsent4.getRisk())
+                .links(createDomesticScheduledPaymentConsentsLink(controllerClass, consent.getId()))
+                .meta(new Meta());
+    }
+}

--- a/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/v3_1_10/domesticpayments/DomesticPaymentsApiController.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/v3_1_10/domesticpayments/DomesticPaymentsApiController.java
@@ -23,7 +23,6 @@ package com.forgerock.sapi.gateway.ob.uk.rs.server.api.obie.payment.v3_1_10.dome
 import org.springframework.stereotype.Controller;
 
 import com.forgerock.sapi.gateway.ob.uk.rs.obie.api.payment.v3_1_10.domesticpayments.DomesticPaymentsApi;
-import com.forgerock.sapi.gateway.ob.uk.rs.server.api.obie.payment.factories.OBWriteDomesticConsentResponse5Factory;
 import com.forgerock.sapi.gateway.ob.uk.rs.server.persistence.repository.accounts.accounts.FRAccountRepository;
 import com.forgerock.sapi.gateway.ob.uk.rs.server.persistence.repository.payments.DomesticPaymentSubmissionRepository;
 import com.forgerock.sapi.gateway.ob.uk.rs.server.validator.PaymentSubmissionValidator;
@@ -44,8 +43,7 @@ public class DomesticPaymentsApiController
             PaymentSubmissionValidator paymentSubmissionValidator,
             OBValidationService<OBWriteDomestic2ValidationContext> paymentValidator,
             DomesticPaymentConsentStoreClient consentApiClient,
-            OBWriteDomesticConsentResponse5Factory consentResponseFactory,
             FRAccountRepository frAccountRepository) {
-        super(paymentSubmissionRepository, paymentSubmissionValidator, paymentValidator, consentApiClient, consentResponseFactory, frAccountRepository);
+        super(paymentSubmissionRepository, paymentSubmissionValidator, paymentValidator, consentApiClient, frAccountRepository);
     }
 }

--- a/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/v3_1_10/domesticscheduledpayments/DomesticScheduledPaymentConsentsApiController.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/v3_1_10/domesticscheduledpayments/DomesticScheduledPaymentConsentsApiController.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.ob.uk.rs.server.api.obie.payment.v3_1_10.domesticscheduledpayments;
+
+import java.security.Principal;
+import java.util.List;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.joda.time.DateTime;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+
+import com.forgerock.sapi.gateway.ob.uk.common.datamodel.common.FRCharge;
+import com.forgerock.sapi.gateway.ob.uk.common.datamodel.converter.payment.FRWriteDomesticScheduledConsentConverter;
+import com.forgerock.sapi.gateway.ob.uk.common.error.OBErrorResponseException;
+import com.forgerock.sapi.gateway.ob.uk.rs.obie.api.payment.v3_1_10.domesticscheduledpayments.DomesticScheduledPaymentConsentsApi;
+import com.forgerock.sapi.gateway.ob.uk.rs.server.api.obie.payment.factories.OBWriteDomesticScheduledConsentResponse5Factory;
+import com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.OBValidationService;
+import com.forgerock.sapi.gateway.rcs.conent.store.client.payment.domesticscheduled.v3_1_10.DomesticScheduledPaymentConsentStoreClient;
+import com.forgerock.sapi.gateway.rcs.conent.store.datamodel.payment.domesticscheduled.v3_1_10.CreateDomesticScheduledPaymentConsentRequest;
+import com.forgerock.sapi.gateway.rcs.conent.store.datamodel.payment.domesticscheduled.v3_1_10.DomesticScheduledPaymentConsent;
+
+import uk.org.openbanking.datamodel.payment.OBWriteDomesticScheduledConsent4;
+import uk.org.openbanking.datamodel.payment.OBWriteDomesticScheduledConsentResponse5;
+
+@Controller("DomesticScheduledPaymentConsentsApiV3.1.10")
+public class DomesticScheduledPaymentConsentsApiController implements DomesticScheduledPaymentConsentsApi {
+
+    private final Logger logger = LoggerFactory.getLogger(getClass());
+
+    private final DomesticScheduledPaymentConsentStoreClient consentStoreApiClient;
+
+    private final OBValidationService<OBWriteDomesticScheduledConsent4> consentValidator;
+
+    private final OBWriteDomesticScheduledConsentResponse5Factory consentResponseFactory;
+
+
+    public DomesticScheduledPaymentConsentsApiController(DomesticScheduledPaymentConsentStoreClient consentStoreApiClient,
+                                                         OBValidationService<OBWriteDomesticScheduledConsent4> consentValidator,
+                                                         OBWriteDomesticScheduledConsentResponse5Factory consentResponseFactory) {
+
+        this.consentStoreApiClient = consentStoreApiClient;
+        this.consentValidator = consentValidator;
+        this.consentResponseFactory = consentResponseFactory;
+    }
+
+    @Override
+    public ResponseEntity<OBWriteDomesticScheduledConsentResponse5> createDomesticScheduledPaymentConsents(OBWriteDomesticScheduledConsent4 obWriteDomesticScheduledConsent4,
+                                                                                                           String authorization,
+                                                                                                           String xIdempotencyKey,
+                                                                                                           String xJwsSignature,
+                                                                                                           DateTime xFapiAuthDate,
+                                                                                                           String xFapiCustomerIpAddress,
+                                                                                                           String xFapiInteractionId,
+                                                                                                           String xCustomerUserAgent,
+                                                                                                           String apiClientId,
+                                                                                                           HttpServletRequest request,
+                                                                                                           Principal principal) throws OBErrorResponseException {
+        logger.info("Processing createDomesticScheduledPaymentConsents request - consent: {}, idempotencyKey: {}, apiClient: {}, x-fapi-interaction-id: {}",
+                obWriteDomesticScheduledConsent4, xIdempotencyKey, apiClientId, xFapiInteractionId);
+
+        consentValidator.validate(obWriteDomesticScheduledConsent4);
+
+        final CreateDomesticScheduledPaymentConsentRequest createRequest = new CreateDomesticScheduledPaymentConsentRequest();
+        createRequest.setConsentRequest(FRWriteDomesticScheduledConsentConverter.toFRWriteDomesticScheduledConsent(obWriteDomesticScheduledConsent4));
+        createRequest.setApiClientId(apiClientId);
+        createRequest.setIdempotencyKey(xIdempotencyKey);
+        createRequest.setCharges(calculateCharges(obWriteDomesticScheduledConsent4));
+
+        final DomesticScheduledPaymentConsent consent = consentStoreApiClient.createConsent(createRequest);
+        logger.info("Created consent - id: {}", consent.getId());
+
+        return new ResponseEntity<>(consentResponseFactory.buildConsentResponse(consent, getClass()), HttpStatus.CREATED);
+    }
+
+    private List<FRCharge> calculateCharges(OBWriteDomesticScheduledConsent4 obWriteDomesticScheduledConsent4) {
+        return List.of();
+    }
+
+    @Override
+    public ResponseEntity<OBWriteDomesticScheduledConsentResponse5> getDomesticScheduledPaymentConsentsConsentId(String consentId,
+                                                                                                                 String authorization,
+                                                                                                                 DateTime xFapiAuthDate,
+                                                                                                                 String xFapiCustomerIpAddress,
+                                                                                                                 String xFapiInteractionId,
+                                                                                                                 String xCustomerUserAgent,
+                                                                                                                 String apiClientId,
+                                                                                                                 HttpServletRequest request,
+                                                                                                                 Principal principal) throws OBErrorResponseException {
+
+        logger.info("Processing getDomesticScheduledPaymentConsentsConsentId request - consentId: {}, apiClient, x-fapi-interaction-id: {}",
+                consentId, apiClientId, xFapiInteractionId);
+
+        return ResponseEntity.ok(consentResponseFactory.buildConsentResponse(consentStoreApiClient.getConsent(consentId, apiClientId), getClass()));
+    }
+}

--- a/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/v3_1_10/domesticscheduledpayments/DomesticScheduledPaymentsApiController.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/v3_1_10/domesticscheduledpayments/DomesticScheduledPaymentsApiController.java
@@ -21,12 +21,14 @@
 package com.forgerock.sapi.gateway.ob.uk.rs.server.api.obie.payment.v3_1_10.domesticscheduledpayments;
 
 import com.forgerock.sapi.gateway.ob.uk.rs.obie.api.payment.v3_1_10.domesticscheduledpayments.DomesticScheduledPaymentsApi;
-import com.forgerock.sapi.gateway.ob.uk.rs.server.api.obie.payment.services.ConsentService;
-import com.forgerock.sapi.gateway.ob.uk.rs.server.api.obie.payment.services.validation.RiskValidationService;
 import com.forgerock.sapi.gateway.ob.uk.rs.server.persistence.repository.accounts.accounts.FRAccountRepository;
 import com.forgerock.sapi.gateway.ob.uk.rs.server.persistence.repository.payments.DomesticScheduledPaymentSubmissionRepository;
 import com.forgerock.sapi.gateway.ob.uk.rs.server.service.scheduledpayment.ScheduledPaymentService;
 import com.forgerock.sapi.gateway.ob.uk.rs.server.validator.PaymentSubmissionValidator;
+import com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.OBValidationService;
+import com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.payment.OBWriteDomesticScheduled2Validator.OBWriteDomesticScheduled2ValidationContext;
+import com.forgerock.sapi.gateway.rcs.conent.store.client.payment.domesticscheduled.v3_1_10.DomesticScheduledPaymentConsentStoreClient;
+
 import org.springframework.stereotype.Controller;
 
 @Controller("DomesticScheduledPaymentsApiV3.1.10")
@@ -36,17 +38,17 @@ public class DomesticScheduledPaymentsApiController extends com.forgerock.sapi.g
             DomesticScheduledPaymentSubmissionRepository scheduledPaymentSubmissionRepository,
             PaymentSubmissionValidator paymentSubmissionValidator,
             ScheduledPaymentService scheduledPaymentService,
-            ConsentService consentService,
-            RiskValidationService riskValidationService,
-            FRAccountRepository frAccountRepository
+            DomesticScheduledPaymentConsentStoreClient consentStoreClient,
+            FRAccountRepository accountRepository,
+            OBValidationService<OBWriteDomesticScheduled2ValidationContext> paymentValidator
     ) {
         super(
                 scheduledPaymentSubmissionRepository,
                 paymentSubmissionValidator,
                 scheduledPaymentService,
-                consentService,
-                riskValidationService,
-                frAccountRepository
+                consentStoreClient,
+                accountRepository,
+                paymentValidator
         );
     }
 }

--- a/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/v3_1_5/domesticscheduledpayments/DomesticScheduledPaymentsApiController.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/v3_1_5/domesticscheduledpayments/DomesticScheduledPaymentsApiController.java
@@ -117,7 +117,6 @@ public class DomesticScheduledPaymentsApiController implements DomesticScheduled
             String authorization,
             String xIdempotencyKey,
             String xJwsSignature,
-            String xAccountId,
             DateTime xFapiAuthDate,
             String xFapiCustomerIpAddress,
             String xFapiInteractionId,
@@ -159,7 +158,7 @@ public class DomesticScheduledPaymentsApiController implements DomesticScheduled
                 .idempotentSave(frPaymentSubmission);
 
         // Save the scheduled payment data for the Accounts API
-        FRScheduledPaymentData scheduledPaymentData = FRScheduledPaymentDataFactory.createFRScheduledPaymentData(frScheduledPayment, xAccountId);
+        FRScheduledPaymentData scheduledPaymentData = FRScheduledPaymentDataFactory.createFRScheduledPaymentData(frScheduledPayment, consent.getAuthorisedDebtorAccountId());
         scheduledPaymentService.createScheduledPayment(scheduledPaymentData);
 
         return ResponseEntity.status(CREATED).body(responseEntity(consent, frPaymentSubmission));

--- a/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/v3_1_5/domesticscheduledpayments/DomesticScheduledPaymentsApiController.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/v3_1_5/domesticscheduledpayments/DomesticScheduledPaymentsApiController.java
@@ -20,20 +20,38 @@
  */
 package com.forgerock.sapi.gateway.ob.uk.rs.server.api.obie.payment.v3_1_5.domesticscheduledpayments;
 
+import static com.forgerock.sapi.gateway.ob.uk.common.datamodel.common.FRSubmissionStatus.INITIATIONPENDING;
+import static com.forgerock.sapi.gateway.ob.uk.common.datamodel.converter.common.FRAccountIdentifierConverter.toOBCashAccountDebtor4;
+import static com.forgerock.sapi.gateway.ob.uk.common.datamodel.converter.common.FRChargeConverter.toOBWriteDomesticConsentResponse5DataCharges;
+import static com.forgerock.sapi.gateway.ob.uk.common.datamodel.converter.common.FRSubmissionStatusConverter.toOBWriteDomesticScheduledResponse5DataStatus;
+import static com.forgerock.sapi.gateway.ob.uk.common.datamodel.converter.payment.FRWriteDomesticScheduledConsentConverter.toOBWriteDomesticScheduled2DataInitiation;
+import static com.forgerock.sapi.gateway.ob.uk.common.datamodel.converter.payment.FRWriteDomesticScheduledConverter.toFRWriteDomesticScheduled;
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+import static org.springframework.http.HttpStatus.CREATED;
+
+import java.security.Principal;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.UUID;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.validation.Valid;
+
+import org.joda.time.DateTime;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+
 import com.forgerock.sapi.gateway.ob.uk.common.datamodel.account.FRScheduledPaymentData;
 import com.forgerock.sapi.gateway.ob.uk.common.datamodel.common.FRAccountIdentifier;
+import com.forgerock.sapi.gateway.ob.uk.common.datamodel.common.FRReadRefundAccount;
 import com.forgerock.sapi.gateway.ob.uk.common.datamodel.common.FRResponseDataRefund;
 import com.forgerock.sapi.gateway.ob.uk.common.datamodel.converter.common.FRResponseDataRefundConverter;
+import com.forgerock.sapi.gateway.ob.uk.common.datamodel.converter.payment.FRWriteDomesticScheduledConsentConverter;
 import com.forgerock.sapi.gateway.ob.uk.common.datamodel.payment.FRWriteDataDomesticScheduled;
 import com.forgerock.sapi.gateway.ob.uk.common.datamodel.payment.FRWriteDomesticScheduled;
-import com.forgerock.sapi.gateway.ob.uk.common.error.OBErrorException;
 import com.forgerock.sapi.gateway.ob.uk.common.error.OBErrorResponseException;
-import com.forgerock.sapi.gateway.ob.uk.common.error.OBRIErrorResponseCategory;
-import com.forgerock.sapi.gateway.ob.uk.common.error.OBRIErrorType;
 import com.forgerock.sapi.gateway.ob.uk.rs.obie.api.payment.v3_1_5.domesticscheduledpayments.DomesticScheduledPaymentsApi;
 import com.forgerock.sapi.gateway.ob.uk.rs.server.api.obie.payment.factories.FRScheduledPaymentDataFactory;
-import com.forgerock.sapi.gateway.ob.uk.rs.server.api.obie.payment.services.ConsentService;
-import com.forgerock.sapi.gateway.ob.uk.rs.server.api.obie.payment.services.validation.RiskValidationService;
 import com.forgerock.sapi.gateway.ob.uk.rs.server.common.refund.FRResponseDataRefundFactory;
 import com.forgerock.sapi.gateway.ob.uk.rs.server.common.util.PaymentApiResponseUtil;
 import com.forgerock.sapi.gateway.ob.uk.rs.server.common.util.PaymentsUtils;
@@ -47,29 +65,23 @@ import com.forgerock.sapi.gateway.ob.uk.rs.server.persistence.repository.payment
 import com.forgerock.sapi.gateway.ob.uk.rs.server.service.scheduledpayment.ScheduledPaymentService;
 import com.forgerock.sapi.gateway.ob.uk.rs.server.validator.PaymentSubmissionValidator;
 import com.forgerock.sapi.gateway.ob.uk.rs.server.validator.ResourceVersionValidator;
+import com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.OBValidationService;
+import com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.payment.OBWriteDomesticScheduled2Validator.OBWriteDomesticScheduled2ValidationContext;
+import com.forgerock.sapi.gateway.rcs.conent.store.client.payment.domesticscheduled.v3_1_10.DomesticScheduledPaymentConsentStoreClient;
+import com.forgerock.sapi.gateway.rcs.conent.store.datamodel.payment.domesticscheduled.v3_1_10.DomesticScheduledPaymentConsent;
 import com.forgerock.sapi.gateway.uk.common.shared.api.meta.obie.OBVersion;
 import com.google.gson.JsonObject;
+
 import lombok.extern.slf4j.Slf4j;
-import org.joda.time.DateTime;
-import org.springframework.http.ResponseEntity;
-import org.springframework.stereotype.Controller;
 import uk.org.openbanking.datamodel.common.Meta;
-import uk.org.openbanking.datamodel.payment.*;
-
-import javax.servlet.http.HttpServletRequest;
-import javax.validation.Valid;
-import java.security.Principal;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.UUID;
-
-import static com.forgerock.sapi.gateway.ob.uk.common.datamodel.common.FRSubmissionStatus.INITIATIONPENDING;
-import static com.forgerock.sapi.gateway.ob.uk.common.datamodel.converter.common.FRAccountIdentifierConverter.toOBCashAccountDebtor4;
-import static com.forgerock.sapi.gateway.ob.uk.common.datamodel.converter.common.FRSubmissionStatusConverter.toOBWriteDomesticScheduledResponse5DataStatus;
-import static com.forgerock.sapi.gateway.ob.uk.common.datamodel.converter.payment.FRWriteDomesticScheduledConsentConverter.toOBWriteDomesticScheduled2DataInitiation;
-import static com.forgerock.sapi.gateway.ob.uk.common.datamodel.converter.payment.FRWriteDomesticScheduledConverter.toFRWriteDomesticScheduled;
-import static org.springframework.http.HttpStatus.BAD_REQUEST;
-import static org.springframework.http.HttpStatus.CREATED;
+import uk.org.openbanking.datamodel.payment.OBReadRefundAccountEnum;
+import uk.org.openbanking.datamodel.payment.OBWriteDomesticScheduled2;
+import uk.org.openbanking.datamodel.payment.OBWriteDomesticScheduledResponse5;
+import uk.org.openbanking.datamodel.payment.OBWriteDomesticScheduledResponse5Data;
+import uk.org.openbanking.datamodel.payment.OBWritePaymentDetailsResponse1;
+import uk.org.openbanking.datamodel.payment.OBWritePaymentDetailsResponse1Data;
+import uk.org.openbanking.datamodel.payment.OBWritePaymentDetailsResponse1DataPaymentStatus;
+import uk.org.openbanking.datamodel.payment.OBWritePaymentDetailsResponse1DataStatusDetail;
 
 @Controller("DomesticScheduledPaymentsApiV3.1.5")
 @Slf4j
@@ -79,24 +91,24 @@ public class DomesticScheduledPaymentsApiController implements DomesticScheduled
     private final PaymentSubmissionValidator paymentSubmissionValidator;
     private final ScheduledPaymentService scheduledPaymentService;
 
-    private final ConsentService consentService;
-    private final RiskValidationService riskValidationService;
-    private final FRAccountRepository frAccountRepository;
+    private final DomesticScheduledPaymentConsentStoreClient consentStoreClient;
+    private final OBValidationService<OBWriteDomesticScheduled2ValidationContext> paymentValidator;
+    private final FRAccountRepository accountRepository;
 
     public DomesticScheduledPaymentsApiController(
             DomesticScheduledPaymentSubmissionRepository scheduledPaymentSubmissionRepository,
             PaymentSubmissionValidator paymentSubmissionValidator,
             ScheduledPaymentService scheduledPaymentService,
-            ConsentService consentService,
-            RiskValidationService riskValidationService,
-            FRAccountRepository frAccountRepository
+            DomesticScheduledPaymentConsentStoreClient consentStoreClient,
+            FRAccountRepository accountRepository,
+            OBValidationService<OBWriteDomesticScheduled2ValidationContext> paymentValidator
     ) {
         this.scheduledPaymentSubmissionRepository = scheduledPaymentSubmissionRepository;
         this.paymentSubmissionValidator = paymentSubmissionValidator;
         this.scheduledPaymentService = scheduledPaymentService;
-        this.consentService = consentService;
-        this.riskValidationService = riskValidationService;
-        this.frAccountRepository = frAccountRepository;
+        this.consentStoreClient = consentStoreClient;
+        this.accountRepository = accountRepository;
+        this.paymentValidator = paymentValidator;
     }
 
     @Override
@@ -110,6 +122,7 @@ public class DomesticScheduledPaymentsApiController implements DomesticScheduled
             String xFapiCustomerIpAddress,
             String xFapiInteractionId,
             String xCustomerUserAgent,
+            String apiClientId,
             HttpServletRequest request,
             Principal principal) throws OBErrorResponseException {
         log.debug("Received payment submission: '{}'", obWriteDomesticScheduled2);
@@ -117,37 +130,18 @@ public class DomesticScheduledPaymentsApiController implements DomesticScheduled
         paymentSubmissionValidator.validateIdempotencyKeyAndRisk(xIdempotencyKey, obWriteDomesticScheduled2.getRisk());
 
         String consentId = obWriteDomesticScheduled2.getData().getConsentId();
-        //get the consent
-        JsonObject intent = consentService.getIDMIntent(authorization, consentId);
-        log.debug("Retrieved consent from IDM");
-
-        //deserialize the intent to ob response object
-        OBWriteDomesticScheduledConsentResponse5 obConsentResponse = consentService.deserialize(
-                OBWriteDomesticScheduledConsentResponse5.class,
-                intent.getAsJsonObject("OBIntentObject"),
-                consentId
-        );
-        log.debug("Deserialized consent from IDM");
+        log.debug("Attempting to get consent: {}, clientId: {}", consentId, apiClientId);
+        final DomesticScheduledPaymentConsent consent = consentStoreClient.getConsent(consentId, apiClientId);
+        log.debug("Got consent from store: {}", consent);
 
         FRWriteDomesticScheduled frScheduledPayment = toFRWriteDomesticScheduled(obWriteDomesticScheduled2);
         log.trace("Converted to: '{}'", frScheduledPayment);
 
         // validate the consent against the request
         log.debug("Validating Domestic Scheduled Payment submission");
-        try {
-            // validates the initiation
-            if (!obWriteDomesticScheduled2.getData().getInitiation().equals(obConsentResponse.getData().getInitiation())) {
-                throw new OBErrorException(OBRIErrorType.PAYMENT_INVALID_INITIATION,
-                        "The initiation field from payment submitted does not match with the initiation field submitted for the consent"
-                );
-            }
-            riskValidationService.validate(obConsentResponse.getRisk(), obWriteDomesticScheduled2.getRisk());
-        } catch (OBErrorException e) {
-            throw new OBErrorResponseException(
-                    e.getObriErrorType().getHttpStatus(),
-                    OBRIErrorResponseCategory.REQUEST_INVALID,
-                    e.getOBError());
-        }
+        final OBWriteDomesticScheduled2ValidationContext validationCtxt = new OBWriteDomesticScheduled2ValidationContext(obWriteDomesticScheduled2,
+                FRWriteDomesticScheduledConsentConverter.toOBWriteDomesticScheduledConsent4(consent.getRequestObj()), consent.getStatus());
+        paymentValidator.validate(validationCtxt);
         log.debug("Domestic Scheduled Payment validation successful");
 
         FRDomesticScheduledPaymentSubmission frPaymentSubmission = FRDomesticScheduledPaymentSubmission.builder()
@@ -168,15 +162,7 @@ public class DomesticScheduledPaymentsApiController implements DomesticScheduled
         FRScheduledPaymentData scheduledPaymentData = FRScheduledPaymentDataFactory.createFRScheduledPaymentData(frScheduledPayment, xAccountId);
         scheduledPaymentService.createScheduledPayment(scheduledPaymentData);
 
-        OBWriteDomesticScheduledResponse5 entity = responseEntity(
-                frPaymentSubmission,
-                obConsentResponse
-        );
-
-        // update the entity with refund
-        setRefund(obConsentResponse.getData().getReadRefundAccount(), intent, entity);
-
-        return ResponseEntity.status(CREATED).body(entity);
+        return ResponseEntity.status(CREATED).body(responseEntity(consent, frPaymentSubmission));
     }
 
     @Override
@@ -187,6 +173,7 @@ public class DomesticScheduledPaymentsApiController implements DomesticScheduled
             String xFapiCustomerIpAddress,
             String xFapiInteractionId,
             String xCustomerUserAgent,
+            String apiClientId,
             HttpServletRequest request,
             Principal principal
     ) {
@@ -202,25 +189,10 @@ public class DomesticScheduledPaymentsApiController implements DomesticScheduled
             return PaymentApiResponseUtil.resourceConflictResponse(frPaymentSubmission, apiVersion);
         }
         // Get the consent to update the response
-        JsonObject intent = consentService.getIDMIntent(authorization, frPaymentSubmission.getConsentId());
-        log.debug("Retrieved consent from IDM");
+        final DomesticScheduledPaymentConsent consent = consentStoreClient.getConsent(frPaymentSubmission.getConsentId(), apiClientId);
+        log.debug("Got consent from store: {}", consent);
 
-        // deserialize the intent to ob response object
-        OBWriteDomesticScheduledConsentResponse5 obConsentResponse = consentService.deserialize(
-                OBWriteDomesticScheduledConsentResponse5.class,
-                intent.getAsJsonObject("OBIntentObject"),
-                frPaymentSubmission.getConsentId()
-        );
-
-        OBWriteDomesticScheduledResponse5 entity = responseEntity(
-                frPaymentSubmission,
-                obConsentResponse
-        );
-
-        // update the entity with refund
-        setRefund(obConsentResponse.getData().getReadRefundAccount(), intent, entity);
-
-        return ResponseEntity.ok(entity);
+        return ResponseEntity.ok(responseEntity(consent, frPaymentSubmission));
     }
 
     @Override
@@ -231,8 +203,10 @@ public class DomesticScheduledPaymentsApiController implements DomesticScheduled
             String xFapiCustomerIpAddress,
             String xFapiInteractionId,
             String xCustomerUserAgent,
+            String apiClientId,
             HttpServletRequest request,
             Principal principal) {
+
         Optional<FRDomesticScheduledPaymentSubmission> isPaymentSubmission = scheduledPaymentSubmissionRepository.findById(domesticScheduledPaymentId);
         if (!isPaymentSubmission.isPresent()) {
             return ResponseEntity.status(BAD_REQUEST).body("Payment submission '" + domesticScheduledPaymentId + "' can't be found");
@@ -250,13 +224,22 @@ public class DomesticScheduledPaymentsApiController implements DomesticScheduled
     }
 
     private OBWriteDomesticScheduledResponse5 responseEntity(
-            FRDomesticScheduledPaymentSubmission frPaymentSubmission,
-            OBWriteDomesticScheduledConsentResponse5 obConsent
+            DomesticScheduledPaymentConsent consent,
+            FRDomesticScheduledPaymentSubmission frPaymentSubmission
     ) {
+
+        final Optional<FRResponseDataRefund> refundAccountData;
+        if (consent.getRequestObj().getData().getReadRefundAccount() == FRReadRefundAccount.YES) {
+            final FRAccount debtorAccount = accountRepository.byAccountId(consent.getAuthorisedDebtorAccountId());
+            refundAccountData = FRResponseDataRefundFactory.frResponseDataRefund(debtorAccount.getAccount().getFirstAccount());
+        } else {
+            refundAccountData = Optional.empty();
+        }
+
         FRWriteDataDomesticScheduled data = frPaymentSubmission.getScheduledPayment().getData();
         return new OBWriteDomesticScheduledResponse5()
                 .data(new OBWriteDomesticScheduledResponse5Data()
-                        .charges(obConsent.getData().getCharges())
+                        .charges(toOBWriteDomesticConsentResponse5DataCharges(consent.getCharges()))
                         .domesticScheduledPaymentId(frPaymentSubmission.getId())
                         .initiation(toOBWriteDomesticScheduled2DataInitiation(data.getInitiation()))
                         .creationDateTime(frPaymentSubmission.getCreated())
@@ -264,6 +247,7 @@ public class DomesticScheduledPaymentsApiController implements DomesticScheduled
                         .status(toOBWriteDomesticScheduledResponse5DataStatus(frPaymentSubmission.getStatus()))
                         .consentId(data.getConsentId())
                         .debtor(toOBCashAccountDebtor4(data.getInitiation().getDebtorAccount()))
+                        .refund(refundAccountData.map(FRResponseDataRefundConverter::toOBWriteDomesticResponse5DataRefund).orElse(null))
                 )
                 .links(LinksHelper.createDomesticScheduledPaymentLink(this.getClass(), frPaymentSubmission.getId()))
                 .meta(new Meta());
@@ -308,7 +292,7 @@ public class DomesticScheduledPaymentsApiController implements DomesticScheduled
             String accountId = Objects.nonNull(intent.get("accountId")) ? intent.get("accountId").getAsString() : null;
             log.debug("Account Id from consent '{}'", accountId);
             if (Objects.nonNull(accountId)) {
-                FRAccount frAccount = Objects.nonNull(accountId) ? frAccountRepository.byAccountId(accountId) : null;
+                FRAccount frAccount = Objects.nonNull(accountId) ? accountRepository.byAccountId(accountId) : null;
                 FRAccountIdentifier frAccountIdentifier = Objects.nonNull(frAccount) ?
                         frAccount.getAccount().getFirstAccount() :
                         null;

--- a/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/v3_1_6/domesticpayments/DomesticPaymentsApiController.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/v3_1_6/domesticpayments/DomesticPaymentsApiController.java
@@ -23,7 +23,6 @@ package com.forgerock.sapi.gateway.ob.uk.rs.server.api.obie.payment.v3_1_6.domes
 import org.springframework.stereotype.Controller;
 
 import com.forgerock.sapi.gateway.ob.uk.rs.obie.api.payment.v3_1_6.domesticpayments.DomesticPaymentsApi;
-import com.forgerock.sapi.gateway.ob.uk.rs.server.api.obie.payment.factories.OBWriteDomesticConsentResponse5Factory;
 import com.forgerock.sapi.gateway.ob.uk.rs.server.persistence.repository.accounts.accounts.FRAccountRepository;
 import com.forgerock.sapi.gateway.ob.uk.rs.server.persistence.repository.payments.DomesticPaymentSubmissionRepository;
 import com.forgerock.sapi.gateway.ob.uk.rs.server.validator.PaymentSubmissionValidator;
@@ -44,8 +43,7 @@ public class DomesticPaymentsApiController
             PaymentSubmissionValidator paymentSubmissionValidator,
             OBValidationService<OBWriteDomestic2ValidationContext> paymentValidator,
             DomesticPaymentConsentStoreClient consentApiClient,
-            OBWriteDomesticConsentResponse5Factory consentResponseFactory,
             FRAccountRepository frAccountRepository) {
-        super(paymentSubmissionRepository, paymentSubmissionValidator, paymentValidator, consentApiClient, consentResponseFactory, frAccountRepository);
+        super(paymentSubmissionRepository, paymentSubmissionValidator, paymentValidator, consentApiClient, frAccountRepository);
     }
 }

--- a/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/v3_1_6/domesticscheduledpayments/DomesticScheduledPaymentsApiController.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/v3_1_6/domesticscheduledpayments/DomesticScheduledPaymentsApiController.java
@@ -21,12 +21,14 @@
 package com.forgerock.sapi.gateway.ob.uk.rs.server.api.obie.payment.v3_1_6.domesticscheduledpayments;
 
 import com.forgerock.sapi.gateway.ob.uk.rs.obie.api.payment.v3_1_6.domesticscheduledpayments.DomesticScheduledPaymentsApi;
-import com.forgerock.sapi.gateway.ob.uk.rs.server.api.obie.payment.services.ConsentService;
-import com.forgerock.sapi.gateway.ob.uk.rs.server.api.obie.payment.services.validation.RiskValidationService;
 import com.forgerock.sapi.gateway.ob.uk.rs.server.persistence.repository.accounts.accounts.FRAccountRepository;
 import com.forgerock.sapi.gateway.ob.uk.rs.server.persistence.repository.payments.DomesticScheduledPaymentSubmissionRepository;
 import com.forgerock.sapi.gateway.ob.uk.rs.server.service.scheduledpayment.ScheduledPaymentService;
 import com.forgerock.sapi.gateway.ob.uk.rs.server.validator.PaymentSubmissionValidator;
+import com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.OBValidationService;
+import com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.payment.OBWriteDomesticScheduled2Validator.OBWriteDomesticScheduled2ValidationContext;
+import com.forgerock.sapi.gateway.rcs.conent.store.client.payment.domesticscheduled.v3_1_10.DomesticScheduledPaymentConsentStoreClient;
+
 import org.springframework.stereotype.Controller;
 
 @Controller("DomesticScheduledPaymentsApiV3.1.6")
@@ -36,17 +38,17 @@ public class DomesticScheduledPaymentsApiController extends com.forgerock.sapi.g
             DomesticScheduledPaymentSubmissionRepository scheduledPaymentSubmissionRepository,
             PaymentSubmissionValidator paymentSubmissionValidator,
             ScheduledPaymentService scheduledPaymentService,
-            ConsentService consentService,
-            RiskValidationService riskValidationService,
-            FRAccountRepository frAccountRepository
+            DomesticScheduledPaymentConsentStoreClient consentStoreClient,
+            FRAccountRepository accountRepository,
+            OBValidationService<OBWriteDomesticScheduled2ValidationContext> paymentValidator
     ) {
         super(
                 scheduledPaymentSubmissionRepository,
                 paymentSubmissionValidator,
                 scheduledPaymentService,
-                consentService,
-                riskValidationService,
-                frAccountRepository
+                consentStoreClient,
+                accountRepository,
+                paymentValidator
         );
     }
 }

--- a/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/v3_1_7/domesticpayments/DomesticPaymentsApiController.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/v3_1_7/domesticpayments/DomesticPaymentsApiController.java
@@ -23,7 +23,6 @@ package com.forgerock.sapi.gateway.ob.uk.rs.server.api.obie.payment.v3_1_7.domes
 import org.springframework.stereotype.Controller;
 
 import com.forgerock.sapi.gateway.ob.uk.rs.obie.api.payment.v3_1_7.domesticpayments.DomesticPaymentsApi;
-import com.forgerock.sapi.gateway.ob.uk.rs.server.api.obie.payment.factories.OBWriteDomesticConsentResponse5Factory;
 import com.forgerock.sapi.gateway.ob.uk.rs.server.persistence.repository.accounts.accounts.FRAccountRepository;
 import com.forgerock.sapi.gateway.ob.uk.rs.server.persistence.repository.payments.DomesticPaymentSubmissionRepository;
 import com.forgerock.sapi.gateway.ob.uk.rs.server.validator.PaymentSubmissionValidator;
@@ -44,8 +43,7 @@ public class DomesticPaymentsApiController
             PaymentSubmissionValidator paymentSubmissionValidator,
             OBValidationService<OBWriteDomestic2ValidationContext> paymentValidator,
             DomesticPaymentConsentStoreClient consentApiClient,
-            OBWriteDomesticConsentResponse5Factory consentResponseFactory,
             FRAccountRepository frAccountRepository) {
-        super(paymentSubmissionRepository, paymentSubmissionValidator, paymentValidator, consentApiClient, consentResponseFactory, frAccountRepository);
+        super(paymentSubmissionRepository, paymentSubmissionValidator, paymentValidator, consentApiClient, frAccountRepository);
     }
 }

--- a/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/v3_1_7/domesticscheduledpayments/DomesticScheduledPaymentsApiController.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/v3_1_7/domesticscheduledpayments/DomesticScheduledPaymentsApiController.java
@@ -21,12 +21,14 @@
 package com.forgerock.sapi.gateway.ob.uk.rs.server.api.obie.payment.v3_1_7.domesticscheduledpayments;
 
 import com.forgerock.sapi.gateway.ob.uk.rs.obie.api.payment.v3_1_7.domesticscheduledpayments.DomesticScheduledPaymentsApi;
-import com.forgerock.sapi.gateway.ob.uk.rs.server.api.obie.payment.services.ConsentService;
-import com.forgerock.sapi.gateway.ob.uk.rs.server.api.obie.payment.services.validation.RiskValidationService;
 import com.forgerock.sapi.gateway.ob.uk.rs.server.persistence.repository.accounts.accounts.FRAccountRepository;
 import com.forgerock.sapi.gateway.ob.uk.rs.server.persistence.repository.payments.DomesticScheduledPaymentSubmissionRepository;
 import com.forgerock.sapi.gateway.ob.uk.rs.server.service.scheduledpayment.ScheduledPaymentService;
 import com.forgerock.sapi.gateway.ob.uk.rs.server.validator.PaymentSubmissionValidator;
+import com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.OBValidationService;
+import com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.payment.OBWriteDomesticScheduled2Validator.OBWriteDomesticScheduled2ValidationContext;
+import com.forgerock.sapi.gateway.rcs.conent.store.client.payment.domesticscheduled.v3_1_10.DomesticScheduledPaymentConsentStoreClient;
+
 import org.springframework.stereotype.Controller;
 
 @Controller("DomesticScheduledPaymentsApiV3.1.7")
@@ -36,17 +38,17 @@ public class DomesticScheduledPaymentsApiController extends com.forgerock.sapi.g
             DomesticScheduledPaymentSubmissionRepository scheduledPaymentSubmissionRepository,
             PaymentSubmissionValidator paymentSubmissionValidator,
             ScheduledPaymentService scheduledPaymentService,
-            ConsentService consentService,
-            RiskValidationService riskValidationService,
-            FRAccountRepository frAccountRepository
+            DomesticScheduledPaymentConsentStoreClient consentStoreClient,
+            FRAccountRepository accountRepository,
+            OBValidationService<OBWriteDomesticScheduled2ValidationContext> paymentValidator
     ) {
         super(
                 scheduledPaymentSubmissionRepository,
                 paymentSubmissionValidator,
                 scheduledPaymentService,
-                consentService,
-                riskValidationService,
-                frAccountRepository
+                consentStoreClient,
+                accountRepository,
+                paymentValidator
         );
     }
 }

--- a/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/v3_1_8/domesticpayments/DomesticPaymentsApiController.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/v3_1_8/domesticpayments/DomesticPaymentsApiController.java
@@ -23,7 +23,6 @@ package com.forgerock.sapi.gateway.ob.uk.rs.server.api.obie.payment.v3_1_8.domes
 import org.springframework.stereotype.Controller;
 
 import com.forgerock.sapi.gateway.ob.uk.rs.obie.api.payment.v3_1_8.domesticpayments.DomesticPaymentsApi;
-import com.forgerock.sapi.gateway.ob.uk.rs.server.api.obie.payment.factories.OBWriteDomesticConsentResponse5Factory;
 import com.forgerock.sapi.gateway.ob.uk.rs.server.persistence.repository.accounts.accounts.FRAccountRepository;
 import com.forgerock.sapi.gateway.ob.uk.rs.server.persistence.repository.payments.DomesticPaymentSubmissionRepository;
 import com.forgerock.sapi.gateway.ob.uk.rs.server.validator.PaymentSubmissionValidator;
@@ -44,8 +43,7 @@ public class DomesticPaymentsApiController
             PaymentSubmissionValidator paymentSubmissionValidator,
             OBValidationService<OBWriteDomestic2ValidationContext> paymentValidator,
             DomesticPaymentConsentStoreClient consentApiClient,
-            OBWriteDomesticConsentResponse5Factory consentResponseFactory,
             FRAccountRepository frAccountRepository) {
-        super(paymentSubmissionRepository, paymentSubmissionValidator, paymentValidator, consentApiClient, consentResponseFactory, frAccountRepository);
+        super(paymentSubmissionRepository, paymentSubmissionValidator, paymentValidator, consentApiClient, frAccountRepository);
     }
 }

--- a/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/v3_1_8/domesticscheduledpayments/DomesticScheduledPaymentsApiController.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/v3_1_8/domesticscheduledpayments/DomesticScheduledPaymentsApiController.java
@@ -21,12 +21,14 @@
 package com.forgerock.sapi.gateway.ob.uk.rs.server.api.obie.payment.v3_1_8.domesticscheduledpayments;
 
 import com.forgerock.sapi.gateway.ob.uk.rs.obie.api.payment.v3_1_8.domesticscheduledpayments.DomesticScheduledPaymentsApi;
-import com.forgerock.sapi.gateway.ob.uk.rs.server.api.obie.payment.services.ConsentService;
-import com.forgerock.sapi.gateway.ob.uk.rs.server.api.obie.payment.services.validation.RiskValidationService;
 import com.forgerock.sapi.gateway.ob.uk.rs.server.persistence.repository.accounts.accounts.FRAccountRepository;
 import com.forgerock.sapi.gateway.ob.uk.rs.server.persistence.repository.payments.DomesticScheduledPaymentSubmissionRepository;
 import com.forgerock.sapi.gateway.ob.uk.rs.server.service.scheduledpayment.ScheduledPaymentService;
 import com.forgerock.sapi.gateway.ob.uk.rs.server.validator.PaymentSubmissionValidator;
+import com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.OBValidationService;
+import com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.payment.OBWriteDomesticScheduled2Validator.OBWriteDomesticScheduled2ValidationContext;
+import com.forgerock.sapi.gateway.rcs.conent.store.client.payment.domesticscheduled.v3_1_10.DomesticScheduledPaymentConsentStoreClient;
+
 import org.springframework.stereotype.Controller;
 
 @Controller("DomesticScheduledPaymentsApiV3.1.8")
@@ -36,17 +38,17 @@ public class DomesticScheduledPaymentsApiController extends com.forgerock.sapi.g
             DomesticScheduledPaymentSubmissionRepository scheduledPaymentSubmissionRepository,
             PaymentSubmissionValidator paymentSubmissionValidator,
             ScheduledPaymentService scheduledPaymentService,
-            ConsentService consentService,
-            RiskValidationService riskValidationService,
-            FRAccountRepository frAccountRepository
+            DomesticScheduledPaymentConsentStoreClient consentStoreClient,
+            FRAccountRepository accountRepository,
+            OBValidationService<OBWriteDomesticScheduled2ValidationContext> paymentValidator
     ) {
         super(
                 scheduledPaymentSubmissionRepository,
                 paymentSubmissionValidator,
                 scheduledPaymentService,
-                consentService,
-                riskValidationService,
-                frAccountRepository
+                consentStoreClient,
+                accountRepository,
+                paymentValidator
         );
     }
 }

--- a/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/v3_1_9/domesticpayments/DomesticPaymentsApiController.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/v3_1_9/domesticpayments/DomesticPaymentsApiController.java
@@ -23,7 +23,6 @@ package com.forgerock.sapi.gateway.ob.uk.rs.server.api.obie.payment.v3_1_9.domes
 import org.springframework.stereotype.Controller;
 
 import com.forgerock.sapi.gateway.ob.uk.rs.obie.api.payment.v3_1_9.domesticpayments.DomesticPaymentsApi;
-import com.forgerock.sapi.gateway.ob.uk.rs.server.api.obie.payment.factories.OBWriteDomesticConsentResponse5Factory;
 import com.forgerock.sapi.gateway.ob.uk.rs.server.persistence.repository.accounts.accounts.FRAccountRepository;
 import com.forgerock.sapi.gateway.ob.uk.rs.server.persistence.repository.payments.DomesticPaymentSubmissionRepository;
 import com.forgerock.sapi.gateway.ob.uk.rs.server.validator.PaymentSubmissionValidator;
@@ -44,8 +43,7 @@ public class DomesticPaymentsApiController
             PaymentSubmissionValidator paymentSubmissionValidator,
             OBValidationService<OBWriteDomestic2ValidationContext> paymentValidator,
             DomesticPaymentConsentStoreClient consentApiClient,
-            OBWriteDomesticConsentResponse5Factory consentResponseFactory,
             FRAccountRepository frAccountRepository) {
-        super(paymentSubmissionRepository, paymentSubmissionValidator, paymentValidator, consentApiClient, consentResponseFactory, frAccountRepository);
+        super(paymentSubmissionRepository, paymentSubmissionValidator, paymentValidator, consentApiClient, frAccountRepository);
     }
 }

--- a/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/v3_1_9/domesticscheduledpayments/DomesticScheduledPaymentsApiController.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/v3_1_9/domesticscheduledpayments/DomesticScheduledPaymentsApiController.java
@@ -21,12 +21,14 @@
 package com.forgerock.sapi.gateway.ob.uk.rs.server.api.obie.payment.v3_1_9.domesticscheduledpayments;
 
 import com.forgerock.sapi.gateway.ob.uk.rs.obie.api.payment.v3_1_9.domesticscheduledpayments.DomesticScheduledPaymentsApi;
-import com.forgerock.sapi.gateway.ob.uk.rs.server.api.obie.payment.services.ConsentService;
-import com.forgerock.sapi.gateway.ob.uk.rs.server.api.obie.payment.services.validation.RiskValidationService;
 import com.forgerock.sapi.gateway.ob.uk.rs.server.persistence.repository.accounts.accounts.FRAccountRepository;
 import com.forgerock.sapi.gateway.ob.uk.rs.server.persistence.repository.payments.DomesticScheduledPaymentSubmissionRepository;
 import com.forgerock.sapi.gateway.ob.uk.rs.server.service.scheduledpayment.ScheduledPaymentService;
 import com.forgerock.sapi.gateway.ob.uk.rs.server.validator.PaymentSubmissionValidator;
+import com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.OBValidationService;
+import com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.payment.OBWriteDomesticScheduled2Validator.OBWriteDomesticScheduled2ValidationContext;
+import com.forgerock.sapi.gateway.rcs.conent.store.client.payment.domesticscheduled.v3_1_10.DomesticScheduledPaymentConsentStoreClient;
+
 import org.springframework.stereotype.Controller;
 
 @Controller("DomesticScheduledPaymentsApiV3.1.9")
@@ -36,17 +38,17 @@ public class DomesticScheduledPaymentsApiController extends com.forgerock.sapi.g
             DomesticScheduledPaymentSubmissionRepository scheduledPaymentSubmissionRepository,
             PaymentSubmissionValidator paymentSubmissionValidator,
             ScheduledPaymentService scheduledPaymentService,
-            ConsentService consentService,
-            RiskValidationService riskValidationService,
-            FRAccountRepository frAccountRepository
+            DomesticScheduledPaymentConsentStoreClient consentStoreClient,
+            FRAccountRepository accountRepository,
+            OBValidationService<OBWriteDomesticScheduled2ValidationContext> paymentValidator
     ) {
         super(
                 scheduledPaymentSubmissionRepository,
                 paymentSubmissionValidator,
                 scheduledPaymentService,
-                consentService,
-                riskValidationService,
-                frAccountRepository
+                consentStoreClient,
+                accountRepository,
+                paymentValidator
         );
     }
 }

--- a/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/common/util/link/LinksHelper.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/common/util/link/LinksHelper.java
@@ -30,6 +30,7 @@ public class LinksHelper {
     private static final String DOMESTIC_PAYMENT_CONSENTS = "domestic-payment-consents";
     private static final String DOMESTIC_PAYMENTS = "domestic-payments";
     private static final String DOMESTIC_PAYMENTS_DETAILS = "payment-details";
+    private static final String DOMESTIC_SCHEDULED_PAYMENT_CONSENTS = "domestic-scheduled-payment-consents";
     private static final String DOMESTIC_SCHEDULED_PAYMENTS = "domestic-scheduled-payments";
     private static final String DOMESTIC_STANDING_ORDER = "domestic-standing-orders";
     private static final String FILE_PAYMENTS = "file-payments";
@@ -79,6 +80,11 @@ public class LinksHelper {
      */
     public static Links createDomesticPaymentDetailsLink(Class<?> controllerClass, String id) {
         return createSelfLink(controllerClass, DOMESTIC_PAYMENTS, id, DOMESTIC_PAYMENTS_DETAILS);
+    }
+
+
+    public static Links createDomesticScheduledPaymentConsentsLink(Class<?> controllerClass, String id) {
+        return createSelfLink(controllerClass, DOMESTIC_SCHEDULED_PAYMENT_CONSENTS, id);
     }
 
     /**

--- a/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/configuration/validation/DefaultOBValidationModule.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/configuration/validation/DefaultOBValidationModule.java
@@ -23,15 +23,20 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 import com.forgerock.sapi.gateway.ob.uk.rs.server.common.Currencies;
+import com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.BaseOBValidator;
 import com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.OBValidationService;
 import com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.payment.OBDomesticVRPRequestValidator;
 import com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.payment.OBDomesticVRPRequestValidator.OBDomesticVRPRequestValidationContext;
+import com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.payment.OBWriteDomestic2DataInitiationInstructedAmountValidator;
 import com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.payment.OBWriteDomestic2Validator;
 import com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.payment.OBWriteDomestic2Validator.OBWriteDomestic2ValidationContext;
 import com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.payment.consent.OBDomesticVRPConsentRequestValidator;
 import com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.payment.consent.OBWriteDomesticConsent4Validator;
+import com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.payment.consent.OBWriteDomesticScheduledConsent4Validator;
 
+import uk.org.openbanking.datamodel.payment.OBWriteDomestic2DataInitiationInstructedAmount;
 import uk.org.openbanking.datamodel.payment.OBWriteDomesticConsent4;
+import uk.org.openbanking.datamodel.payment.OBWriteDomesticScheduledConsent4;
 import uk.org.openbanking.datamodel.vrp.OBDomesticVRPConsentRequest;
 
 /**
@@ -58,8 +63,18 @@ public class DefaultOBValidationModule {
     }
 
     @Bean
-    public OBValidationService<OBWriteDomesticConsent4> domesticPaymentConsentValidator() {
-        return new OBValidationService<>(new OBWriteDomesticConsent4Validator(Arrays.stream(Currencies.values()).map(Currencies::getCode).collect(Collectors.toSet())));
+    public OBValidationService<OBWriteDomesticConsent4> domesticPaymentConsentValidator(BaseOBValidator<OBWriteDomestic2DataInitiationInstructedAmount> instructedAmountValidator) {
+        return new OBValidationService<>(new OBWriteDomesticConsent4Validator(instructedAmountValidator));
+    }
+
+    @Bean
+    public BaseOBValidator<OBWriteDomestic2DataInitiationInstructedAmount> instructedAmountValidator() {
+        return new OBWriteDomestic2DataInitiationInstructedAmountValidator(Arrays.stream(Currencies.values()).map(Currencies::getCode).collect(Collectors.toSet()));
+    }
+
+    @Bean
+    public OBValidationService<OBWriteDomesticScheduledConsent4> domesticScheduledPaymentConsentValidator(BaseOBValidator<OBWriteDomestic2DataInitiationInstructedAmount> instructedAmountValidator) {
+        return new OBValidationService<>(new OBWriteDomesticScheduledConsent4Validator(instructedAmountValidator));
     }
 
     @Bean

--- a/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/configuration/validation/DefaultOBValidationModule.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/configuration/validation/DefaultOBValidationModule.java
@@ -30,6 +30,8 @@ import com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.payment.OBDomesticVRP
 import com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.payment.OBWriteDomestic2DataInitiationInstructedAmountValidator;
 import com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.payment.OBWriteDomestic2Validator;
 import com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.payment.OBWriteDomestic2Validator.OBWriteDomestic2ValidationContext;
+import com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.payment.OBWriteDomesticScheduled2Validator;
+import com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.payment.OBWriteDomesticScheduled2Validator.OBWriteDomesticScheduled2ValidationContext;
 import com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.payment.consent.OBDomesticVRPConsentRequestValidator;
 import com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.payment.consent.OBWriteDomesticConsent4Validator;
 import com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.payment.consent.OBWriteDomesticScheduledConsent4Validator;
@@ -75,6 +77,11 @@ public class DefaultOBValidationModule {
     @Bean
     public OBValidationService<OBWriteDomesticScheduledConsent4> domesticScheduledPaymentConsentValidator(BaseOBValidator<OBWriteDomestic2DataInitiationInstructedAmount> instructedAmountValidator) {
         return new OBValidationService<>(new OBWriteDomesticScheduledConsent4Validator(instructedAmountValidator));
+    }
+
+    @Bean
+    public OBValidationService<OBWriteDomesticScheduled2ValidationContext> domesticScheduledPaymentValidator() {
+        return new OBValidationService<>(new OBWriteDomesticScheduled2Validator());
     }
 
     @Bean

--- a/secure-api-gateway-ob-uk-rs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/factories/OBWriteDomesticScheduledConsentResponse5FactoryTest.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/factories/OBWriteDomesticScheduledConsentResponse5FactoryTest.java
@@ -36,7 +36,7 @@ class OBWriteDomesticScheduledConsentResponse5FactoryTest {
     private final OBWriteDomesticScheduledConsentResponse5Factory factory = new OBWriteDomesticScheduledConsentResponse5Factory();
 
     @Test
-    void testCreateOBWriteDomesticConsentResponse5() {
+    void testCreateConsentResponse() {
         final OBWriteDomesticScheduledConsent4 consentRequest = OBWriteDomesticScheduledConsentTestDataFactory.aValidOBWriteDomesticScheduledConsent4();
         final OBWriteDomesticScheduledConsent4Data requestData = consentRequest.getData();
         final DomesticScheduledPaymentConsent consent = DomesticScheduledPaymentConsentsApiControllerTest.buildAwaitingAuthorisationConsent(consentRequest);

--- a/secure-api-gateway-ob-uk-rs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/factories/OBWriteDomesticScheduledConsentResponse5FactoryTest.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/factories/OBWriteDomesticScheduledConsentResponse5FactoryTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.ob.uk.rs.server.api.obie.payment.factories;
+
+import static com.forgerock.sapi.gateway.ob.uk.rs.server.util.BeanValidationTestUtils.verifyBeanValidationIsSuccessful;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+import com.forgerock.sapi.gateway.ob.uk.rs.obie.api.payment.v3_1_10.domesticscheduledpayments.DomesticScheduledPaymentConsentsApi;
+import com.forgerock.sapi.gateway.ob.uk.rs.server.api.obie.payment.v3_1_10.domesticscheduledpayments.DomesticScheduledPaymentConsentsApiControllerTest;
+import com.forgerock.sapi.gateway.rcs.conent.store.datamodel.payment.domesticscheduled.v3_1_10.DomesticScheduledPaymentConsent;
+
+import uk.org.openbanking.datamodel.payment.OBWriteDomesticScheduledConsent4;
+import uk.org.openbanking.datamodel.payment.OBWriteDomesticScheduledConsent4Data;
+import uk.org.openbanking.datamodel.payment.OBWriteDomesticScheduledConsentResponse5;
+import uk.org.openbanking.datamodel.payment.OBWriteDomesticScheduledConsentResponse5Data;
+import uk.org.openbanking.datamodel.payment.OBWriteDomesticScheduledConsentResponse5Data.StatusEnum;
+import uk.org.openbanking.testsupport.payment.OBWriteDomesticScheduledConsentTestDataFactory;
+
+class OBWriteDomesticScheduledConsentResponse5FactoryTest {
+
+    private final OBWriteDomesticScheduledConsentResponse5Factory factory = new OBWriteDomesticScheduledConsentResponse5Factory();
+
+    @Test
+    void testCreateOBWriteDomesticConsentResponse5() {
+        final OBWriteDomesticScheduledConsent4 consentRequest = OBWriteDomesticScheduledConsentTestDataFactory.aValidOBWriteDomesticScheduledConsent4();
+        final OBWriteDomesticScheduledConsent4Data requestData = consentRequest.getData();
+        final DomesticScheduledPaymentConsent consent = DomesticScheduledPaymentConsentsApiControllerTest.buildAwaitingAuthorisationConsent(consentRequest);
+        final OBWriteDomesticScheduledConsentResponse5 response = factory.buildConsentResponse(consent, DomesticScheduledPaymentConsentsApi.class);
+
+        final OBWriteDomesticScheduledConsentResponse5Data responseData = response.getData();
+        assertThat(responseData.getStatus()).isEqualTo(StatusEnum.AWAITINGAUTHORISATION);
+        assertThat(responseData.getConsentId()).isEqualTo(consent.getId());
+        assertThat(responseData.getCreationDateTime()).isEqualTo(consent.getCreationDateTime());
+        assertThat(responseData.getStatusUpdateDateTime()).isEqualTo(consent.getStatusUpdateDateTime());
+        assertThat(responseData.getCharges()).isEqualTo(consent.getCharges());
+
+        // Verify data against original Consent Request
+        assertThat(responseData.getScASupportData()).isEqualTo(requestData.getScASupportData());
+        assertThat(responseData.getReadRefundAccount()).isEqualTo(requestData.getReadRefundAccount());
+        assertThat(responseData.getAuthorisation()).isEqualTo(requestData.getAuthorisation());
+        assertThat(responseData.getInitiation()).isEqualTo(requestData.getInitiation());
+        assertThat(responseData.getPermission()).isEqualTo(requestData.getPermission());
+
+        // Not currently generating data for these optional response fields
+        assertThat(responseData.getCutOffDateTime()).isNull();
+        assertThat(responseData.getExpectedExecutionDateTime()).isNull();
+        assertThat(responseData.getExpectedExecutionDateTime()).isNull();
+
+        assertThat(response.getRisk()).isEqualTo(consentRequest.getRisk());
+        assertThat(response.getLinks().getSelf().toString())
+                .endsWith("/open-banking/v3.1.10/pisp/domestic-scheduled-payment-consents/" + consent.getId());
+        assertThat(response.getMeta()).isNotNull();
+
+        verifyBeanValidationIsSuccessful(response);
+    }
+}

--- a/secure-api-gateway-ob-uk-rs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/v3_1_10/domesticscheduledpayments/DomesticScheduledPaymentConsentsApiControllerTest.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/v3_1_10/domesticscheduledpayments/DomesticScheduledPaymentConsentsApiControllerTest.java
@@ -1,0 +1,212 @@
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.ob.uk.rs.server.api.obie.payment.v3_1_10.domesticscheduledpayments;
+
+import static com.forgerock.sapi.gateway.ob.uk.common.error.ErrorCode.OBRI_CONSENT_NOT_FOUND;
+import static com.forgerock.sapi.gateway.ob.uk.common.error.ErrorCode.OBRI_PERMISSION_INVALID;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
+
+import java.util.List;
+
+import javax.annotation.PostConstruct;
+
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.ActiveProfiles;
+
+import com.forgerock.sapi.gateway.ob.uk.common.datamodel.converter.payment.FRWriteDomesticScheduledConsentConverter;
+import com.forgerock.sapi.gateway.ob.uk.common.error.ErrorCode;
+import com.forgerock.sapi.gateway.ob.uk.rs.server.testsupport.api.HttpHeadersTestDataFactory;
+import com.forgerock.sapi.gateway.rcs.conent.store.client.ConsentStoreClientException;
+import com.forgerock.sapi.gateway.rcs.conent.store.client.ConsentStoreClientException.ErrorType;
+import com.forgerock.sapi.gateway.rcs.conent.store.client.payment.domesticscheduled.v3_1_10.DomesticScheduledPaymentConsentStoreClient;
+import com.forgerock.sapi.gateway.rcs.conent.store.datamodel.payment.domesticscheduled.v3_1_10.CreateDomesticScheduledPaymentConsentRequest;
+import com.forgerock.sapi.gateway.rcs.conent.store.datamodel.payment.domesticscheduled.v3_1_10.DomesticScheduledPaymentConsent;
+import com.forgerock.sapi.gateway.uk.common.shared.api.meta.share.IntentType;
+
+import uk.org.openbanking.datamodel.error.OBError1;
+import uk.org.openbanking.datamodel.error.OBErrorResponse1;
+import uk.org.openbanking.datamodel.error.OBStandardErrorCodes1;
+import uk.org.openbanking.datamodel.payment.OBWriteDomesticScheduledConsent4;
+import uk.org.openbanking.datamodel.payment.OBWriteDomesticScheduledConsentResponse5;
+import uk.org.openbanking.datamodel.payment.OBWriteDomesticScheduledConsentResponse5Data.StatusEnum;
+import uk.org.openbanking.testsupport.payment.OBWriteDomesticScheduledConsentTestDataFactory;
+
+@SpringBootTest(webEnvironment = RANDOM_PORT)
+@ActiveProfiles("test")
+public class DomesticScheduledPaymentConsentsApiControllerTest {
+
+    private static final String TEST_API_CLIENT_ID = "client_234093-49";
+
+    private static final HttpHeaders HTTP_HEADERS = HttpHeadersTestDataFactory.requiredPaymentsHttpHeadersWithApiClientId(TEST_API_CLIENT_ID);
+
+    @LocalServerPort
+    private int port;
+
+    @Autowired
+    private TestRestTemplate restTemplate;
+
+    @MockBean
+    private DomesticScheduledPaymentConsentStoreClient consentStoreClient;
+
+    private String controllerBaseUri;
+
+    @PostConstruct
+    public void postConstruct() {
+        controllerBaseUri = "http://localhost:" + port + "/open-banking/v3.1.10/pisp/domestic-scheduled-payment-consents";
+    }
+
+
+    @Test
+    public void testCreateConsent() {
+        final OBWriteDomesticScheduledConsent4 consentRequest = createValidateConsentRequest();
+        final DomesticScheduledPaymentConsent consentStoreResponse = buildAwaitingAuthorisationConsent(consentRequest);
+        when(consentStoreClient.createConsent(any())).thenAnswer(invocation -> {
+            final CreateDomesticScheduledPaymentConsentRequest createConsentArg = invocation.getArgument(0, CreateDomesticScheduledPaymentConsentRequest.class);
+            assertThat(createConsentArg.getApiClientId()).isEqualTo(TEST_API_CLIENT_ID);
+            assertThat(createConsentArg.getConsentRequest()).isEqualTo(FRWriteDomesticScheduledConsentConverter.toFRWriteDomesticScheduledConsent(consentRequest));
+            assertThat(createConsentArg.getCharges()).isEmpty();
+            assertThat(createConsentArg.getIdempotencyKey()).isEqualTo(HTTP_HEADERS.getFirst("x-idempotency-key"));
+
+            return consentStoreResponse;
+        });
+
+        final HttpEntity<OBWriteDomesticScheduledConsent4> entity = new HttpEntity<>(consentRequest, HTTP_HEADERS);
+
+        final ResponseEntity<OBWriteDomesticScheduledConsentResponse5> createResponse = restTemplate.exchange(controllerBaseUri, HttpMethod.POST,
+                                                                                                              entity, OBWriteDomesticScheduledConsentResponse5.class);
+        assertThat(createResponse.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+        final OBWriteDomesticScheduledConsentResponse5 consentResponse = createResponse.getBody();
+        final String consentId = consentResponse.getData().getConsentId();
+        assertThat(consentId).isEqualTo(consentStoreResponse.getId());
+        assertThat(consentResponse.getData().getStatus()).isEqualTo(StatusEnum.AWAITINGAUTHORISATION);
+        assertThat(consentResponse.getData().getInitiation()).isEqualTo(consentRequest.getData().getInitiation());
+        assertThat(consentResponse.getData().getAuthorisation()).isEqualTo(consentRequest.getData().getAuthorisation());
+        assertThat(consentResponse.getData().getScASupportData()).isEqualTo(consentRequest.getData().getScASupportData());
+        assertThat(consentResponse.getData().getReadRefundAccount()).isEqualTo(consentRequest.getData().getReadRefundAccount());
+        assertThat(consentResponse.getData().getCreationDateTime()).isNotNull();
+        assertThat(consentResponse.getData().getStatusUpdateDateTime()).isNotNull();
+        assertThat(consentResponse.getRisk()).isEqualTo(consentRequest.getRisk());
+        final String selfLinkToConsent = consentResponse.getLinks().getSelf().toString();
+        assertThat(selfLinkToConsent).isEqualTo(controllerGetConsentUri(consentId));
+
+        // Get the consent and verify it matches the create response
+        when(consentStoreClient.getConsent(eq(consentId), eq(TEST_API_CLIENT_ID))).thenReturn(consentStoreResponse);
+
+        final ResponseEntity<OBWriteDomesticScheduledConsentResponse5> getConsentResponse = restTemplate.exchange(selfLinkToConsent,
+                HttpMethod.GET, new HttpEntity<>(HTTP_HEADERS), OBWriteDomesticScheduledConsentResponse5.class);
+
+        assertThat(getConsentResponse.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(getConsentResponse.getBody()).isEqualTo(consentResponse);
+    }
+
+    @Test
+    public void failsToCreateConsentIfRequestDoesNotPassJavaBeanValidation() {
+        final OBWriteDomesticScheduledConsent4 emptyConsent = new OBWriteDomesticScheduledConsent4();
+
+        final ResponseEntity<OBErrorResponse1> response = restTemplate.exchange(controllerBaseUri, HttpMethod.POST,
+                new HttpEntity<>(emptyConsent, HTTP_HEADERS), OBErrorResponse1.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+
+        final List<OBError1> errors = response.getBody().getErrors();
+        assertThat(errors).hasSize(2);
+        final String fieldMustNotBeNullErrMsg = "The field received is invalid. Reason 'must not be null'";
+        final String fieldInvalidErrCode = OBStandardErrorCodes1.UK_OBIE_FIELD_INVALID.toString();
+        assertThat(errors).containsExactlyInAnyOrder(new OBError1().errorCode(fieldInvalidErrCode).message(fieldMustNotBeNullErrMsg).path("risk"),
+                                                     new OBError1().errorCode(fieldInvalidErrCode).message(fieldMustNotBeNullErrMsg).path("data"));
+
+        verifyNoMoreInteractions(consentStoreClient);
+    }
+
+    @Test
+    public void failsToCreateConsentIfRequestDoesNotPassBizLogicValidation() {
+        final OBWriteDomesticScheduledConsent4 consentWithInvalidAmount = OBWriteDomesticScheduledConsentTestDataFactory.aValidOBWriteDomesticScheduledConsent4();
+        consentWithInvalidAmount.getData().getInitiation().getInstructedAmount().setAmount("0"); // Invalid amount
+
+        final ResponseEntity<OBErrorResponse1> response = restTemplate.exchange(controllerBaseUri, HttpMethod.POST,
+                new HttpEntity<>(consentWithInvalidAmount, HTTP_HEADERS), OBErrorResponse1.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        final List<OBError1> errors = response.getBody().getErrors();
+        assertThat(errors).hasSize(1);
+        assertThat(errors.get(0).getErrorCode()).isEqualTo(ErrorCode.OBRI_DATA_REQUEST_INVALID.toString());
+        assertThat(errors.get(0).getMessage()).isEqualTo("Your data request is invalid: reason The amount 0 provided must be greater than 0");
+
+        verifyNoMoreInteractions(consentStoreClient);
+    }
+
+    @Test
+    public void failsToGetConsentThatDoesNotExist() {
+        when(consentStoreClient.getConsent(anyString(), anyString())).thenThrow(new ConsentStoreClientException(ErrorType.NOT_FOUND, "Consent Not Found"));
+        final ResponseEntity<OBErrorResponse1> consentNotFoundResponse = restTemplate.exchange(controllerGetConsentUri("unknown"),
+                HttpMethod.GET, new HttpEntity<>(HTTP_HEADERS), OBErrorResponse1.class);
+
+        assertThat(consentNotFoundResponse.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+        assertThat(consentNotFoundResponse.getBody().getCode()).isEqualTo(OBRI_CONSENT_NOT_FOUND.toString());
+    }
+
+    @Test
+    public void failsToGetConsentInvalidPermissions() {
+        when(consentStoreClient.getConsent(anyString(), anyString())).thenThrow(new ConsentStoreClientException(ErrorType.INVALID_PERMISSIONS, "ApiClient does not have permission to access Consent"));
+        final ResponseEntity<OBErrorResponse1> consentNotFoundResponse = restTemplate.exchange(controllerGetConsentUri("unknown"),
+                HttpMethod.GET, new HttpEntity<>(HTTP_HEADERS), OBErrorResponse1.class);
+
+        assertThat(consentNotFoundResponse.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
+        assertThat(consentNotFoundResponse.getBody().getCode()).isEqualTo(OBRI_PERMISSION_INVALID.toString());
+    }
+
+    private String controllerGetConsentUri(String consentId) {
+        return controllerBaseUri + "/" + consentId;
+    }
+
+    private static OBWriteDomesticScheduledConsent4 createValidateConsentRequest() {
+        final OBWriteDomesticScheduledConsent4 consentRequest = OBWriteDomesticScheduledConsentTestDataFactory.aValidOBWriteDomesticScheduledConsent4();
+        consentRequest.getData().getAuthorisation().setCompletionDateTime(DateTime.now(DateTimeZone.UTC));
+        consentRequest.getData().getInitiation().setRequestedExecutionDateTime(DateTime.now(DateTimeZone.UTC).plusDays(2));
+        return consentRequest;
+    }
+
+    public static DomesticScheduledPaymentConsent buildAwaitingAuthorisationConsent(OBWriteDomesticScheduledConsent4 consentRequest) {
+        final DomesticScheduledPaymentConsent consentStoreResponse = new DomesticScheduledPaymentConsent();
+        consentStoreResponse.setId(IntentType.PAYMENT_DOMESTIC_CONSENT.generateIntentId());
+        consentStoreResponse.setRequestObj(FRWriteDomesticScheduledConsentConverter.toFRWriteDomesticScheduledConsent(consentRequest));
+        consentStoreResponse.setStatus(StatusEnum.AWAITINGAUTHORISATION.toString());
+        consentStoreResponse.setCharges(List.of());
+        final DateTime creationDateTime = DateTime.now();
+        consentStoreResponse.setCreationDateTime(creationDateTime);
+        consentStoreResponse.setStatusUpdateDateTime(creationDateTime);
+        return consentStoreResponse;
+    }
+
+}

--- a/secure-api-gateway-ob-uk-rs-validation/secure-api-gateway-ob-uk-rs-validation-obie/pom.xml
+++ b/secure-api-gateway-ob-uk-rs-validation/secure-api-gateway-ob-uk-rs-validation-obie/pom.xml
@@ -55,6 +55,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>com.forgerock.sapi.gateway</groupId>
             <artifactId>secure-api-gateway-ob-uk-rs-validation-core</artifactId>
             <version>${project.version}</version>

--- a/secure-api-gateway-ob-uk-rs-validation/secure-api-gateway-ob-uk-rs-validation-obie/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/validation/obie/payment/OBWriteDomestic2DataInitiationInstructedAmountValidator.java
+++ b/secure-api-gateway-ob-uk-rs-validation/secure-api-gateway-ob-uk-rs-validation-obie/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/validation/obie/payment/OBWriteDomestic2DataInitiationInstructedAmountValidator.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.payment;
+
+import static java.math.BigDecimal.ZERO;
+
+import java.math.BigDecimal;
+import java.util.Objects;
+import java.util.Set;
+
+import com.forgerock.sapi.gateway.ob.uk.common.error.OBRIErrorType;
+import com.forgerock.sapi.gateway.ob.uk.rs.validation.ValidationResult;
+import com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.BaseOBValidator;
+
+import uk.org.openbanking.datamodel.error.OBError1;
+import uk.org.openbanking.datamodel.payment.OBWriteDomestic2DataInitiationInstructedAmount;
+
+public class OBWriteDomestic2DataInitiationInstructedAmountValidator extends BaseOBValidator<OBWriteDomestic2DataInitiationInstructedAmount> {
+
+    private final Set<String> validPaymentCurrencies;
+
+    public OBWriteDomestic2DataInitiationInstructedAmountValidator(Set<String> validPaymentCurrencies) {
+        this.validPaymentCurrencies = Objects.requireNonNull(validPaymentCurrencies, "validPaymentCurrencies must be supplied");
+    }
+
+    @Override
+    protected void validate(OBWriteDomestic2DataInitiationInstructedAmount instructedAmount, ValidationResult<OBError1> validationResult) {
+        final String amount = instructedAmount.getAmount();
+        if (new BigDecimal(amount).compareTo(ZERO) <= 0) {
+            validationResult.addError(OBRIErrorType.DATA_INVALID_REQUEST.toOBError1(
+                    String.format("The amount %s provided must be greater than 0", amount)));
+        }
+        final String currency = instructedAmount.getCurrency();
+        if (!validPaymentCurrencies.contains(currency)) {
+            validationResult.addError(OBRIErrorType.DATA_INVALID_REQUEST.toOBError1(
+                    String.format("The currency %s provided is not supported", currency)));
+        }
+    }
+}

--- a/secure-api-gateway-ob-uk-rs-validation/secure-api-gateway-ob-uk-rs-validation-obie/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/validation/obie/payment/OBWriteDomesticScheduled2Validator.java
+++ b/secure-api-gateway-ob-uk-rs-validation/secure-api-gateway-ob-uk-rs-validation-obie/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/validation/obie/payment/OBWriteDomesticScheduled2Validator.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.payment;
+
+import com.forgerock.sapi.gateway.ob.uk.rs.validation.ValidationResult;
+import com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.payment.OBWriteDomesticScheduled2Validator.OBWriteDomesticScheduled2ValidationContext;
+
+import uk.org.openbanking.datamodel.error.OBError1;
+import uk.org.openbanking.datamodel.payment.OBWriteDomesticScheduled2;
+import uk.org.openbanking.datamodel.payment.OBWriteDomesticScheduled2DataInitiation;
+import uk.org.openbanking.datamodel.payment.OBWriteDomesticScheduledConsent4;
+
+/**
+ * Validator of OBWriteDomesticScheduled2 objects (Domestic Scheduled Payment Requests)
+ */
+public class OBWriteDomesticScheduled2Validator extends BasePaymentRequestValidator<OBWriteDomesticScheduled2ValidationContext, OBWriteDomesticScheduled2, OBWriteDomesticScheduled2DataInitiation> {
+
+    public static class OBWriteDomesticScheduled2ValidationContext extends PaymentRequestValidationContext<OBWriteDomesticScheduled2, OBWriteDomesticScheduled2DataInitiation> {
+        public OBWriteDomesticScheduled2ValidationContext(OBWriteDomesticScheduled2 paymentRequest, OBWriteDomesticScheduledConsent4 consentRequest, String consentStatus) {
+            super(paymentRequest, () -> paymentRequest.getData().getInitiation(), paymentRequest::getRisk,
+                  consentStatus, () -> consentRequest.getData().getInitiation(), consentRequest::getRisk);
+        }
+    }
+
+    @Override
+    protected void doPaymentSpecificValidation(OBWriteDomesticScheduled2ValidationContext paymentReqValidationCtxt,
+                                               ValidationResult<OBError1> validationResult) {
+
+        // Add validation rules as required.
+    }
+}

--- a/secure-api-gateway-ob-uk-rs-validation/secure-api-gateway-ob-uk-rs-validation-obie/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/validation/obie/payment/consent/OBWriteDomesticScheduledConsent4Validator.java
+++ b/secure-api-gateway-ob-uk-rs-validation/secure-api-gateway-ob-uk-rs-validation-obie/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/validation/obie/payment/consent/OBWriteDomesticScheduledConsent4Validator.java
@@ -44,9 +44,8 @@ public class OBWriteDomesticScheduledConsent4Validator extends BaseOBValidator<O
         validationResult.mergeResults(instructedAmountValidator.validate(consent.getData().getInitiation().getInstructedAmount()));
 
         final DateTime requestedExecutionDateTime = consent.getData().getInitiation().getRequestedExecutionDateTime();
-        if (requestedExecutionDateTime.isBeforeNow()) {
-            validationResult.addError(OBRIErrorType.DATA_INVALID_REQUEST.toOBError1(
-                    String.format("RequestedExecutionDateTime must be in the future")));
+        if (!requestedExecutionDateTime.isAfterNow()) {
+            validationResult.addError(OBRIErrorType.DATA_INVALID_REQUEST.toOBError1("RequestedExecutionDateTime must be in the future"));
         }
     }
 

--- a/secure-api-gateway-ob-uk-rs-validation/secure-api-gateway-ob-uk-rs-validation-obie/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/validation/obie/payment/consent/OBWriteDomesticScheduledConsent4Validator.java
+++ b/secure-api-gateway-ob-uk-rs-validation/secure-api-gateway-ob-uk-rs-validation-obie/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/validation/obie/payment/consent/OBWriteDomesticScheduledConsent4Validator.java
@@ -18,25 +18,27 @@ package com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.payment.consent;
 import java.util.Objects;
 
 import com.forgerock.sapi.gateway.ob.uk.rs.validation.ValidationResult;
+import com.forgerock.sapi.gateway.ob.uk.rs.validation.Validator;
 import com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.BaseOBValidator;
 
 import uk.org.openbanking.datamodel.error.OBError1;
 import uk.org.openbanking.datamodel.payment.OBWriteDomestic2DataInitiationInstructedAmount;
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticConsent4;
+import uk.org.openbanking.datamodel.payment.OBWriteDomesticScheduledConsent4;
 
 /**
- * Validator of OBWriteDomesticConsent4 objects (Domestic Payment Consents)
+ * Validator of OBWriteDomesticScheduledConsent4 objects (Domestic Scheduled Payment Consents)
  */
-public class OBWriteDomesticConsent4Validator extends BaseOBValidator<OBWriteDomesticConsent4> {
+public class OBWriteDomesticScheduledConsent4Validator extends BaseOBValidator<OBWriteDomesticScheduledConsent4> {
 
-    private final BaseOBValidator<OBWriteDomestic2DataInitiationInstructedAmount> instructedAmountValidator;
+    private final Validator<OBWriteDomestic2DataInitiationInstructedAmount, OBError1> instructedAmountValidator;
 
-    public OBWriteDomesticConsent4Validator(BaseOBValidator<OBWriteDomestic2DataInitiationInstructedAmount> instructedAmountValidator) {
+    public OBWriteDomesticScheduledConsent4Validator(Validator<OBWriteDomestic2DataInitiationInstructedAmount, OBError1> instructedAmountValidator) {
         this.instructedAmountValidator = Objects.requireNonNull(instructedAmountValidator, "instructedAmountValidator must be supplied");
     }
 
     @Override
-    protected void validate(OBWriteDomesticConsent4 domesticPaymentConsent, ValidationResult<OBError1> validationResult) {
+    protected void validate(OBWriteDomesticScheduledConsent4 domesticPaymentConsent, ValidationResult<OBError1> validationResult) {
         validationResult.mergeResults(instructedAmountValidator.validate(domesticPaymentConsent.getData().getInitiation().getInstructedAmount()));
     }
+
 }

--- a/secure-api-gateway-ob-uk-rs-validation/secure-api-gateway-ob-uk-rs-validation-obie/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/validation/obie/payment/consent/OBWriteDomesticScheduledConsent4Validator.java
+++ b/secure-api-gateway-ob-uk-rs-validation/secure-api-gateway-ob-uk-rs-validation-obie/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/validation/obie/payment/consent/OBWriteDomesticScheduledConsent4Validator.java
@@ -17,6 +17,9 @@ package com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.payment.consent;
 
 import java.util.Objects;
 
+import org.joda.time.DateTime;
+
+import com.forgerock.sapi.gateway.ob.uk.common.error.OBRIErrorType;
 import com.forgerock.sapi.gateway.ob.uk.rs.validation.ValidationResult;
 import com.forgerock.sapi.gateway.ob.uk.rs.validation.Validator;
 import com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.BaseOBValidator;
@@ -37,8 +40,14 @@ public class OBWriteDomesticScheduledConsent4Validator extends BaseOBValidator<O
     }
 
     @Override
-    protected void validate(OBWriteDomesticScheduledConsent4 domesticPaymentConsent, ValidationResult<OBError1> validationResult) {
-        validationResult.mergeResults(instructedAmountValidator.validate(domesticPaymentConsent.getData().getInitiation().getInstructedAmount()));
+    protected void validate(OBWriteDomesticScheduledConsent4 consent, ValidationResult<OBError1> validationResult) {
+        validationResult.mergeResults(instructedAmountValidator.validate(consent.getData().getInitiation().getInstructedAmount()));
+
+        final DateTime requestedExecutionDateTime = consent.getData().getInitiation().getRequestedExecutionDateTime();
+        if (requestedExecutionDateTime.isBeforeNow()) {
+            validationResult.addError(OBRIErrorType.DATA_INVALID_REQUEST.toOBError1(
+                    String.format("RequestedExecutionDateTime must be in the future")));
+        }
     }
 
 }

--- a/secure-api-gateway-ob-uk-rs-validation/secure-api-gateway-ob-uk-rs-validation-obie/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/validation/obie/payment/OBWriteDomestic2DataInitiationInstructedAmountValidatorTest.java
+++ b/secure-api-gateway-ob-uk-rs-validation/secure-api-gateway-ob-uk-rs-validation-obie/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/validation/obie/payment/OBWriteDomestic2DataInitiationInstructedAmountValidatorTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.payment;
+
+import static com.forgerock.sapi.gateway.ob.uk.rs.validation.ValidationResultTest.validateErrorResult;
+
+import java.util.List;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+
+import uk.org.openbanking.datamodel.error.OBError1;
+import uk.org.openbanking.datamodel.payment.OBWriteDomestic2DataInitiationInstructedAmount;
+
+public class OBWriteDomestic2DataInitiationInstructedAmountValidatorTest {
+
+    public static OBWriteDomestic2DataInitiationInstructedAmountValidator createInstructedAmountValidator(String... currencies) {
+        return new OBWriteDomestic2DataInitiationInstructedAmountValidator(Set.of(currencies));
+    }
+
+
+    private final OBWriteDomestic2DataInitiationInstructedAmountValidator validator = createInstructedAmountValidator("USD", "GBP", "EUR", "CHF");
+
+    @Test
+    public void failsValidationWhenInstructedAmountCurrencyInvalid() {
+        final String invalidCcy = "ZZZ";
+        final OBWriteDomestic2DataInitiationInstructedAmount amount = new OBWriteDomestic2DataInitiationInstructedAmount();
+        amount.currency(invalidCcy).amount("12.22");
+
+        validateErrorResult(validator.validate(amount), List.of(new OBError1().errorCode("OBRI.Data.Request.Invalid")
+                .message("Your data request is invalid: reason The currency " + invalidCcy + " provided is not supported")));
+    }
+
+    @Test
+    public void failsValidationWhenInstructedAmountLessThanOrEqualToZero() {
+        final String[] invalidAmounts = new String[] {
+                "-1000.12", "-0.01", "0", "0.0"
+        };
+
+        for (String invalidAmount : invalidAmounts) {
+            final OBWriteDomestic2DataInitiationInstructedAmount amount = new OBWriteDomestic2DataInitiationInstructedAmount();
+            amount.currency("GBP").amount(invalidAmount);
+            validateErrorResult(validator.validate(amount), List.of(new OBError1().errorCode("OBRI.Data.Request.Invalid")
+                    .message("Your data request is invalid: reason The amount " + invalidAmount + " provided must be greater than 0")));
+        }
+    }
+}

--- a/secure-api-gateway-ob-uk-rs-validation/secure-api-gateway-ob-uk-rs-validation-obie/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/validation/obie/payment/consent/OBWriteDomesticScheduledConsent4ValidatorTest.java
+++ b/secure-api-gateway-ob-uk-rs-validation/secure-api-gateway-ob-uk-rs-validation-obie/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/validation/obie/payment/consent/OBWriteDomesticScheduledConsent4ValidatorTest.java
@@ -29,19 +29,19 @@ import com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.BaseOBValidator;
 
 import uk.org.openbanking.datamodel.common.OBRisk1;
 import uk.org.openbanking.datamodel.error.OBError1;
-import uk.org.openbanking.datamodel.payment.OBWriteDomestic2DataInitiation;
 import uk.org.openbanking.datamodel.payment.OBWriteDomestic2DataInitiationInstructedAmount;
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticConsent4;
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticConsent4Data;
+import uk.org.openbanking.datamodel.payment.OBWriteDomesticScheduled2DataInitiation;
+import uk.org.openbanking.datamodel.payment.OBWriteDomesticScheduledConsent4;
+import uk.org.openbanking.datamodel.payment.OBWriteDomesticScheduledConsent4Data;
 
-class OBWriteDomesticConsent4ValidatorTest {
+class OBWriteDomesticScheduledConsent4ValidatorTest {
 
-    final OBWriteDomesticConsent4Validator validator = new OBWriteDomesticConsent4Validator(createInstructedAmountValidator("GBP", "EUR", "USD"));
+    final OBWriteDomesticScheduledConsent4Validator validator = new OBWriteDomesticScheduledConsent4Validator(createInstructedAmountValidator("GBP", "EUR", "USD"));
 
-    private static OBWriteDomesticConsent4 createValidConsent() {
-        final OBWriteDomesticConsent4 consent = new OBWriteDomesticConsent4();
-        final OBWriteDomesticConsent4Data consentData = new OBWriteDomesticConsent4Data();
-        final OBWriteDomestic2DataInitiation initiation = new OBWriteDomestic2DataInitiation();
+    private static OBWriteDomesticScheduledConsent4 createValidConsent() {
+        final OBWriteDomesticScheduledConsent4 consent = new OBWriteDomesticScheduledConsent4();
+        final OBWriteDomesticScheduledConsent4Data consentData = new OBWriteDomesticScheduledConsent4Data();
+        final OBWriteDomesticScheduled2DataInitiation initiation = new OBWriteDomesticScheduled2DataInitiation();
         initiation.setInstructedAmount(new OBWriteDomestic2DataInitiationInstructedAmount().amount("12.99").currency("GBP"));
         consentData.setInitiation(initiation);
         consent.setData(consentData);
@@ -50,14 +50,14 @@ class OBWriteDomesticConsent4ValidatorTest {
     }
 
     @Test
-    public void testValidDomesticConsent() {
+    public void testValidConsent() {
         validateSuccessResult(validator.validate(createValidConsent()));
     }
 
     @Test
     public void failsValidationWhenInstructedAmountIsInvalid() {
         final OBError1 expectedValidationError = OBRIErrorType.DATA_INVALID_REQUEST.toOBError1("invalid instructed amount");
-        final ValidationResult<OBError1> validationResult = new OBWriteDomesticConsent4Validator(new BaseOBValidator<>() {
+        final ValidationResult<OBError1> validationResult = new OBWriteDomesticScheduledConsent4Validator(new BaseOBValidator<>() {
             @Override
             protected void validate(OBWriteDomestic2DataInitiationInstructedAmount obj, ValidationResult<OBError1> validationResult) {
                 validationResult.addError(expectedValidationError);

--- a/secure-api-gateway-ob-uk-rs-validation/secure-api-gateway-ob-uk-rs-validation-obie/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/validation/obie/payment/consent/OBWriteDomesticScheduledConsent4ValidatorTest.java
+++ b/secure-api-gateway-ob-uk-rs-validation/secure-api-gateway-ob-uk-rs-validation-obie/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/validation/obie/payment/consent/OBWriteDomesticScheduledConsent4ValidatorTest.java
@@ -21,6 +21,7 @@ import static com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.payment.OBWrit
 
 import java.util.List;
 
+import org.joda.time.DateTime;
 import org.junit.jupiter.api.Test;
 
 import com.forgerock.sapi.gateway.ob.uk.common.error.OBRIErrorType;
@@ -43,6 +44,7 @@ class OBWriteDomesticScheduledConsent4ValidatorTest {
         final OBWriteDomesticScheduledConsent4Data consentData = new OBWriteDomesticScheduledConsent4Data();
         final OBWriteDomesticScheduled2DataInitiation initiation = new OBWriteDomesticScheduled2DataInitiation();
         initiation.setInstructedAmount(new OBWriteDomestic2DataInitiationInstructedAmount().amount("12.99").currency("GBP"));
+        initiation.setRequestedExecutionDateTime(DateTime.now().plusDays(7));
         consentData.setInitiation(initiation);
         consent.setData(consentData);
         consent.setRisk(new OBRisk1());
@@ -52,6 +54,15 @@ class OBWriteDomesticScheduledConsent4ValidatorTest {
     @Test
     public void testValidConsent() {
         validateSuccessResult(validator.validate(createValidConsent()));
+    }
+
+    @Test
+    public void failsValidationWhenRequestExecutionDateTimeInPast() {
+        final OBWriteDomesticScheduledConsent4 consent = createValidConsent();
+        consent.getData().getInitiation().setRequestedExecutionDateTime(DateTime.now().minusSeconds(1));
+
+        final ValidationResult<OBError1> validationResult = validator.validate(consent);
+        validateErrorResult(validationResult, List.of(OBRIErrorType.DATA_INVALID_REQUEST.toOBError1("RequestedExecutionDateTime must be in the future")));
     }
 
     @Test


### PR DESCRIPTION
Using the RCS Consent Store for Domestic Scheduled Payment Consents.

Adding DomesticScheduledPaymentConsentsApi + Controller

Updating DomesticScheduledPaymentsApiController to fetch consents from the RCS Consent Store. 