### PR TITLE
1065: Adding FilePaymentConsentsApi + Controller

### DIFF
--- a/secure-api-gateway-ob-uk-rs-obie-api/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/obie/api/payment/v3_1_10/file/FilePaymentConsentsApi.java
+++ b/secure-api-gateway-ob-uk-rs-obie-api/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/obie/api/payment/v3_1_10/file/FilePaymentConsentsApi.java
@@ -1,0 +1,260 @@
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.ob.uk.rs.obie.api.payment.v3_1_10.file;
+
+import static com.forgerock.sapi.gateway.ob.uk.rs.obie.api.ApiConstants.HTTP_DATE_FORMAT;
+
+import java.io.File;
+import java.security.Principal;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.validation.Valid;
+
+import org.joda.time.DateTime;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+
+import com.forgerock.sapi.gateway.ob.uk.common.error.OBErrorException;
+import com.forgerock.sapi.gateway.ob.uk.common.error.OBErrorResponseException;
+
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
+import io.swagger.annotations.Authorization;
+import io.swagger.annotations.AuthorizationScope;
+import uk.org.openbanking.datamodel.error.OBErrorResponse1;
+import uk.org.openbanking.datamodel.payment.OBWriteFileConsent3;
+import uk.org.openbanking.datamodel.payment.OBWriteFileConsentResponse4;
+
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2020-05-22T14:20:48.770Z")
+
+@Api(value = "file-payment-consents", description = "the file-payment-consents API")
+@RequestMapping(value = "/open-banking/v3.1.10/pisp")
+public interface FilePaymentConsentsApi {
+
+    @ApiOperation(value = "Create File Payment Consents", nickname = "createFilePaymentConsents", notes = "", response = OBWriteFileConsentResponse4.class, authorizations = {
+            @Authorization(value = "TPPOAuth2Security", scopes = {
+                    @AuthorizationScope(scope = "payments", description = "Generic payment scope")
+            })
+    }, tags = {"File Payments",})
+    @ApiResponses(value = {
+            @ApiResponse(code = 201, message = "File Payment Consents Created", response = OBWriteFileConsentResponse4.class),
+            @ApiResponse(code = 400, message = "Bad request", response = OBErrorResponse1.class),
+            @ApiResponse(code = 401, message = "Unauthorized"),
+            @ApiResponse(code = 403, message = "Forbidden", response = OBErrorResponse1.class),
+            @ApiResponse(code = 404, message = "Not found"),
+            @ApiResponse(code = 405, message = "Method Not Allowed"),
+            @ApiResponse(code = 406, message = "Not Acceptable"),
+            @ApiResponse(code = 429, message = "Too Many Requests"),
+            @ApiResponse(code = 500, message = "Internal Server Error", response = OBErrorResponse1.class)})
+    @RequestMapping(value = "/file-payment-consents",
+            produces = {"application/json; charset=utf-8", "application/jose+jwe"},
+            consumes = {"application/json; charset=utf-8", "application/jose+jwe"},
+            method = RequestMethod.POST)
+    ResponseEntity<OBWriteFileConsentResponse4> createFilePaymentConsents(
+            @ApiParam(value = "Default", required = true)
+            @Valid
+            @RequestBody OBWriteFileConsent3 obWriteFileConsent3,
+
+            @ApiParam(value = "An Authorisation Token as per https://tools.ietf.org/html/rfc6750", required = true)
+            @RequestHeader(value = "Authorization", required = true) String authorization,
+
+            @ApiParam(value = "Every request will be processed only once per x-idempotency-key.  The Idempotency Key will be valid for 24 hours. ", required = true)
+            @RequestHeader(value = "x-idempotency-key", required = true) String xIdempotencyKey,
+
+            @ApiParam(value = "A detached JWS signature of the body of the payload.", required = true)
+            @RequestHeader(value = "x-jws-signature", required = true) String xJwsSignature,
+
+            @ApiParam(value = "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC")
+            @RequestHeader(value = "x-fapi-auth-date", required = false)
+            @DateTimeFormat(pattern = HTTP_DATE_FORMAT) DateTime xFapiAuthDate,
+
+            @ApiParam(value = "The PSU's IP address if the PSU is currently logged in with the TPP.")
+            @RequestHeader(value = "x-fapi-customer-ip-address", required = false) String xFapiCustomerIpAddress,
+
+            @ApiParam(value = "An RFC4122 UID used as a correlation id.")
+            @RequestHeader(value = "x-fapi-interaction-id", required = false) String xFapiInteractionId,
+
+            @ApiParam(value = "Indicates the user-agent that the PSU is using.")
+            @RequestHeader(value = "x-customer-user-agent", required = false) String xCustomerUserAgent,
+
+            @ApiParam(value = "OAuth2.0 client_id of the ApiClient making the request")
+            @RequestHeader(value = "x-api-client-id") String apiClientId,
+
+            HttpServletRequest request,
+
+            Principal principal
+    ) throws OBErrorResponseException;
+
+
+    @ApiOperation(value = "Create File Payment Consents", nickname = "createFilePaymentConsentsConsentIdFile", notes = "", authorizations = {
+            @Authorization(value = "TPPOAuth2Security", scopes = {
+                    @AuthorizationScope(scope = "payments", description = "Generic payment scope")
+            })
+    }, tags = {"File Payments",})
+    @ApiResponses(value = {
+            @ApiResponse(code = 200, message = "File Payment Consents Created"),
+            @ApiResponse(code = 400, message = "Bad request", response = OBErrorResponse1.class),
+            @ApiResponse(code = 401, message = "Unauthorized"),
+            @ApiResponse(code = 403, message = "Forbidden", response = OBErrorResponse1.class),
+            @ApiResponse(code = 404, message = "Not found"),
+            @ApiResponse(code = 405, message = "Method Not Allowed"),
+            @ApiResponse(code = 406, message = "Not Acceptable"),
+            @ApiResponse(code = 429, message = "Too Many Requests"),
+            @ApiResponse(code = 500, message = "Internal Server Error", response = OBErrorResponse1.class)})
+    @RequestMapping(value = "/file-payment-consents/{ConsentId}/file",
+            produces = {"application/json; charset=utf-8"},
+            consumes = {"*/*"},
+            method = RequestMethod.POST)
+    ResponseEntity<Void> createFilePaymentConsentsConsentIdFile(
+            @ApiParam(value = "Default", required = true)
+            @Valid
+            @RequestBody String fileParam,
+
+            @ApiParam(value = "ConsentId", required = true)
+            @PathVariable("ConsentId") String consentId,
+
+            @ApiParam(value = "An Authorisation Token as per https://tools.ietf.org/html/rfc6750", required = true)
+            @RequestHeader(value = "Authorization", required = true) String authorization,
+
+            @ApiParam(value = "Every request will be processed only once per x-idempotency-key.  The Idempotency Key will be valid for 24 hours. ", required = true)
+            @RequestHeader(value = "x-idempotency-key", required = true) String xIdempotencyKey,
+
+            @ApiParam(value = "A detached JWS signature of the body of the payload.", required = true)
+            @RequestHeader(value = "x-jws-signature", required = true) String xJwsSignature,
+
+            @ApiParam(value = "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC")
+            @RequestHeader(value = "x-fapi-auth-date", required = false)
+            @DateTimeFormat(pattern = HTTP_DATE_FORMAT) DateTime xFapiAuthDate,
+
+            @ApiParam(value = "The PSU's IP address if the PSU is currently logged in with the TPP.")
+            @RequestHeader(value = "x-fapi-customer-ip-address", required = false) String xFapiCustomerIpAddress,
+
+            @ApiParam(value = "An RFC4122 UID used as a correlation id.")
+            @RequestHeader(value = "x-fapi-interaction-id", required = false) String xFapiInteractionId,
+
+            @ApiParam(value = "Indicates the user-agent that the PSU is using.")
+            @RequestHeader(value = "x-customer-user-agent", required = false) String xCustomerUserAgent,
+
+            @ApiParam(value = "OAuth2.0 client_id of the ApiClient making the request")
+            @RequestHeader(value = "x-api-client-id") String apiClientId,
+
+            HttpServletRequest request,
+
+            Principal principal
+    ) throws OBErrorResponseException, OBErrorException;
+
+
+    @ApiOperation(value = "Get File Payment Consents", nickname = "getFilePaymentConsentsConsentId", notes = "", response = OBWriteFileConsentResponse4.class, authorizations = {
+            @Authorization(value = "TPPOAuth2Security", scopes = {
+                    @AuthorizationScope(scope = "payments", description = "Generic payment scope")
+            })
+    }, tags = {"File Payments",})
+    @ApiResponses(value = {
+            @ApiResponse(code = 200, message = "File Payment Consents Read", response = OBWriteFileConsentResponse4.class),
+            @ApiResponse(code = 400, message = "Bad request", response = OBErrorResponse1.class),
+            @ApiResponse(code = 401, message = "Unauthorized"),
+            @ApiResponse(code = 403, message = "Forbidden", response = OBErrorResponse1.class),
+            @ApiResponse(code = 404, message = "Not found"),
+            @ApiResponse(code = 405, message = "Method Not Allowed"),
+            @ApiResponse(code = 406, message = "Not Acceptable"),
+            @ApiResponse(code = 429, message = "Too Many Requests"),
+            @ApiResponse(code = 500, message = "Internal Server Error", response = OBErrorResponse1.class)})
+    @RequestMapping(value = "/file-payment-consents/{ConsentId}",
+            produces = {"application/json; charset=utf-8", "application/jose+jwe"},
+            method = RequestMethod.GET)
+    ResponseEntity<OBWriteFileConsentResponse4> getFilePaymentConsentsConsentId(
+            @ApiParam(value = "ConsentId", required = true)
+            @PathVariable("ConsentId") String consentId,
+
+            @ApiParam(value = "An Authorisation Token as per https://tools.ietf.org/html/rfc6750", required = true)
+            @RequestHeader(value = "Authorization", required = true) String authorization,
+
+            @ApiParam(value = "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC")
+            @RequestHeader(value = "x-fapi-auth-date", required = false)
+            @DateTimeFormat(pattern = HTTP_DATE_FORMAT) DateTime xFapiAuthDate,
+
+            @ApiParam(value = "The PSU's IP address if the PSU is currently logged in with the TPP.")
+            @RequestHeader(value = "x-fapi-customer-ip-address", required = false) String xFapiCustomerIpAddress,
+
+            @ApiParam(value = "An RFC4122 UID used as a correlation id.")
+            @RequestHeader(value = "x-fapi-interaction-id", required = false) String xFapiInteractionId,
+
+            @ApiParam(value = "Indicates the user-agent that the PSU is using.")
+            @RequestHeader(value = "x-customer-user-agent", required = false) String xCustomerUserAgent,
+
+            @ApiParam(value = "OAuth2.0 client_id of the ApiClient making the request")
+            @RequestHeader(value = "x-api-client-id") String apiClientId,
+
+            HttpServletRequest request,
+
+            Principal principal
+    ) throws OBErrorResponseException;
+
+
+    @ApiOperation(value = "Get File Payment Consents", nickname = "getFilePaymentConsentsConsentIdFile", notes = "", response = File.class, authorizations = {
+            @Authorization(value = "TPPOAuth2Security", scopes = {
+                    @AuthorizationScope(scope = "payments", description = "Generic payment scope")
+            })
+    }, tags = {"File Payments",})
+    @ApiResponses(value = {
+            @ApiResponse(code = 200, message = "File Payment Consents Read", response = File.class),
+            @ApiResponse(code = 400, message = "Bad request", response = OBErrorResponse1.class),
+            @ApiResponse(code = 401, message = "Unauthorized"),
+            @ApiResponse(code = 403, message = "Forbidden", response = OBErrorResponse1.class),
+            @ApiResponse(code = 404, message = "Not found"),
+            @ApiResponse(code = 405, message = "Method Not Allowed"),
+            @ApiResponse(code = 406, message = "Not Acceptable"),
+            @ApiResponse(code = 429, message = "Too Many Requests"),
+            @ApiResponse(code = 500, message = "Internal Server Error", response = OBErrorResponse1.class)})
+    @RequestMapping(value = "/file-payment-consents/{ConsentId}/file",
+            produces = {"*/*"},
+            method = RequestMethod.GET)
+    ResponseEntity<String> getFilePaymentConsentsConsentIdFile(
+            @ApiParam(value = "ConsentId", required = true)
+            @PathVariable("ConsentId") String consentId,
+
+            @ApiParam(value = "An Authorisation Token as per https://tools.ietf.org/html/rfc6750", required = true)
+            @RequestHeader(value = "Authorization", required = true) String authorization,
+
+            @ApiParam(value = "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC")
+            @RequestHeader(value = "x-fapi-auth-date", required = false) String xFapiAuthDate,
+
+            @ApiParam(value = "The PSU's IP address if the PSU is currently logged in with the TPP.")
+            @RequestHeader(value = "x-fapi-customer-ip-address", required = false) String xFapiCustomerIpAddress,
+
+            @ApiParam(value = "An RFC4122 UID used as a correlation id.")
+            @RequestHeader(value = "x-fapi-interaction-id", required = false) String xFapiInteractionId,
+
+            @ApiParam(value = "Indicates the user-agent that the PSU is using.")
+            @RequestHeader(value = "x-customer-user-agent", required = false) String xCustomerUserAgent,
+
+            @ApiParam(value = "OAuth2.0 client_id of the ApiClient making the request")
+            @RequestHeader(value = "x-api-client-id") String apiClientId,
+
+            HttpServletRequest request,
+
+            Principal principal
+    ) throws OBErrorResponseException, OBErrorException;
+
+}

