### PR TITLE
1076: No longer deploying jars when building a PR

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -62,12 +62,6 @@ jobs:
         run: |
           make verify
 
-      - name: Deploy artifact package
-        run: mvn -B deploy -DskipTests -DskipITs -DdockerCompose.skip -Ddockerfile.skip
-        env:
-          FR_ARTIFACTORY_USER: ${{ secrets.FR_ARTIFACTORY_USER }}
-          FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD: ${{ secrets.FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD }}
-
       - run: |
           gcloud auth configure-docker
       


### PR DESCRIPTION
Issue with the previous approach is that the SNAPSHOT version will be latest PR to be built, this causes instability in extension projects which use the SNAPSHOT version.

https://github.com/SecureApiGateway/SecureApiGateway/issues/1076