--- a/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/factories/OBWriteFileConsentResponse4Factory.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/factories/OBWriteFileConsentResponse4Factory.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.ob.uk.rs.server.api.obie.payment.factories;
+
+import static com.forgerock.sapi.gateway.ob.uk.rs.server.common.util.link.LinksHelper.createFilePaymentConsentsLink;
+
+import org.springframework.stereotype.Component;
+
+import com.forgerock.sapi.gateway.ob.uk.common.datamodel.converter.common.FRChargeConverter;
+import com.forgerock.sapi.gateway.ob.uk.common.datamodel.converter.payment.FRWriteFileConsentConverter;
+import com.forgerock.sapi.gateway.rcs.consent.store.datamodel.payment.file.v3_1_10.FilePaymentConsent;
+
+import uk.org.openbanking.datamodel.common.Meta;
+import uk.org.openbanking.datamodel.payment.OBWriteFileConsent3;
+import uk.org.openbanking.datamodel.payment.OBWriteFileConsent3Data;
+import uk.org.openbanking.datamodel.payment.OBWriteFileConsentResponse4;
+import uk.org.openbanking.datamodel.payment.OBWriteFileConsentResponse4Data;
+import uk.org.openbanking.datamodel.payment.OBWriteFileConsentResponse4Data.StatusEnum;
+
+@Component
+public class OBWriteFileConsentResponse4Factory {
+
+    public OBWriteFileConsentResponse4 buildConsentResponse(FilePaymentConsent consent, Class<?> controllerClass) {
+        final OBWriteFileConsentResponse4Data data = new OBWriteFileConsentResponse4Data();
+
+        final OBWriteFileConsent3 oBWriteDomesticStandingOrderConsent5 = FRWriteFileConsentConverter.toOBWriteFileConsent3(consent.getRequestObj());
+        final OBWriteFileConsent3Data obConsentData = oBWriteDomesticStandingOrderConsent5.getData();
+        data.authorisation(obConsentData.getAuthorisation());
+        data.scASupportData(obConsentData.getScASupportData());
+        data.initiation(obConsentData.getInitiation());
+        data.charges(FRChargeConverter.toOBWriteDomesticConsentResponse5DataCharges(consent.getCharges()));
+        data.consentId(consent.getId());
+        data.status(StatusEnum.fromValue(consent.getStatus()));
+        data.creationDateTime(consent.getCreationDateTime());
+        data.statusUpdateDateTime(consent.getStatusUpdateDateTime());
+
+        return new OBWriteFileConsentResponse4().data(data)
+                .links(createFilePaymentConsentsLink(controllerClass, consent.getId()))
+                .meta(new Meta());
+    }
+
+}

--- a/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/services/validation/FilePaymentFileContentValidator.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/services/validation/FilePaymentFileContentValidator.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.ob.uk.rs.server.api.obie.payment.services.validation;
+
+import java.math.BigDecimal;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.forgerock.sapi.gateway.ob.uk.common.error.OBErrorException;
+import com.forgerock.sapi.gateway.ob.uk.common.error.OBRIErrorType;
+import com.forgerock.sapi.gateway.ob.uk.rs.server.api.obie.payment.services.validation.FilePaymentFileContentValidator.FilePaymentFileContentValidationContext;
+import com.forgerock.sapi.gateway.ob.uk.rs.server.common.filepayment.PaymentFile;
+import com.forgerock.sapi.gateway.ob.uk.rs.server.common.filepayment.PaymentFileFactory;
+import com.forgerock.sapi.gateway.ob.uk.rs.server.common.filepayment.PaymentFileType;
+import com.forgerock.sapi.gateway.ob.uk.rs.server.common.util.HashUtils;
+import com.forgerock.sapi.gateway.ob.uk.rs.validation.ValidationResult;
+import com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.BaseOBValidator;
+
+import uk.org.openbanking.datamodel.error.OBError1;
+import uk.org.openbanking.datamodel.payment.OBWriteFileConsent3;
+
+/**
+ * Validator which verifies that the Content of the Payment File uploaded is valid.
+ *
+ * Checks applied:
+ * - Parses the file as the fileType defined in the consent
+ * - Validates the fileHash
+ */
+public class FilePaymentFileContentValidator extends BaseOBValidator<FilePaymentFileContentValidationContext> {
+
+    private final Logger logger = LoggerFactory.getLogger(getClass());
+
+    public static class FilePaymentFileContentValidationContext {
+        private final String fileContent;
+        private final OBWriteFileConsent3 obFileConsent;
+
+        public FilePaymentFileContentValidationContext(String fileContent, OBWriteFileConsent3 obFileConsent) {
+            this.fileContent = fileContent;
+            this.obFileConsent = obFileConsent;
+        }
+
+        public String getFileContent() {
+            return fileContent;
+        }
+
+        public OBWriteFileConsent3 getObFileConsent() {
+            return obFileConsent;
+        }
+    }
+
+    @Override
+    protected void validate(FilePaymentFileContentValidationContext filePaymentFileContentValidationContext,
+                            ValidationResult<OBError1> validationResult) {
+
+        final String fileContent = filePaymentFileContentValidationContext.getFileContent();
+        final OBWriteFileConsent3 obFileConsent = filePaymentFileContentValidationContext.getObFileConsent();
+
+        final String fileHash = HashUtils.computeSHA256FullHash(fileContent);
+        final String consentHash = obFileConsent.getData().getInitiation().getFileHash();
+        if (!fileHash.equals(consentHash)) {
+            validationResult.addError(OBRIErrorType.REQUEST_FILE_INCORRECT_FILE_HASH.toOBError1(fileHash, consentHash));
+            return;
+        }
+
+        PaymentFile paymentFile;
+        try {
+            paymentFile = PaymentFileFactory.createPaymentFile(PaymentFileType.fromFileType(obFileConsent.getData().getInitiation().getFileType()), fileContent);
+
+            final String numTransactionsInConsent = obFileConsent.getData().getInitiation().getNumberOfTransactions();
+            final String numTransactionsInFile = String.valueOf(paymentFile.getNumberOfTransactions());
+            if (!numTransactionsInFile.equals(numTransactionsInConsent)) {
+                validationResult.addError(OBRIErrorType.REQUEST_FILE_WRONG_NUMBER_OF_TRANSACTIONS.toOBError1(numTransactionsInFile, numTransactionsInConsent));
+            }
+            final BigDecimal consentControlSum = obFileConsent.getData().getInitiation().getControlSum();
+            if (paymentFile.getControlSum().compareTo(consentControlSum) != 0) {
+                validationResult.addError(OBRIErrorType.REQUEST_FILE_INCORRECT_CONTROL_SUM.toOBError1(paymentFile.getControlSum(), consentControlSum));
+            }
+
+        } catch (OBErrorException e) {
+           logger.warn("Failed to parse payment file", e);
+           validationResult.addError(e.getOBError());
+        }
+
+    }
+
+}

--- a/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/v3_1_10/file/FilePaymentConsentsApiController.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/v3_1_10/file/FilePaymentConsentsApiController.java
@@ -1,0 +1,185 @@
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.ob.uk.rs.server.api.obie.payment.v3_1_10.file;
+
+import static com.forgerock.sapi.gateway.ob.uk.common.datamodel.converter.payment.FRWriteFileConsentConverter.toFRWriteFileConsent;
+
+import java.security.Principal;
+import java.util.Collections;
+import java.util.List;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.joda.time.DateTime;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+
+import com.forgerock.sapi.gateway.ob.uk.common.datamodel.common.FRCharge;
+import com.forgerock.sapi.gateway.ob.uk.common.datamodel.converter.payment.FRWriteFileConsentConverter;
+import com.forgerock.sapi.gateway.ob.uk.common.error.OBErrorException;
+import com.forgerock.sapi.gateway.ob.uk.common.error.OBErrorResponseException;
+import com.forgerock.sapi.gateway.ob.uk.common.error.OBRIErrorType;
+import com.forgerock.sapi.gateway.ob.uk.rs.obie.api.payment.v3_1_10.file.FilePaymentConsentsApi;
+import com.forgerock.sapi.gateway.ob.uk.rs.server.api.obie.payment.factories.OBWriteFileConsentResponse4Factory;
+import com.forgerock.sapi.gateway.ob.uk.rs.server.api.obie.payment.services.validation.FilePaymentFileContentValidator.FilePaymentFileContentValidationContext;
+import com.forgerock.sapi.gateway.ob.uk.rs.server.common.filepayment.PaymentFileType;
+import com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.OBValidationService;
+import com.forgerock.sapi.gateway.rcs.consent.store.client.payment.file.v3_1_10.FilePaymentConsentStoreClient;
+import com.forgerock.sapi.gateway.rcs.consent.store.datamodel.payment.file.v3_1_10.CreateFilePaymentConsentRequest;
+import com.forgerock.sapi.gateway.rcs.consent.store.datamodel.payment.file.v3_1_10.FilePaymentConsent;
+import com.forgerock.sapi.gateway.rcs.consent.store.datamodel.payment.file.v3_1_10.FileUploadRequest;
+
+import uk.org.openbanking.datamodel.payment.OBWriteFileConsent3;
+import uk.org.openbanking.datamodel.payment.OBWriteFileConsentResponse4;
+
+@Controller("FilePaymentConsentsApiV3.1.10")
+public class FilePaymentConsentsApiController implements FilePaymentConsentsApi {
+
+    private final Logger logger = LoggerFactory.getLogger(getClass());
+
+    private final FilePaymentConsentStoreClient consentStoreApiClient;
+
+    private final OBValidationService<OBWriteFileConsent3> consentValidator;
+
+    private final OBValidationService<FilePaymentFileContentValidationContext> fileContentValidator;
+
+    private final OBWriteFileConsentResponse4Factory consentResponseFactory;
+
+    public FilePaymentConsentsApiController(FilePaymentConsentStoreClient consentStoreApiClient,
+                                            OBValidationService<OBWriteFileConsent3> consentValidator,
+                                            OBValidationService<FilePaymentFileContentValidationContext> fileContentValidator,
+                                            OBWriteFileConsentResponse4Factory consentResponseFactory) {
+        this.consentStoreApiClient = consentStoreApiClient;
+        this.consentValidator = consentValidator;
+        this.fileContentValidator = fileContentValidator;
+        this.consentResponseFactory = consentResponseFactory;
+    }
+
+    @Override
+    public ResponseEntity<OBWriteFileConsentResponse4> createFilePaymentConsents(OBWriteFileConsent3 obWriteFileConsent3,
+                                                                                 String authorization,
+                                                                                 String xIdempotencyKey,
+                                                                                 String xJwsSignature,
+                                                                                 DateTime xFapiAuthDate,
+                                                                                 String xFapiCustomerIpAddress,
+                                                                                 String xFapiInteractionId,
+                                                                                 String xCustomerUserAgent,
+                                                                                 String apiClientId,
+                                                                                 HttpServletRequest request,
+                                                                                 Principal principal) throws OBErrorResponseException {
+
+        logger.info("Processing createFilePaymentConsents request - consent: {}, idempotencyKey: {}, apiClient: {}, x-fapi-interaction-id: {}",
+                obWriteFileConsent3, xIdempotencyKey, apiClientId, xFapiInteractionId);
+
+        consentValidator.validate(obWriteFileConsent3);
+
+        final CreateFilePaymentConsentRequest createRequest = new CreateFilePaymentConsentRequest();
+        createRequest.setConsentRequest(toFRWriteFileConsent(obWriteFileConsent3));
+        createRequest.setApiClientId(apiClientId);
+        createRequest.setIdempotencyKey(xIdempotencyKey);
+        createRequest.setCharges(calculateCharges(obWriteFileConsent3));
+
+        final FilePaymentConsent consent = consentStoreApiClient.createConsent(createRequest);
+        logger.info("Created consent - id: {}", consent.getId());
+
+        return new ResponseEntity<>(consentResponseFactory.buildConsentResponse(consent, getClass()), HttpStatus.CREATED);
+    }
+
+    private List<FRCharge> calculateCharges(OBWriteFileConsent3 obWriteFileConsent3) {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public ResponseEntity<Void> createFilePaymentConsentsConsentIdFile(String fileParam,
+                                                                       String consentId,
+                                                                       String authorization,
+                                                                       String xIdempotencyKey,
+                                                                       String xJwsSignature,
+                                                                       DateTime xFapiAuthDate,
+                                                                       String xFapiCustomerIpAddress,
+                                                                       String xFapiInteractionId,
+                                                                       String xCustomerUserAgent,
+                                                                       String apiClientId,
+                                                                       HttpServletRequest request,
+                                                                       Principal principal) throws OBErrorException, OBErrorResponseException {
+
+        logger.info("Processing createFilePaymentConsentsConsentIdFile request - idempotencyKey: {}, apiClient: {}, x-fapi-interaction-id: {}",
+                xIdempotencyKey, apiClientId, xFapiInteractionId);
+
+        if (fileParam == null || fileParam.isBlank()) {
+            throw new OBErrorException(OBRIErrorType.REQUEST_FILE_EMPTY);
+        }
+
+        final FilePaymentConsent consent = consentStoreApiClient.getConsent(consentId, apiClientId);
+        fileContentValidator.validate(new FilePaymentFileContentValidationContext(fileParam,
+                FRWriteFileConsentConverter.toOBWriteFileConsent3(consent.getRequestObj())));
+
+        final FileUploadRequest fileUploadRequest = new FileUploadRequest();
+        fileUploadRequest.setApiClientId(apiClientId);
+        fileUploadRequest.setConsentId(consentId);
+        fileUploadRequest.setFileUploadIdempotencyKey(xIdempotencyKey);
+        fileUploadRequest.setFileContents(fileParam);
+
+        consentStoreApiClient.uploadFile(fileUploadRequest);
+
+        return ResponseEntity.status(HttpStatus.OK).build();
+    }
+
+    @Override
+    public ResponseEntity<OBWriteFileConsentResponse4> getFilePaymentConsentsConsentId(String consentId,
+                                                                                       String authorization,
+                                                                                       DateTime xFapiAuthDate,
+                                                                                       String xFapiCustomerIpAddress,
+                                                                                       String xFapiInteractionId,
+                                                                                       String xCustomerUserAgent,
+                                                                                       String apiClientId,
+                                                                                       HttpServletRequest request,
+                                                                                       Principal principal) {
+
+        logger.info("Processing getFilePaymentConsentsConsentId request - consentId: {}, apiClient: {}, x-fapi-interaction-id: {}",
+                consentId, apiClientId, xFapiInteractionId);
+
+        return ResponseEntity.ok(consentResponseFactory.buildConsentResponse(consentStoreApiClient.getConsent(consentId, apiClientId), getClass()));
+    }
+
+    @Override
+    public ResponseEntity<String> getFilePaymentConsentsConsentIdFile(String consentId,
+                                                                      String authorization,
+                                                                      String xFapiAuthDate,
+                                                                      String xFapiCustomerIpAddress,
+                                                                      String xFapiInteractionId,
+                                                                      String xCustomerUserAgent,
+                                                                      String apiClientId,
+                                                                      HttpServletRequest request,
+                                                                      Principal principal) throws OBErrorException {
+        logger.info("Processing getFilePaymentConsentsConsentIdFile request - consentId: {}, apiClient: {}, x-fapi-interaction-id: {}",
+                consentId, apiClientId, xFapiInteractionId);
+
+        final FilePaymentConsent consent = consentStoreApiClient.getConsent(consentId, apiClientId);
+        if (consent.getFileContent() == null) {
+            throw new OBErrorException(OBRIErrorType.NO_FILE_FOR_CONSENT);
+        }
+        final String fileType = consent.getRequestObj().getData().getInitiation().getFileType();
+        final PaymentFileType paymentFileType = PaymentFileType.fromFileType(fileType);
+
+        return ResponseEntity.status(HttpStatus.OK)
+                             .contentType(paymentFileType.getContentType())
+                             .body(consent.getFileContent());
+    }
+}

--- a/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/common/util/link/LinksHelper.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/common/util/link/LinksHelper.java
@@ -34,6 +34,7 @@ public class LinksHelper {
     private static final String DOMESTIC_SCHEDULED_PAYMENTS = "domestic-scheduled-payments";
     private static final String DOMESTIC_STANDING_ORDER_CONSENTS = "domestic-standing-order-consents";
     private static final String DOMESTIC_STANDING_ORDER = "domestic-standing-orders";
+    private static final String FILE_PAYMENT_CONSENTS = "file-payment-consents";
     private static final String FILE_PAYMENTS = "file-payments";
     private static final String INTERNATIONAL_PAYMENTS = "international-payments";
     private static final String INTERNATIONAL_SCHEDULED_PAYMENTS = "international-scheduled-payments";
@@ -139,6 +140,9 @@ public class LinksHelper {
         return createSelfLink(controllerClass, DOMESTIC_STANDING_ORDER, id, DOMESTIC_PAYMENTS_DETAILS);
     }
 
+    public static Links createFilePaymentConsentsLink(Class<?> controllerClass, String id) {
+        return createSelfLink(controllerClass, FILE_PAYMENT_CONSENTS, id);
+    }
 
     /**
      * Creates an instance of the OB {@link Links} class with only the 'self' link populated for a payments file.

--- a/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/configuration/validation/DefaultOBValidationModule.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/configuration/validation/DefaultOBValidationModule.java
@@ -23,6 +23,8 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+import com.forgerock.sapi.gateway.ob.uk.rs.server.api.obie.payment.services.validation.FilePaymentFileContentValidator;
+import com.forgerock.sapi.gateway.ob.uk.rs.server.api.obie.payment.services.validation.FilePaymentFileContentValidator.FilePaymentFileContentValidationContext;
 import com.forgerock.sapi.gateway.ob.uk.rs.server.common.Currencies;
 import com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.BaseOBValidator;
 import com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.OBValidationService;
@@ -39,11 +41,13 @@ import com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.payment.consent.OBDom
 import com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.payment.consent.OBWriteDomesticConsent4Validator;
 import com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.payment.consent.OBWriteDomesticScheduledConsent4Validator;
 import com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.payment.consent.OBWriteDomesticStandingOrderConsent5Validator;
+import com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.payment.consent.OBWriteFileConsent3Validator;
 
 import uk.org.openbanking.datamodel.payment.OBWriteDomestic2DataInitiationInstructedAmount;
 import uk.org.openbanking.datamodel.payment.OBWriteDomesticConsent4;
 import uk.org.openbanking.datamodel.payment.OBWriteDomesticScheduledConsent4;
 import uk.org.openbanking.datamodel.payment.OBWriteDomesticStandingOrderConsent5;
+import uk.org.openbanking.datamodel.payment.OBWriteFileConsent3;
 import uk.org.openbanking.datamodel.vrp.OBDomesticVRPConsentRequest;
 
 /**
@@ -112,5 +116,15 @@ public class DefaultOBValidationModule {
     @Bean
     public Set<String> validPaymentCurrencies() {
         return Arrays.stream(Currencies.values()).map(Currencies::getCode).collect(Collectors.toSet());
+    }
+
+    @Bean
+    public OBValidationService<OBWriteFileConsent3> filePaymentConsentValidator() {
+        return new OBValidationService<>(new OBWriteFileConsent3Validator());
+    }
+
+    @Bean
+    public OBValidationService<FilePaymentFileContentValidationContext> filePaymentFileContentValidator() {
+        return new OBValidationService<>(new FilePaymentFileContentValidator());
     }
 }

--- a/secure-api-gateway-ob-uk-rs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/factories/OBWriteFileConsentResponse4FactoryTest.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/factories/OBWriteFileConsentResponse4FactoryTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.ob.uk.rs.server.api.obie.payment.factories;
+
+import static com.forgerock.sapi.gateway.ob.uk.rs.server.util.BeanValidationTestUtils.verifyBeanValidationIsSuccessful;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.math.BigDecimal;
+
+import org.junit.jupiter.api.Test;
+
+import com.forgerock.sapi.gateway.ob.uk.rs.obie.api.payment.v3_1_10.domesticstandingorders.DomesticStandingOrderConsentsApi;
+import com.forgerock.sapi.gateway.ob.uk.rs.server.api.obie.payment.v3_1_10.file.FilePaymentConsentsApiControllerTest;
+import com.forgerock.sapi.gateway.rcs.consent.store.datamodel.payment.file.v3_1_10.FilePaymentConsent;
+
+import uk.org.openbanking.datamodel.payment.OBWriteFileConsent3;
+import uk.org.openbanking.datamodel.payment.OBWriteFileConsent3Data;
+import uk.org.openbanking.datamodel.payment.OBWriteFileConsentResponse4;
+import uk.org.openbanking.datamodel.payment.OBWriteFileConsentResponse4Data;
+import uk.org.openbanking.datamodel.payment.OBWriteFileConsentResponse4Data.StatusEnum;
+import uk.org.openbanking.testsupport.payment.OBWriteFileConsentTestDataFactory;
+
+class OBWriteFileConsentResponse4FactoryTest {
+
+    private final OBWriteFileConsentResponse4Factory factory = new OBWriteFileConsentResponse4Factory();
+
+    @Test
+    void testCreateConsentResponse() {
+        final OBWriteFileConsent3 consentRequest = OBWriteFileConsentTestDataFactory.aValidOBWriteFileConsent3(
+                "test-file-type", "test-hash", "8", new BigDecimal("1234567890.19"));
+        final OBWriteFileConsent3Data requestData = consentRequest.getData();
+        final FilePaymentConsent consent = FilePaymentConsentsApiControllerTest.buildAwaitingUploadConsent(consentRequest);
+        final OBWriteFileConsentResponse4 response = factory.buildConsentResponse(consent, DomesticStandingOrderConsentsApi.class);
+
+        final OBWriteFileConsentResponse4Data responseData = response.getData();
+        assertThat(responseData.getStatus()).isEqualTo(StatusEnum.AWAITINGUPLOAD);
+        assertThat(responseData.getConsentId()).isEqualTo(consent.getId());
+        assertThat(responseData.getCreationDateTime()).isEqualTo(consent.getCreationDateTime());
+        assertThat(responseData.getStatusUpdateDateTime()).isEqualTo(consent.getStatusUpdateDateTime());
+        assertThat(responseData.getCharges()).isEqualTo(consent.getCharges());
+
+        // Verify data against original Consent Request
+        assertThat(responseData.getScASupportData()).isEqualTo(requestData.getScASupportData());
+        assertThat(responseData.getAuthorisation()).isEqualTo(requestData.getAuthorisation());
+        assertThat(responseData.getInitiation()).usingRecursiveComparison().isEqualTo(requestData.getInitiation());
+
+        // Not currently generating data for these optional response fields
+        assertThat(responseData.getCutOffDateTime()).isNull();
+
+        assertThat(response.getLinks().getSelf().toString())
+                .endsWith("/open-banking/v3.1.10/pisp/file-payment-consents/" + consent.getId());
+        assertThat(response.getMeta()).isNotNull();
+
+        verifyBeanValidationIsSuccessful(response);
+    }
+}

--- a/secure-api-gateway-ob-uk-rs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/services/validation/FilePaymentFileContentValidatorTest.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/services/validation/FilePaymentFileContentValidatorTest.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.ob.uk.rs.server.api.obie.payment.services.validation;
+
+import static com.forgerock.sapi.gateway.ob.uk.rs.server.util.payment.file.TestPaymentFileResources.PAIN_001_001_08_FILE_PATH;
+import static com.forgerock.sapi.gateway.ob.uk.rs.server.util.payment.file.TestPaymentFileResources.PAYMENT_INITIATION_3_1_FILE_PATH;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.math.BigDecimal;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import com.forgerock.sapi.gateway.ob.uk.rs.server.api.obie.payment.services.validation.FilePaymentFileContentValidator.FilePaymentFileContentValidationContext;
+import com.forgerock.sapi.gateway.ob.uk.rs.server.common.util.HashUtils;
+import com.forgerock.sapi.gateway.ob.uk.rs.server.util.payment.file.TestPaymentFileResources;
+import com.forgerock.sapi.gateway.ob.uk.rs.server.util.payment.file.TestPaymentFileResources.TestPaymentFile;
+import com.forgerock.sapi.gateway.ob.uk.rs.validation.ValidationResult;
+
+import uk.org.openbanking.datamodel.error.OBError1;
+import uk.org.openbanking.datamodel.payment.OBWriteFileConsent3;
+import uk.org.openbanking.testsupport.payment.OBWriteFileConsentTestDataFactory;
+
+class FilePaymentFileContentValidatorTest {
+
+    private final TestPaymentFileResources testPaymentFileResources = new TestPaymentFileResources();
+
+    private final FilePaymentFileContentValidator validator = new FilePaymentFileContentValidator();
+
+
+    @ParameterizedTest
+    @ValueSource(strings = {PAYMENT_INITIATION_3_1_FILE_PATH, PAIN_001_001_08_FILE_PATH})
+    void fileContentValidationSucceeds(String filePath) {
+        final TestPaymentFile paymentFile = testPaymentFileResources.getPaymentFile(filePath);
+        final OBWriteFileConsent3 obFileConsent = createConsent(paymentFile);
+
+        final ValidationResult<OBError1> validationResult = validator.validate(new FilePaymentFileContentValidationContext(paymentFile.getFileContent(), obFileConsent));
+        assertThat(validationResult.isValid()).isTrue();
+    }
+
+
+    @ParameterizedTest
+    @ValueSource(strings = {PAYMENT_INITIATION_3_1_FILE_PATH, PAIN_001_001_08_FILE_PATH})
+    void validationFailsDueToFileParseError(String filePath) {
+        final String fileContent = "junk";
+        final TestPaymentFile paymentFile = testPaymentFileResources.getPaymentFile(filePath);
+
+        final ValidationResult<OBError1> validationResult = validator.validate(new FilePaymentFileContentValidationContext(fileContent,
+                OBWriteFileConsentTestDataFactory.aValidOBWriteFileConsent3(
+                        paymentFile.getFileType().getFileType(), HashUtils.computeSHA256FullHash(fileContent),
+                        String.valueOf(paymentFile.getNumTransactions()), paymentFile.getControlSum())));
+
+        assertThat(validationResult.isValid()).isFalse();
+        final OBError1 obError1 = validationResult.getErrors().get(0);
+        assertThat(obError1.getErrorCode()).startsWith("OBRI.Request.Object.file.invalid");
+        assertThat(obError1.getMessage()).startsWith("The file received was not parsable");
+    }
+
+    @Test
+    void validationFailsDueToFileHashMismatch() {
+        final TestPaymentFile paymentFile = testPaymentFileResources.getPaymentFile(PAIN_001_001_08_FILE_PATH);
+        final OBWriteFileConsent3 obFileConsent = OBWriteFileConsentTestDataFactory.aValidOBWriteFileConsent3(
+                paymentFile.getFileType().getFileType(), HashUtils.computeSHA256FullHash("different file"),
+                String.valueOf(paymentFile.getNumTransactions()), paymentFile.getControlSum());
+
+        final ValidationResult<OBError1> validationResult = validator.validate(new FilePaymentFileContentValidationContext(paymentFile.getFileContent(), obFileConsent));
+
+        assertThat(validationResult.isValid()).isFalse();
+        final OBError1 obError1 = validationResult.getErrors().get(0);
+        assertThat(obError1.getErrorCode()).isEqualTo("OBRI.Request.Object.file.hash.no.matching.metadata");
+        assertThat(obError1.getMessage()).contains("but the file consent metadata indicated that we are expecting a file hash of");
+    }
+
+    @Test
+    void validationFailsDueToNumberOfTransactionsMismatch() {
+        final TestPaymentFile paymentFile = testPaymentFileResources.getPaymentFile(PAIN_001_001_08_FILE_PATH);
+
+        final OBWriteFileConsent3 consent = OBWriteFileConsentTestDataFactory.aValidOBWriteFileConsent3(
+                paymentFile.getFileType().getFileType(), paymentFile.getFileHash(),
+                "999", paymentFile.getControlSum());
+
+        final ValidationResult<OBError1> validationResult = validator.validate(new FilePaymentFileContentValidationContext(
+                paymentFile.getFileContent(), consent));
+
+        assertThat(validationResult.isValid()).isFalse();
+        final OBError1 obError1 = validationResult.getErrors().get(0);
+        assertThat(obError1.getErrorCode()).isEqualTo("OBRI.Request.Object.file.wrong.number.of.transactions");
+        assertThat(obError1.getMessage()).isEqualTo("The file received contains 3 transactions but the file consent metadata indicated that we are expecting a file with 999 transactions'");
+    }
+
+    @Test
+    void validationFailsDueToControlSumMismatch() {
+        final TestPaymentFile paymentFile = testPaymentFileResources.getPaymentFile(PAIN_001_001_08_FILE_PATH);
+
+        final OBWriteFileConsent3 consent = OBWriteFileConsentTestDataFactory.aValidOBWriteFileConsent3(
+                paymentFile.getFileType().getFileType(), paymentFile.getFileHash(),
+                String.valueOf(paymentFile.getNumTransactions()), paymentFile.getControlSum().multiply(BigDecimal.valueOf(2)));
+
+        final ValidationResult<OBError1> validationResult = validator.validate(new FilePaymentFileContentValidationContext(
+                paymentFile.getFileContent(), consent));
+
+        assertThat(validationResult.isValid()).isFalse();
+        final OBError1 obError1 = validationResult.getErrors().get(0);
+        assertThat(obError1.getErrorCode()).isEqualTo("OBRI.Request.Object.file.wrong.control.sum");
+        assertThat(obError1.getMessage()).isEqualTo("The file received contains total transaction value of: 11500000 but the file consent metadata indicated a control sum value of 23000000.0000'");
+    }
+
+    private static OBWriteFileConsent3 createConsent(TestPaymentFile paymentFile) {
+        return OBWriteFileConsentTestDataFactory.aValidOBWriteFileConsent3(
+                paymentFile.getFileType().getFileType(), paymentFile.getFileHash(),
+                String.valueOf(paymentFile.getNumTransactions()), paymentFile.getControlSum());
+    }
+
+}

--- a/secure-api-gateway-ob-uk-rs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/v3_1_10/file/FilePaymentConsentsApiControllerTest.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/v3_1_10/file/FilePaymentConsentsApiControllerTest.java
@@ -1,0 +1,270 @@
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.ob.uk.rs.server.api.obie.payment.v3_1_10.file;
+
+import static com.forgerock.sapi.gateway.ob.uk.common.error.ErrorCode.OBRI_CONSENT_NOT_FOUND;
+import static com.forgerock.sapi.gateway.ob.uk.common.error.ErrorCode.OBRI_PERMISSION_INVALID;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.UUID;
+
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.ActiveProfiles;
+
+import com.forgerock.sapi.gateway.ob.uk.common.datamodel.converter.payment.FRWriteFileConsentConverter;
+import com.forgerock.sapi.gateway.ob.uk.rs.server.common.filepayment.PaymentFileType;
+import com.forgerock.sapi.gateway.ob.uk.rs.server.testsupport.api.HttpHeadersTestDataFactory;
+import com.forgerock.sapi.gateway.ob.uk.rs.server.util.payment.file.TestPaymentFileResources;
+import com.forgerock.sapi.gateway.ob.uk.rs.server.util.payment.file.TestPaymentFileResources.TestPaymentFile;
+import com.forgerock.sapi.gateway.rcs.consent.store.client.ConsentStoreClientException;
+import com.forgerock.sapi.gateway.rcs.consent.store.client.ConsentStoreClientException.ErrorType;
+import com.forgerock.sapi.gateway.rcs.consent.store.client.payment.file.v3_1_10.FilePaymentConsentStoreClient;
+import com.forgerock.sapi.gateway.rcs.consent.store.datamodel.payment.file.v3_1_10.CreateFilePaymentConsentRequest;
+import com.forgerock.sapi.gateway.rcs.consent.store.datamodel.payment.file.v3_1_10.FilePaymentConsent;
+import com.forgerock.sapi.gateway.rcs.consent.store.datamodel.payment.file.v3_1_10.FileUploadRequest;
+import com.forgerock.sapi.gateway.uk.common.shared.api.meta.share.IntentType;
+
+import uk.org.openbanking.datamodel.error.OBError1;
+import uk.org.openbanking.datamodel.error.OBErrorResponse1;
+import uk.org.openbanking.datamodel.error.OBStandardErrorCodes1;
+import uk.org.openbanking.datamodel.payment.OBWriteFileConsent3;
+import uk.org.openbanking.datamodel.payment.OBWriteFileConsentResponse4;
+import uk.org.openbanking.datamodel.payment.OBWriteFileConsentResponse4Data.StatusEnum;
+import uk.org.openbanking.testsupport.payment.OBWriteFileConsentTestDataFactory;
+
+@SpringBootTest(webEnvironment = RANDOM_PORT)
+@ActiveProfiles("test")
+public class FilePaymentConsentsApiControllerTest {
+
+    private static final String TEST_API_CLIENT_ID = "client_234093-49";
+
+    private static final HttpHeaders HTTP_HEADERS = HttpHeadersTestDataFactory.requiredPaymentsHttpHeadersWithApiClientId(TEST_API_CLIENT_ID);
+
+    @LocalServerPort
+    private int port;
+
+    @Autowired
+    private TestRestTemplate restTemplate;
+
+    @MockBean
+    private FilePaymentConsentStoreClient consentStoreClient;
+
+    private final TestPaymentFileResources testPaymentFileResources = new TestPaymentFileResources();
+
+    private String controllerBaseUri() {
+        return "http://localhost:" + port + "/open-banking/v3.1.10/pisp/file-payment-consents";
+    }
+
+    private String controllerGetConsentUri(String consentId) {
+        return controllerBaseUri() + "/" + consentId;
+    }
+
+    private String controllerUploadFileUri(String consentId) {
+        return controllerGetConsentUri(consentId) + "/file";
+    }
+
+
+    @Test
+    public void testCreateConsent() {
+        final String fileHash = "fileHash";
+        final int numTransactions = 1;
+        final BigDecimal controlSum = BigDecimal.ONE;
+        final OBWriteFileConsent3 consentRequest = createValidateConsentRequest(PaymentFileType.UK_OBIE_PAIN_001, fileHash,  numTransactions, controlSum);
+        final FilePaymentConsent consentStoreResponse = buildAwaitingUploadConsent(consentRequest);
+        when(consentStoreClient.createConsent(any())).thenAnswer(invocation -> {
+            final CreateFilePaymentConsentRequest createConsentArg = invocation.getArgument(0, CreateFilePaymentConsentRequest.class);
+            assertThat(createConsentArg.getApiClientId()).isEqualTo(TEST_API_CLIENT_ID);
+            assertThat(createConsentArg.getConsentRequest()).isEqualTo(FRWriteFileConsentConverter.toFRWriteFileConsent(consentRequest));
+            assertThat(createConsentArg.getCharges()).isEmpty();
+            assertThat(createConsentArg.getIdempotencyKey()).isEqualTo(HTTP_HEADERS.getFirst("x-idempotency-key"));
+
+            return consentStoreResponse;
+        });
+
+        final HttpEntity<OBWriteFileConsent3> entity = new HttpEntity<>(consentRequest, HTTP_HEADERS);
+
+        final ResponseEntity<OBWriteFileConsentResponse4> createResponse = restTemplate.exchange(controllerBaseUri(), HttpMethod.POST,
+                entity, OBWriteFileConsentResponse4.class);
+        assertThat(createResponse.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+        final OBWriteFileConsentResponse4 consentResponse = createResponse.getBody();
+        final String consentId = consentResponse.getData().getConsentId();
+        assertThat(consentId).isEqualTo(consentStoreResponse.getId());
+        assertThat(consentResponse.getData().getStatus()).isEqualTo(StatusEnum.AWAITINGUPLOAD);
+        assertThat(consentResponse.getData().getInitiation()).isEqualTo(consentRequest.getData().getInitiation());
+        assertThat(consentResponse.getData().getAuthorisation()).isEqualTo(consentRequest.getData().getAuthorisation());
+        assertThat(consentResponse.getData().getScASupportData()).isEqualTo(consentRequest.getData().getScASupportData());
+        assertThat(consentResponse.getData().getCreationDateTime()).isNotNull();
+        assertThat(consentResponse.getData().getStatusUpdateDateTime()).isNotNull();
+        final String selfLinkToConsent = consentResponse.getLinks().getSelf().toString();
+        assertThat(selfLinkToConsent).isEqualTo(controllerGetConsentUri(consentId));
+
+        // Get the consent and verify it matches the create response
+        when(consentStoreClient.getConsent(eq(consentId), eq(TEST_API_CLIENT_ID))).thenReturn(consentStoreResponse);
+
+        final ResponseEntity<OBWriteFileConsentResponse4> getConsentResponse = restTemplate.exchange(selfLinkToConsent,
+                HttpMethod.GET, new HttpEntity<>(HTTP_HEADERS), OBWriteFileConsentResponse4.class);
+
+        assertThat(getConsentResponse.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(getConsentResponse.getBody()).isEqualTo(consentResponse);
+    }
+
+    @Test
+    void testUploadFile() {
+        final String consentId = IntentType.PAYMENT_FILE_CONSENT.generateIntentId();
+
+        final TestPaymentFile paymentFile = testPaymentFileResources.getPaymentFile(TestPaymentFileResources.PAIN_001_001_08_FILE_PATH);
+
+        final String idempotencyKey = UUID.randomUUID().toString();
+        final HttpEntity<String> entity = new HttpEntity<>(paymentFile.getFileContent(), createHeadersForFileUpload(idempotencyKey, paymentFile.getFileType()));
+
+        given(consentStoreClient.getConsent(eq(consentId), eq(TEST_API_CLIENT_ID))).willReturn(buildAwaitingUploadConsent(
+                createValidateConsentRequest(paymentFile.getFileType(), paymentFile.getFileHash(), paymentFile.getNumTransactions(), paymentFile.getControlSum())));
+
+        final ResponseEntity<Void> createResponse = restTemplate.exchange(controllerUploadFileUri(consentId), HttpMethod.POST,
+                entity, Void.class);
+        assertThat(createResponse.getStatusCode()).isEqualTo(HttpStatus.OK);
+
+        final ArgumentCaptor<FileUploadRequest> fileUploadRequestArgumentCaptor = ArgumentCaptor.forClass(FileUploadRequest.class);
+        verify(consentStoreClient).uploadFile(fileUploadRequestArgumentCaptor.capture());
+        final FileUploadRequest fileUploadRequest = fileUploadRequestArgumentCaptor.getValue();
+        assertThat(fileUploadRequest.getConsentId()).isEqualTo(consentId);
+        assertThat(fileUploadRequest.getFileContents()).isEqualTo(paymentFile.getFileContent());
+        assertThat(fileUploadRequest.getFileUploadIdempotencyKey()).isEqualTo(idempotencyKey);
+        assertThat(fileUploadRequest.getApiClientId()).isEqualTo(TEST_API_CLIENT_ID);
+    }
+
+    @Test
+    void testFailToUploadInvalidFile() {
+        final String consentId = IntentType.PAYMENT_FILE_CONSENT.generateIntentId();
+
+        final TestPaymentFile paymentFile = testPaymentFileResources.getPaymentFile(TestPaymentFileResources.PAIN_001_001_08_FILE_PATH);
+
+        final String idempotencyKey = UUID.randomUUID().toString();
+        final HttpEntity<String> entity = new HttpEntity<>(paymentFile.getFileContent(), createHeadersForFileUpload(idempotencyKey, paymentFile.getFileType()));
+
+        // Num transactions in consent != num in file
+        given(consentStoreClient.getConsent(eq(consentId), eq(TEST_API_CLIENT_ID))).willReturn(buildAwaitingUploadConsent(
+                createValidateConsentRequest(paymentFile.getFileType(), paymentFile.getFileHash(), 1000, paymentFile.getControlSum())));
+
+        final ResponseEntity<OBErrorResponse1> fileUploadResponse = restTemplate.exchange(controllerUploadFileUri(consentId), HttpMethod.POST,
+                entity, OBErrorResponse1.class);
+
+        assertThat(fileUploadResponse.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        final OBErrorResponse1 obErrorResponse = fileUploadResponse.getBody();
+        assertThat(obErrorResponse.getErrors().size()).isEqualTo(1);
+        assertThat(obErrorResponse.getCode()).isEqualTo("OBRI.Request.Invalid");
+        final OBError1 obError1 = obErrorResponse.getErrors().get(0);
+        assertThat(obError1.getErrorCode()).isEqualTo("OBRI.Request.Object.file.wrong.number.of.transactions");
+        assertThat(obError1.getMessage()).isEqualTo("The file received contains 3 transactions but the file consent metadata indicated that we are expecting a file with 1000 transactions'");
+
+    }
+
+    @Test
+    public void failsToCreateConsentIfRequestDoesNotPassJavaBeanValidation() {
+        final OBWriteFileConsent3 emptyConsent = new OBWriteFileConsent3();
+
+        final ResponseEntity<OBErrorResponse1> response = restTemplate.exchange(controllerBaseUri(), HttpMethod.POST,
+                new HttpEntity<>(emptyConsent, HTTP_HEADERS), OBErrorResponse1.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+
+        final List<OBError1> errors = response.getBody().getErrors();
+        assertThat(errors).hasSize(1);
+        final String fieldInvalidErrCode = OBStandardErrorCodes1.UK_OBIE_FIELD_INVALID.toString();
+        assertThat(errors.get(0)).isEqualTo(
+                new OBError1().errorCode(fieldInvalidErrCode).message("The field received is invalid. Reason 'must not be null'").path("data"));
+
+        verifyNoMoreInteractions(consentStoreClient);
+    }
+
+    @Test
+    public void failsToGetConsentThatDoesNotExist() {
+        when(consentStoreClient.getConsent(anyString(), anyString())).thenThrow(new ConsentStoreClientException(ErrorType.NOT_FOUND, "Consent Not Found"));
+        final ResponseEntity<OBErrorResponse1> consentNotFoundResponse = restTemplate.exchange(controllerGetConsentUri("unknown"),
+                HttpMethod.GET, new HttpEntity<>(HTTP_HEADERS), OBErrorResponse1.class);
+
+        assertThat(consentNotFoundResponse.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+        assertThat(consentNotFoundResponse.getBody().getCode()).isEqualTo(OBRI_CONSENT_NOT_FOUND.toString());
+    }
+
+    @Test
+    public void failsToGetConsentInvalidPermissions() {
+        when(consentStoreClient.getConsent(anyString(), anyString())).thenThrow(new ConsentStoreClientException(ErrorType.INVALID_PERMISSIONS, "ApiClient does not have permission to access Consent"));
+        final ResponseEntity<OBErrorResponse1> consentNotFoundResponse = restTemplate.exchange(controllerGetConsentUri("unknown"),
+                HttpMethod.GET, new HttpEntity<>(HTTP_HEADERS), OBErrorResponse1.class);
+
+        assertThat(consentNotFoundResponse.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
+        assertThat(consentNotFoundResponse.getBody().getCode()).isEqualTo(OBRI_PERMISSION_INVALID.toString());
+    }
+
+
+    private static OBWriteFileConsent3 createValidateConsentRequest(PaymentFileType paymentFileType, String fileHash,
+                                                                    int numTransactions, BigDecimal controlSum) {
+        final OBWriteFileConsent3 consentRequest = OBWriteFileConsentTestDataFactory.aValidOBWriteFileConsent3(
+                paymentFileType.getFileType(), fileHash, String.valueOf(numTransactions), controlSum);
+        consentRequest.getData().getInitiation().setRequestedExecutionDateTime(consentRequest.getData().getInitiation().getRequestedExecutionDateTime().withZone(DateTimeZone.UTC));
+        consentRequest.getData().getAuthorisation().setCompletionDateTime(consentRequest.getData().getAuthorisation().getCompletionDateTime().withZone(DateTimeZone.UTC));
+
+        return consentRequest;
+    }
+
+    public static FilePaymentConsent buildAwaitingUploadConsent(OBWriteFileConsent3 consentRequest) {
+        final FilePaymentConsent consentStoreResponse = new FilePaymentConsent();
+        consentStoreResponse.setId(IntentType.PAYMENT_FILE_CONSENT.generateIntentId());
+        consentStoreResponse.setRequestObj(FRWriteFileConsentConverter.toFRWriteFileConsent(consentRequest));
+        consentStoreResponse.setStatus(StatusEnum.AWAITINGUPLOAD.toString());
+        consentStoreResponse.setCharges(List.of());
+        final DateTime creationDateTime = DateTime.now();
+        consentStoreResponse.setCreationDateTime(creationDateTime);
+        consentStoreResponse.setStatusUpdateDateTime(creationDateTime);
+        return consentStoreResponse;
+    }
+
+    private static HttpHeaders createHeadersForFileUpload(String idempotencyKey, PaymentFileType paymentFileType) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(paymentFileType.getContentType());
+        headers.setBearerAuth("dummyAuthToken");
+        headers.add("x-fapi-interaction-id", UUID.randomUUID().toString());
+        headers.add("x-idempotency-key", idempotencyKey);
+        headers.add("x-api-client-id", TEST_API_CLIENT_ID);
+        headers.add("x-jws-signature", "dummySig");
+        return headers;
+    }
+
+}

--- a/secure-api-gateway-ob-uk-rs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/server/util/payment/file/TestPaymentFileResources.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/server/util/payment/file/TestPaymentFileResources.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.ob.uk.rs.server.util.payment.file;
+
+import java.io.File;
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.nio.file.Files;
+import java.util.HashMap;
+import java.util.Map;
+
+import com.forgerock.sapi.gateway.ob.uk.rs.server.common.filepayment.PaymentFileType;
+import com.forgerock.sapi.gateway.ob.uk.rs.server.common.util.HashUtils;
+
+/**
+ * Class containing test payment files and their metadata
+ */
+public class TestPaymentFileResources {
+
+    public static final String PAIN_001_001_08_FILE_PATH = "src/test/resources/payment/files/UK_OBIE_pain_001_001_08.xml";
+
+    public static final String PAYMENT_INITIATION_3_1_FILE_PATH = "src/test/resources/payment/files/UK_OBIE_PaymentInitiation_3_1.json";
+
+    private final Map<String, TestPaymentFile> paymentFiles;
+
+    public TestPaymentFileResources() {
+        paymentFiles = new HashMap<>();
+        paymentFiles.put(PAIN_001_001_08_FILE_PATH, loadTestPaymentFile(PAIN_001_001_08_FILE_PATH, PaymentFileType.UK_OBIE_PAIN_001, 3, new BigDecimal("11500000")));
+        paymentFiles.put(PAYMENT_INITIATION_3_1_FILE_PATH, loadTestPaymentFile(PAYMENT_INITIATION_3_1_FILE_PATH, PaymentFileType.UK_OBIE_PAYMENT_INITIATION_V3_1, 4, new BigDecimal("87")));
+    }
+
+    public Map<String, TestPaymentFile> getPaymentFiles() {
+        return paymentFiles;
+    }
+
+    public TestPaymentFile getPaymentFile(String filePath) {
+        final TestPaymentFile testPaymentFile = paymentFiles.get(filePath);
+        if (testPaymentFile == null) {
+            throw new IllegalStateException("Test file configuration not found for path: " + filePath);
+        }
+        return testPaymentFile;
+    }
+
+    private TestPaymentFile loadTestPaymentFile(String path, PaymentFileType fileType, int numTransactions, BigDecimal controlSum) {
+        try {
+            final String fileContent = Files.readString(new File(path).toPath());
+            final String fileHash = HashUtils.computeSHA256FullHash(fileContent);
+            return new TestPaymentFile(fileContent, fileType, fileHash, numTransactions, controlSum);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static class TestPaymentFile {
+        private final String fileContent;
+        private final PaymentFileType fileType;
+        private final String fileHash;
+        private final int numTransactions;
+        private final BigDecimal controlSum;
+
+        public TestPaymentFile(String fileContent, PaymentFileType fileType, String fileHash, int numTransactions, BigDecimal controlSum) {
+            this.fileContent = fileContent;
+            this.fileType = fileType;
+            this.fileHash = fileHash;
+            this.numTransactions = numTransactions;
+            this.controlSum = controlSum;
+        }
+
+        public String getFileContent() {
+            return fileContent;
+        }
+
+        public PaymentFileType getFileType() {
+            return fileType;
+        }
+
+        public BigDecimal getControlSum() {
+            return controlSum;
+        }
+
+        public int getNumTransactions() {
+            return numTransactions;
+        }
+
+        public String getFileHash() {
+            return fileHash;
+        }
+    }
+
+}

--- a/secure-api-gateway-ob-uk-rs-validation/secure-api-gateway-ob-uk-rs-validation-obie/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/validation/obie/payment/consent/OBWriteFileConsent3Validator.java
+++ b/secure-api-gateway-ob-uk-rs-validation/secure-api-gateway-ob-uk-rs-validation-obie/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/validation/obie/payment/consent/OBWriteFileConsent3Validator.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.payment.consent;
+
+import com.forgerock.sapi.gateway.ob.uk.rs.validation.ValidationResult;
+import com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.BaseOBValidator;
+
+import uk.org.openbanking.datamodel.error.OBError1;
+import uk.org.openbanking.datamodel.payment.OBWriteFileConsent3;
+
+public class OBWriteFileConsent3Validator extends BaseOBValidator<OBWriteFileConsent3> {
+
+    @Override
+    protected void validate(OBWriteFileConsent3 obj, ValidationResult<OBError1> validationResult) {
+    }
+}


### PR DESCRIPTION
Implementing File Payment Consent API in RS.

FilePaymentFileContentValidator validates that the file uploaded vs the consent request.

https://github.com/SecureApiGateway/SecureApiGateway/issues/1065