### PR TITLE
1062: Adding InternationalPaymentConsentsApi + Controller

### DIFF
--- a/secure-api-gateway-ob-uk-rs-obie-api/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/obie/api/payment/v3_1_10/internationalpayments/InternationalPaymentConsentsApi.java
+++ b/secure-api-gateway-ob-uk-rs-obie-api/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/obie/api/payment/v3_1_10/internationalpayments/InternationalPaymentConsentsApi.java
@@ -1,0 +1,206 @@
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.ob.uk.rs.obie.api.payment.v3_1_10.internationalpayments;
+
+import static com.forgerock.sapi.gateway.ob.uk.rs.obie.api.ApiConstants.HTTP_DATE_FORMAT;
+
+import java.security.Principal;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.validation.Valid;
+
+import org.joda.time.DateTime;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+
+import com.forgerock.sapi.gateway.ob.uk.common.error.OBErrorResponseException;
+
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
+import io.swagger.annotations.Authorization;
+import io.swagger.annotations.AuthorizationScope;
+import uk.org.openbanking.datamodel.error.OBErrorResponse1;
+import uk.org.openbanking.datamodel.payment.OBWriteFundsConfirmationResponse1;
+import uk.org.openbanking.datamodel.payment.OBWriteInternationalConsent5;
+import uk.org.openbanking.datamodel.payment.OBWriteInternationalConsentResponse6;
+
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2020-05-22T14:20:48.770Z")
+
+@Api(value = "international-payment-consents", description = "the international-payment-consents API")
+@RequestMapping(value = "/open-banking/v3.1.10/pisp")
+public interface InternationalPaymentConsentsApi {
+
+    @ApiOperation(value = "Create International Payment Consents", nickname = "createInternationalPaymentConsents", notes = "", response = OBWriteInternationalConsentResponse6.class, authorizations = {
+            @Authorization(value = "TPPOAuth2Security", scopes = {
+                    @AuthorizationScope(scope = "payments", description = "Generic payment scope")
+            })
+    }, tags = {"International Payments",})
+    @ApiResponses(value = {
+            @ApiResponse(code = 201, message = "International Payment Consents Created", response = OBWriteInternationalConsentResponse6.class),
+            @ApiResponse(code = 400, message = "Bad request", response = OBErrorResponse1.class),
+            @ApiResponse(code = 401, message = "Unauthorized"),
+            @ApiResponse(code = 403, message = "Forbidden", response = OBErrorResponse1.class),
+            @ApiResponse(code = 404, message = "Not found"),
+            @ApiResponse(code = 405, message = "Method Not Allowed"),
+            @ApiResponse(code = 406, message = "Not Acceptable"),
+            @ApiResponse(code = 429, message = "Too Many Requests"),
+            @ApiResponse(code = 500, message = "Internal Server Error", response = OBErrorResponse1.class)})
+
+    @RequestMapping(value = "/international-payment-consents",
+            produces = {"application/json; charset=utf-8", "application/jose+jwe"},
+            consumes = {"application/json; charset=utf-8", "application/jose+jwe"},
+            method = RequestMethod.POST)
+    ResponseEntity<OBWriteInternationalConsentResponse6> createInternationalPaymentConsents(
+            @ApiParam(value = "Default", required = true)
+            @Valid
+            @RequestBody OBWriteInternationalConsent5 obWriteInternationalConsent5,
+
+            @ApiParam(value = "An Authorisation Token as per https://tools.ietf.org/html/rfc6750", required = true)
+            @RequestHeader(value = "Authorization", required = true) String authorization,
+
+            @ApiParam(value = "Every request will be processed only once per x-idempotency-key.  The Idempotency Key will be valid for 24 hours. ", required = true)
+            @RequestHeader(value = "x-idempotency-key", required = true) String xIdempotencyKey,
+
+            @ApiParam(value = "A detached JWS signature of the body of the payload.", required = true)
+            @RequestHeader(value = "x-jws-signature", required = true) String xJwsSignature,
+
+            @ApiParam(value = "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC")
+            @RequestHeader(value = "x-fapi-auth-date", required = false)
+            @DateTimeFormat(pattern = HTTP_DATE_FORMAT) DateTime xFapiAuthDate,
+
+            @ApiParam(value = "The PSU's IP address if the PSU is currently logged in with the TPP.")
+            @RequestHeader(value = "x-fapi-customer-ip-address", required = false) String xFapiCustomerIpAddress,
+
+            @ApiParam(value = "An RFC4122 UID used as a correlation id.")
+            @RequestHeader(value = "x-fapi-interaction-id", required = false) String xFapiInteractionId,
+
+            @ApiParam(value = "Indicates the user-agent that the PSU is using.")
+            @RequestHeader(value = "x-customer-user-agent", required = false) String xCustomerUserAgent,
+
+            @ApiParam(value = "OAuth2.0 client_id of the ApiClient making the request")
+            @RequestHeader(value = "x-api-client-id") String apiClientId,
+
+            HttpServletRequest request,
+
+            Principal principal
+    ) throws OBErrorResponseException;
+
+
+    @ApiOperation(value = "Get International Payment Consents", nickname = "getInternationalPaymentConsentsConsentId", notes = "", response = OBWriteInternationalConsentResponse6.class, authorizations = {
+            @Authorization(value = "TPPOAuth2Security", scopes = {
+                    @AuthorizationScope(scope = "payments", description = "Generic payment scope")
+            })
+    }, tags = {"International Payments",})
+    @ApiResponses(value = {
+            @ApiResponse(code = 200, message = "International Payment Consents Read", response = OBWriteInternationalConsentResponse6.class),
+            @ApiResponse(code = 400, message = "Bad request", response = OBErrorResponse1.class),
+            @ApiResponse(code = 401, message = "Unauthorized"),
+            @ApiResponse(code = 403, message = "Forbidden", response = OBErrorResponse1.class),
+            @ApiResponse(code = 404, message = "Not found"),
+            @ApiResponse(code = 405, message = "Method Not Allowed"),
+            @ApiResponse(code = 406, message = "Not Acceptable"),
+            @ApiResponse(code = 429, message = "Too Many Requests"),
+            @ApiResponse(code = 500, message = "Internal Server Error", response = OBErrorResponse1.class)})
+
+    @RequestMapping(value = "/international-payment-consents/{ConsentId}",
+            produces = {"application/json; charset=utf-8", "application/jose+jwe"},
+            method = RequestMethod.GET)
+    ResponseEntity<OBWriteInternationalConsentResponse6> getInternationalPaymentConsentsConsentId(
+            @ApiParam(value = "ConsentId", required = true)
+            @PathVariable("ConsentId") String consentId,
+
+            @ApiParam(value = "An Authorisation Token as per https://tools.ietf.org/html/rfc6750", required = true)
+            @RequestHeader(value = "Authorization", required = true) String authorization,
+
+            @ApiParam(value = "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC")
+            @RequestHeader(value = "x-fapi-auth-date", required = false)
+            @DateTimeFormat(pattern = HTTP_DATE_FORMAT) DateTime xFapiAuthDate,
+
+            @ApiParam(value = "The PSU's IP address if the PSU is currently logged in with the TPP.")
+            @RequestHeader(value = "x-fapi-customer-ip-address", required = false) String xFapiCustomerIpAddress,
+
+            @ApiParam(value = "An RFC4122 UID used as a correlation id.")
+            @RequestHeader(value = "x-fapi-interaction-id", required = false) String xFapiInteractionId,
+
+            @ApiParam(value = "Indicates the user-agent that the PSU is using.")
+            @RequestHeader(value = "x-customer-user-agent", required = false) String xCustomerUserAgent,
+
+            @ApiParam(value = "OAuth2.0 client_id of the ApiClient making the request")
+            @RequestHeader(value = "x-api-client-id") String apiClientId,
+
+            HttpServletRequest request,
+
+            Principal principal
+    ) throws OBErrorResponseException;
+
+
+    @ApiOperation(value = "Get International Payment Consents", nickname = "getInternationalPaymentConsentsConsentIdFundsConfirmation", notes = "", response = OBWriteFundsConfirmationResponse1.class, authorizations = {
+            @Authorization(value = "PSUOAuth2Security", scopes = {
+                    @AuthorizationScope(scope = "payments", description = "Generic payment scope")
+            })
+    }, tags = {"International Payments",})
+    @ApiResponses(value = {
+            @ApiResponse(code = 200, message = "International Payment Consents Read", response = OBWriteFundsConfirmationResponse1.class),
+            @ApiResponse(code = 400, message = "Bad request", response = OBErrorResponse1.class),
+            @ApiResponse(code = 401, message = "Unauthorized"),
+            @ApiResponse(code = 403, message = "Forbidden", response = OBErrorResponse1.class),
+            @ApiResponse(code = 404, message = "Not found"),
+            @ApiResponse(code = 405, message = "Method Not Allowed"),
+            @ApiResponse(code = 406, message = "Not Acceptable"),
+            @ApiResponse(code = 429, message = "Too Many Requests"),
+            @ApiResponse(code = 500, message = "Internal Server Error", response = OBErrorResponse1.class)})
+
+    @RequestMapping(value = "/international-payment-consents/{ConsentId}/funds-confirmation",
+            produces = {"application/json; charset=utf-8", "application/jose+jwe"},
+            method = RequestMethod.GET)
+    ResponseEntity<OBWriteFundsConfirmationResponse1> getInternationalPaymentConsentsConsentIdFundsConfirmation(
+            @ApiParam(value = "ConsentId", required = true)
+            @PathVariable("ConsentId") String consentId,
+
+            @ApiParam(value = "An Authorisation Token as per https://tools.ietf.org/html/rfc6750", required = true)
+            @RequestHeader(value = "Authorization", required = true) String authorization,
+
+            @ApiParam(value = "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC")
+            @RequestHeader(value = "x-fapi-auth-date", required = false)
+            @DateTimeFormat(pattern = HTTP_DATE_FORMAT) DateTime xFapiAuthDate,
+
+            @ApiParam(value = "The PSU's IP address if the PSU is currently logged in with the TPP.")
+            @RequestHeader(value = "x-fapi-customer-ip-address", required = false) String xFapiCustomerIpAddress,
+
+            @ApiParam(value = "An RFC4122 UID used as a correlation id.")
+            @RequestHeader(value = "x-fapi-interaction-id", required = false) String xFapiInteractionId,
+
+            @ApiParam(value = "Indicates the user-agent that the PSU is using.")
+            @RequestHeader(value = "x-customer-user-agent", required = false) String xCustomerUserAgent,
+
+            @ApiParam(value = "OAuth2.0 client_id of the ApiClient making the request")
+            @RequestHeader(value = "x-api-client-id") String apiClientId,
+
+            HttpServletRequest request,
+
+            Principal principal
+    ) throws OBErrorResponseException;
+
+}
+

--- a/secure-api-gateway-ob-uk-rs-obie-api/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/obie/api/payment/v3_1_5/internationalpayments/InternationalPaymentsApi.java
+++ b/secure-api-gateway-ob-uk-rs-obie-api/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/obie/api/payment/v3_1_5/internationalpayments/InternationalPaymentsApi.java
@@ -90,6 +90,9 @@ public interface InternationalPaymentsApi {
             @ApiParam(value = "Indicates the user-agent that the PSU is using.")
             @RequestHeader(value = "x-customer-user-agent", required = false) String xCustomerUserAgent,
 
+            @ApiParam(value = "OAuth2.0 client_id of the ApiClient making the request")
+            @RequestHeader(value = "x-api-client-id") String apiClientId,
+
             HttpServletRequest request,
 
             Principal principal
@@ -135,6 +138,9 @@ public interface InternationalPaymentsApi {
             @ApiParam(value = "Indicates the user-agent that the PSU is using.")
             @RequestHeader(value = "x-customer-user-agent", required = false) String xCustomerUserAgent,
 
+            @ApiParam(value = "OAuth2.0 client_id of the ApiClient making the request")
+            @RequestHeader(value = "x-api-client-id") String apiClientId,
+
             HttpServletRequest request,
 
             Principal principal
@@ -179,6 +185,9 @@ public interface InternationalPaymentsApi {
 
             @ApiParam(value = "Indicates the user-agent that the PSU is using.")
             @RequestHeader(value = "x-customer-user-agent", required = false) String xCustomerUserAgent,
+
+            @ApiParam(value = "OAuth2.0 client_id of the ApiClient making the request")
+            @RequestHeader(value = "x-api-client-id") String apiClientId,
 
             HttpServletRequest request,
 

--- a/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/factories/OBWriteFundsConfirmationResponse1Factory.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/factories/OBWriteFundsConfirmationResponse1Factory.java
@@ -15,30 +15,32 @@
  */
 package com.forgerock.sapi.gateway.ob.uk.rs.server.api.obie.payment.factories;
 
+
+import java.util.function.Function;
+
 import org.joda.time.DateTime;
 import org.springframework.stereotype.Component;
 
-import com.forgerock.sapi.gateway.ob.uk.rs.server.common.util.link.LinksHelper;
-
+import uk.org.openbanking.datamodel.common.Links;
 import uk.org.openbanking.datamodel.common.Meta;
 import uk.org.openbanking.datamodel.payment.OBWriteFundsConfirmationResponse1;
 import uk.org.openbanking.datamodel.payment.OBWriteFundsConfirmationResponse1Data;
 import uk.org.openbanking.datamodel.payment.OBWriteFundsConfirmationResponse1DataFundsAvailableResult;
 
 /**
- * Factory capable of producing {@link OBWriteFundsConfirmationResponse1} objects. These schema objects are reused by
- * the funds confirmation endpoint of many of the Payment APIs.
+ * Factory capable of producing {@link OBWriteFundsConfirmationResponse1} objects.
+ * These schema objects are reused by the funds confirmation endpoint of many of the Payment APIs.
  */
 @Component
 public class OBWriteFundsConfirmationResponse1Factory {
 
-    public OBWriteFundsConfirmationResponse1 create(boolean fundsAvailable, String consentId, Class<?> controllerClass) {
+    public OBWriteFundsConfirmationResponse1 create(boolean fundsAvailable, String consentId, Function<String, Links> fundsConfirmationLinksFactory) {
         return new OBWriteFundsConfirmationResponse1()
                 .data(new OBWriteFundsConfirmationResponse1Data()
                         .fundsAvailableResult(new OBWriteFundsConfirmationResponse1DataFundsAvailableResult()
                                                         .fundsAvailable(fundsAvailable)
                                                         .fundsAvailableDateTime(DateTime.now())))
-                .links(LinksHelper.createDomesticPaymentConsentsFundsConfirmationLink(controllerClass, consentId))
+                .links(fundsConfirmationLinksFactory.apply(consentId))
                 .meta(new Meta());
     }
 

--- a/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/factories/OBWriteInternationalConsentResponse6Factory.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/factories/OBWriteInternationalConsentResponse6Factory.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.ob.uk.rs.server.api.obie.payment.factories;
+
+import static com.forgerock.sapi.gateway.ob.uk.rs.server.common.util.link.LinksHelper.createInternationalPaymentConsentsLink;
+
+import org.springframework.stereotype.Component;
+
+import com.forgerock.sapi.gateway.ob.uk.common.datamodel.converter.common.FRChargeConverter;
+import com.forgerock.sapi.gateway.ob.uk.common.datamodel.converter.payment.FRExchangeRateConverter;
+import com.forgerock.sapi.gateway.ob.uk.common.datamodel.converter.payment.FRWriteInternationalConsentConverter;
+import com.forgerock.sapi.gateway.ob.uk.common.datamodel.payment.FRWriteInternationalConsent;
+import com.forgerock.sapi.gateway.rcs.consent.store.datamodel.payment.international.v3_1_10.InternationalPaymentConsent;
+
+import uk.org.openbanking.datamodel.common.Meta;
+import uk.org.openbanking.datamodel.payment.OBWriteInternationalConsent5;
+import uk.org.openbanking.datamodel.payment.OBWriteInternationalConsent5Data;
+import uk.org.openbanking.datamodel.payment.OBWriteInternationalConsentResponse6;
+import uk.org.openbanking.datamodel.payment.OBWriteInternationalConsentResponse6Data;
+import uk.org.openbanking.datamodel.payment.OBWriteInternationalConsentResponse6Data.StatusEnum;
+
+@Component
+public class OBWriteInternationalConsentResponse6Factory {
+
+    public OBWriteInternationalConsentResponse6 buildConsentResponse(InternationalPaymentConsent consent, Class<?> controllerClass) {
+        final FRWriteInternationalConsent consentRequest = consent.getRequestObj();
+        final OBWriteInternationalConsent5 obConsent = FRWriteInternationalConsentConverter.toOBWriteInternationalConsent5(consentRequest);
+        final OBWriteInternationalConsent5Data obConsentData = obConsent.getData();
+
+        final OBWriteInternationalConsentResponse6Data data = new OBWriteInternationalConsentResponse6Data();
+        data.authorisation(obConsentData.getAuthorisation());
+        data.readRefundAccount(obConsentData.getReadRefundAccount());
+        data.scASupportData(obConsentData.getScASupportData());
+        data.initiation(obConsentData.getInitiation());
+        data.charges(FRChargeConverter.toOBWriteDomesticConsentResponse5DataCharges(consent.getCharges()));
+        data.consentId(consent.getId());
+        data.exchangeRateInformation(FRExchangeRateConverter.toOBWriteInternationalConsentResponse6DataExchangeRateInformation(consent.getExchangeRateInformation()));
+        data.status(StatusEnum.fromValue(consent.getStatus()));
+        data.creationDateTime(consent.getCreationDateTime());
+        data.statusUpdateDateTime(consent.getStatusUpdateDateTime());
+
+        return new OBWriteInternationalConsentResponse6()
+                .data(data)
+                .risk(obConsent.getRisk())
+                .links(createInternationalPaymentConsentsLink(controllerClass, consent.getId()))
+                .meta(new Meta());
+    }
+}

--- a/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/services/RefundAccountService.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/services/RefundAccountService.java
@@ -40,7 +40,7 @@ public class RefundAccountService {
         this.accountRepository = accountRepository;
     }
 
-    public Optional<FRResponseDataRefund> getRefundAccountData(FRReadRefundAccount readRefundAccount, BasePaymentConsent<?> paymentConsent) {
+    public Optional<FRResponseDataRefund> getDomesticPaymentRefundData(FRReadRefundAccount readRefundAccount, BasePaymentConsent<?> paymentConsent) {
         if (readRefundAccount == FRReadRefundAccount.YES) {
             final FRAccount debtorAccount = accountRepository.byAccountId(paymentConsent.getAuthorisedDebtorAccountId());
             return FRResponseDataRefundFactory.frResponseDataRefund(debtorAccount.getAccount().getFirstAccount());
@@ -49,18 +49,14 @@ public class RefundAccountService {
         }
     }
 
-    public Optional<FRInternationalResponseDataRefund> getInternationalRefundAccountData(FRReadRefundAccount readRefundAccount,
+    public Optional<FRInternationalResponseDataRefund> getInternationalPaymentRefundData(FRReadRefundAccount readRefundAccount,
             FRFinancialCreditor creditor, FRFinancialAgent agent, BasePaymentConsent<?> paymentConsent) {
 
-        if (readRefundAccount == FRReadRefundAccount.YES) {
-            return getRefundAccountData(readRefundAccount, paymentConsent).map(refundData -> FRInternationalResponseDataRefund.builder()
-                    .account(refundData.getAccount())
-                    .creditor(creditor)
-                    .agent(agent)
-                    .build());
-        } else {
-            return Optional.empty();
-        }
-
+        return getDomesticPaymentRefundData(readRefundAccount, paymentConsent)
+                    .map(refundData -> FRInternationalResponseDataRefund.builder()
+                                                                        .account(refundData.getAccount())
+                                                                        .creditor(creditor)
+                                                                        .agent(agent)
+                                                                        .build());
     }
 }

--- a/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/services/RefundAccountService.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/services/RefundAccountService.java
@@ -15,8 +15,11 @@
  */
 package com.forgerock.sapi.gateway.ob.uk.rs.server.api.obie.payment.services;
 
+import com.forgerock.sapi.gateway.ob.uk.common.datamodel.common.FRFinancialAgent;
+import com.forgerock.sapi.gateway.ob.uk.common.datamodel.common.FRFinancialCreditor;
 import com.forgerock.sapi.gateway.ob.uk.common.datamodel.common.FRReadRefundAccount;
 import com.forgerock.sapi.gateway.ob.uk.common.datamodel.common.FRResponseDataRefund;
+import com.forgerock.sapi.gateway.ob.uk.common.datamodel.payment.FRInternationalResponseDataRefund;
 import com.forgerock.sapi.gateway.ob.uk.rs.server.common.refund.FRResponseDataRefundFactory;
 import com.forgerock.sapi.gateway.rcs.consent.store.datamodel.payment.BasePaymentConsent;
 import com.forgerock.sapi.gateway.rs.resource.store.repo.entity.account.FRAccount;
@@ -44,5 +47,20 @@ public class RefundAccountService {
         } else {
             return Optional.empty();
         }
+    }
+
+    public Optional<FRInternationalResponseDataRefund> getInternationalRefundAccountData(FRReadRefundAccount readRefundAccount,
+            FRFinancialCreditor creditor, FRFinancialAgent agent, BasePaymentConsent<?> paymentConsent) {
+
+        if (readRefundAccount == FRReadRefundAccount.YES) {
+            return getRefundAccountData(readRefundAccount, paymentConsent).map(refundData -> FRInternationalResponseDataRefund.builder()
+                    .account(refundData.getAccount())
+                    .creditor(creditor)
+                    .agent(agent)
+                    .build());
+        } else {
+            return Optional.empty();
+        }
+
     }
 }

--- a/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/v3_1_10/domesticpayments/DomesticPaymentConsentsApiController.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/v3_1_10/domesticpayments/DomesticPaymentConsentsApiController.java
@@ -36,6 +36,7 @@ import com.forgerock.sapi.gateway.ob.uk.common.error.OBRIErrorType;
 import com.forgerock.sapi.gateway.ob.uk.rs.obie.api.payment.v3_1_10.domesticpayments.DomesticPaymentConsentsApi;
 import com.forgerock.sapi.gateway.ob.uk.rs.server.api.obie.payment.factories.OBWriteDomesticConsentResponse5Factory;
 import com.forgerock.sapi.gateway.ob.uk.rs.server.api.obie.payment.factories.OBWriteFundsConfirmationResponse1Factory;
+import com.forgerock.sapi.gateway.ob.uk.rs.server.common.util.link.LinksHelper;
 import com.forgerock.sapi.gateway.ob.uk.rs.server.service.balance.FundsAvailabilityService;
 import com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.OBValidationService;
 import com.forgerock.sapi.gateway.rcs.consent.store.client.payment.domestic.v3_1_10.DomesticPaymentConsentStoreClient;
@@ -106,7 +107,7 @@ public class DomesticPaymentConsentsApiController implements DomesticPaymentCons
             DateTime xFapiAuthDate, String xFapiCustomerIpAddress, String xFapiInteractionId, String xCustomerUserAgent,
             String apiClientId, HttpServletRequest request, Principal principal) {
 
-        logger.info("Processing getDomesticPaymentConsentsConsentId request - consentId: {}, apiClient, x-fapi-interaction-id: {}",
+        logger.info("Processing getDomesticPaymentConsentsConsentId request - consentId: {}, apiClient: {}, x-fapi-interaction-id: {}",
                     consentId, apiClientId, xFapiInteractionId);
 
         return ResponseEntity.ok(consentResponseFactory.buildConsentResponse(consentStoreApiClient.getConsent(consentId, apiClientId), getClass()));
@@ -129,6 +130,7 @@ public class DomesticPaymentConsentsApiController implements DomesticPaymentCons
         final boolean fundsAvailable = fundsAvailabilityService.isFundsAvailable(consent.getAuthorisedDebtorAccountId(),
                                                                                  consent.getRequestObj().getData().getInitiation().getInstructedAmount().getAmount());
 
-        return ResponseEntity.ok(fundsConfirmationResponseFactory.create(fundsAvailable, consentId, getClass()));
+        return ResponseEntity.ok(fundsConfirmationResponseFactory.create(fundsAvailable, consentId,
+                id -> LinksHelper.createDomesticPaymentConsentsFundsConfirmationLink(getClass(), id)));
     }
 }

--- a/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/v3_1_10/domesticscheduledpayments/DomesticScheduledPaymentConsentsApiController.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/v3_1_10/domesticscheduledpayments/DomesticScheduledPaymentConsentsApiController.java
@@ -106,7 +106,7 @@ public class DomesticScheduledPaymentConsentsApiController implements DomesticSc
                                                                                                                  HttpServletRequest request,
                                                                                                                  Principal principal) throws OBErrorResponseException {
 
-        logger.info("Processing getDomesticScheduledPaymentConsentsConsentId request - consentId: {}, apiClient, x-fapi-interaction-id: {}",
+        logger.info("Processing getDomesticScheduledPaymentConsentsConsentId request - consentId: {}, apiClient: {}, x-fapi-interaction-id: {}",
                 consentId, apiClientId, xFapiInteractionId);
 
         return ResponseEntity.ok(consentResponseFactory.buildConsentResponse(consentStoreApiClient.getConsent(consentId, apiClientId), getClass()));

--- a/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/v3_1_10/domesticstandingorders/DomesticStandingOrderConsentsApiController.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/v3_1_10/domesticstandingorders/DomesticStandingOrderConsentsApiController.java
@@ -107,7 +107,7 @@ public class DomesticStandingOrderConsentsApiController implements DomesticStand
                                                                                                                   HttpServletRequest request,
                                                                                                                   Principal principal) throws OBErrorResponseException {
 
-        logger.info("Processing getDomesticStandingOrderConsentsConsentId request - consentId: {}, apiClient, x-fapi-interaction-id: {}",
+        logger.info("Processing getDomesticStandingOrderConsentsConsentId request - consentId: {}, apiClient: {}, x-fapi-interaction-id: {}",
                 consentId, apiClientId, xFapiInteractionId);
 
         return ResponseEntity.ok(consentResponseFactory.buildConsentResponse(consentStoreApiClient.getConsent(consentId, apiClientId), getClass()));

--- a/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/v3_1_10/internationalpayments/InternationalPaymentConsentsApiController.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/v3_1_10/internationalpayments/InternationalPaymentConsentsApiController.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.ob.uk.rs.server.api.obie.payment.v3_1_10.internationalpayments;
+
+import java.security.Principal;
+import java.util.Collections;
+import java.util.List;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.joda.time.DateTime;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+
+import com.forgerock.sapi.gateway.ob.uk.common.datamodel.common.FRAmount;
+import com.forgerock.sapi.gateway.ob.uk.common.datamodel.common.FRCharge;
+import com.forgerock.sapi.gateway.ob.uk.common.datamodel.converter.payment.FRWriteInternationalConsentConverter;
+import com.forgerock.sapi.gateway.ob.uk.common.error.OBErrorResponseException;
+import com.forgerock.sapi.gateway.ob.uk.common.error.OBRIErrorResponseCategory;
+import com.forgerock.sapi.gateway.ob.uk.common.error.OBRIErrorType;
+import com.forgerock.sapi.gateway.ob.uk.rs.obie.api.payment.v3_1_10.internationalpayments.InternationalPaymentConsentsApi;
+import com.forgerock.sapi.gateway.ob.uk.rs.server.api.obie.payment.factories.OBWriteFundsConfirmationResponse1Factory;
+import com.forgerock.sapi.gateway.ob.uk.rs.server.api.obie.payment.factories.OBWriteInternationalConsentResponse6Factory;
+import com.forgerock.sapi.gateway.ob.uk.rs.server.service.balance.FundsAvailabilityService;
+import com.forgerock.sapi.gateway.ob.uk.rs.server.service.currency.ExchangeRateService;
+import com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.OBValidationService;
+import com.forgerock.sapi.gateway.rcs.consent.store.client.payment.international.v3_1_10.InternationalPaymentConsentStoreClient;
+import com.forgerock.sapi.gateway.rcs.consent.store.datamodel.payment.international.v3_1_10.CreateInternationalPaymentConsentRequest;
+import com.forgerock.sapi.gateway.rcs.consent.store.datamodel.payment.international.v3_1_10.InternationalPaymentConsent;
+
+import uk.org.openbanking.datamodel.payment.OBWriteDomestic2DataInitiationInstructedAmount;
+import uk.org.openbanking.datamodel.payment.OBWriteFundsConfirmationResponse1;
+import uk.org.openbanking.datamodel.payment.OBWriteInternational3DataInitiation;
+import uk.org.openbanking.datamodel.payment.OBWriteInternationalConsent5;
+import uk.org.openbanking.datamodel.payment.OBWriteInternationalConsentResponse6;
+import uk.org.openbanking.datamodel.payment.OBWriteInternationalConsentResponse6Data.StatusEnum;
+
+@Controller("InternationalPaymentConsentsApiV3.1.10")
+public class InternationalPaymentConsentsApiController implements InternationalPaymentConsentsApi {
+
+    private final Logger logger = LoggerFactory.getLogger(getClass());
+
+    private final InternationalPaymentConsentStoreClient consentStoreApiClient;
+
+    private final OBValidationService<OBWriteInternationalConsent5> consentValidator;
+
+    private final ExchangeRateService exchangeRateService;
+
+    private final OBWriteInternationalConsentResponse6Factory consentResponseFactory;
+
+    private final FundsAvailabilityService fundsAvailabilityService;
+
+    private final OBWriteFundsConfirmationResponse1Factory fundsConfirmationResponseFactory;
+
+    public InternationalPaymentConsentsApiController(InternationalPaymentConsentStoreClient consentStoreApiClient,
+                                                     OBValidationService<OBWriteInternationalConsent5> consentValidator,
+                                                     ExchangeRateService exchangeRateService,
+                                                     OBWriteInternationalConsentResponse6Factory consentResponseFactory,
+                                                     FundsAvailabilityService fundsAvailabilityService,
+                                                     OBWriteFundsConfirmationResponse1Factory fundsConfirmationResponseFactory) {
+
+        this.consentStoreApiClient = consentStoreApiClient;
+        this.consentValidator = consentValidator;
+        this.exchangeRateService = exchangeRateService;
+        this.consentResponseFactory = consentResponseFactory;
+        this.fundsAvailabilityService = fundsAvailabilityService;
+        this.fundsConfirmationResponseFactory = fundsConfirmationResponseFactory;
+    }
+
+    @Override
+    public ResponseEntity<OBWriteInternationalConsentResponse6> createInternationalPaymentConsents(OBWriteInternationalConsent5 obWriteInternationalConsent5,
+                String authorization, String xIdempotencyKey, String xJwsSignature, DateTime xFapiAuthDate, String xFapiCustomerIpAddress,
+                String xFapiInteractionId, String xCustomerUserAgent, String apiClientId, HttpServletRequest request, Principal principal) throws OBErrorResponseException {
+
+        logger.info("Processing createInternationalPaymentConsents request - consent: {}, idempotencyKey: {}, apiClient: {}, x-fapi-interaction-id: {}",
+                obWriteInternationalConsent5, xIdempotencyKey, apiClientId, xFapiInteractionId);
+
+        consentValidator.validate(obWriteInternationalConsent5);
+
+        final CreateInternationalPaymentConsentRequest createRequest = new CreateInternationalPaymentConsentRequest();
+        createRequest.setConsentRequest(FRWriteInternationalConsentConverter.toFRWriteInternationalConsent(obWriteInternationalConsent5));
+        createRequest.setApiClientId(apiClientId);
+        createRequest.setIdempotencyKey(xIdempotencyKey);
+        createRequest.setCharges(calculateCharges(obWriteInternationalConsent5));
+        final OBWriteInternational3DataInitiation initiation = obWriteInternationalConsent5.getData().getInitiation();
+        final OBWriteDomestic2DataInitiationInstructedAmount instructedAmount = initiation.getInstructedAmount();
+        createRequest.setExchangeRateInformation(exchangeRateService.calculateExchangeRateInfo(initiation.getCurrencyOfTransfer(),
+                new FRAmount(instructedAmount.getAmount(), instructedAmount.getCurrency()), initiation.getExchangeRateInformation()));
+
+        final InternationalPaymentConsent consent = consentStoreApiClient.createConsent(createRequest);
+        logger.info("Created consent - id: {}", consent.getId());
+
+        return new ResponseEntity<>(consentResponseFactory.buildConsentResponse(consent, getClass()), HttpStatus.CREATED);
+    }
+
+    private List<FRCharge> calculateCharges(OBWriteInternationalConsent5 obWriteInternationalConsent5) {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public ResponseEntity<OBWriteInternationalConsentResponse6> getInternationalPaymentConsentsConsentId(String consentId, String authorization,
+            DateTime xFapiAuthDate, String xFapiCustomerIpAddress, String xFapiInteractionId, String xCustomerUserAgent,
+            String apiClientId, HttpServletRequest request, Principal principal) {
+
+        logger.info("Processing getInternationalPaymentConsentsConsentId request - consentId: {}, apiClient, x-fapi-interaction-id: {}",
+                    consentId, apiClientId, xFapiInteractionId);
+
+        return ResponseEntity.ok(consentResponseFactory.buildConsentResponse(consentStoreApiClient.getConsent(consentId, apiClientId), getClass()));
+    }
+
+    @Override
+    public ResponseEntity<OBWriteFundsConfirmationResponse1> getInternationalPaymentConsentsConsentIdFundsConfirmation(String consentId,
+            String authorization, DateTime xFapiAuthDate, String xFapiCustomerIpAddress, String xFapiInteractionId,
+            String xCustomerUserAgent, String apiClientId, HttpServletRequest request, Principal principal) throws OBErrorResponseException {
+
+        logger.info("Processing getInternationalPaymentConsentsConsentIdFundsConfirmation request - consentId: {}, apiClientId: {}, x-fapi-interaction-id: {}",
+                consentId, apiClientId, xFapiInteractionId);
+
+        final InternationalPaymentConsent consent = consentStoreApiClient.getConsent(consentId, apiClientId);
+        if (StatusEnum.fromValue(consent.getStatus()) != StatusEnum.AUTHORISED) {
+            throw new OBErrorResponseException(HttpStatus.BAD_REQUEST, OBRIErrorResponseCategory.REQUEST_INVALID,
+                                               OBRIErrorType.CONSENT_STATUS_NOT_AUTHORISED.toOBError1(consent.getStatus()));
+        }
+
+        final boolean fundsAvailable = fundsAvailabilityService.isFundsAvailable(consent.getAuthorisedDebtorAccountId(),
+                                                                                 consent.getRequestObj().getData().getInitiation().getInstructedAmount().getAmount());
+
+        return ResponseEntity.ok(fundsConfirmationResponseFactory.create(fundsAvailable, consentId, getClass()));
+    }
+}

--- a/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/v3_1_10/internationalpayments/InternationalPaymentConsentsApiController.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/v3_1_10/internationalpayments/InternationalPaymentConsentsApiController.java
@@ -37,6 +37,7 @@ import com.forgerock.sapi.gateway.ob.uk.common.error.OBRIErrorType;
 import com.forgerock.sapi.gateway.ob.uk.rs.obie.api.payment.v3_1_10.internationalpayments.InternationalPaymentConsentsApi;
 import com.forgerock.sapi.gateway.ob.uk.rs.server.api.obie.payment.factories.OBWriteFundsConfirmationResponse1Factory;
 import com.forgerock.sapi.gateway.ob.uk.rs.server.api.obie.payment.factories.OBWriteInternationalConsentResponse6Factory;
+import com.forgerock.sapi.gateway.ob.uk.rs.server.common.util.link.LinksHelper;
 import com.forgerock.sapi.gateway.ob.uk.rs.server.service.balance.FundsAvailabilityService;
 import com.forgerock.sapi.gateway.ob.uk.rs.server.service.currency.ExchangeRateService;
 import com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.OBValidationService;
@@ -118,7 +119,7 @@ public class InternationalPaymentConsentsApiController implements InternationalP
             DateTime xFapiAuthDate, String xFapiCustomerIpAddress, String xFapiInteractionId, String xCustomerUserAgent,
             String apiClientId, HttpServletRequest request, Principal principal) {
 
-        logger.info("Processing getInternationalPaymentConsentsConsentId request - consentId: {}, apiClient, x-fapi-interaction-id: {}",
+        logger.info("Processing getInternationalPaymentConsentsConsentId request - consentId: {}, apiClient: {}, x-fapi-interaction-id: {}",
                     consentId, apiClientId, xFapiInteractionId);
 
         return ResponseEntity.ok(consentResponseFactory.buildConsentResponse(consentStoreApiClient.getConsent(consentId, apiClientId), getClass()));
@@ -141,6 +142,7 @@ public class InternationalPaymentConsentsApiController implements InternationalP
         final boolean fundsAvailable = fundsAvailabilityService.isFundsAvailable(consent.getAuthorisedDebtorAccountId(),
                                                                                  consent.getRequestObj().getData().getInitiation().getInstructedAmount().getAmount());
 
-        return ResponseEntity.ok(fundsConfirmationResponseFactory.create(fundsAvailable, consentId, getClass()));
+        return ResponseEntity.ok(fundsConfirmationResponseFactory.create(fundsAvailable, consentId,
+                id -> LinksHelper.createInternationalPaymentConsentsFundsConfirmationLink(getClass(), id)));
     }
 }

--- a/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/v3_1_10/internationalpayments/InternationalPaymentsApiController.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/v3_1_10/internationalpayments/InternationalPaymentsApiController.java
@@ -20,13 +20,15 @@
  */
 package com.forgerock.sapi.gateway.ob.uk.rs.server.api.obie.payment.v3_1_10.internationalpayments;
 
-import com.forgerock.sapi.gateway.ob.uk.rs.obie.api.payment.v3_1_10.internationalpayments.InternationalPaymentsApi;
-import com.forgerock.sapi.gateway.ob.uk.rs.server.api.obie.payment.services.ConsentService;
-import com.forgerock.sapi.gateway.ob.uk.rs.server.api.obie.payment.services.validation.RiskValidationService;
-import com.forgerock.sapi.gateway.rs.resource.store.repo.mongo.accounts.accounts.FRAccountRepository;
-import com.forgerock.sapi.gateway.rs.resource.store.repo.mongo.payments.InternationalPaymentSubmissionRepository;
-import com.forgerock.sapi.gateway.ob.uk.rs.server.validator.PaymentSubmissionValidator;
 import org.springframework.stereotype.Controller;
+
+import com.forgerock.sapi.gateway.ob.uk.rs.obie.api.payment.v3_1_10.internationalpayments.InternationalPaymentsApi;
+import com.forgerock.sapi.gateway.ob.uk.rs.server.api.obie.payment.services.RefundAccountService;
+import com.forgerock.sapi.gateway.ob.uk.rs.server.validator.PaymentSubmissionValidator;
+import com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.OBValidationService;
+import com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.payment.OBWriteInternational3Validator.OBWriteInternational3ValidationContext;
+import com.forgerock.sapi.gateway.rcs.consent.store.client.payment.international.v3_1_10.InternationalPaymentConsentStoreClient;
+import com.forgerock.sapi.gateway.rs.resource.store.repo.mongo.payments.InternationalPaymentSubmissionRepository;
 
 @Controller("InternationalPaymentsApiV3.1.10")
 public class InternationalPaymentsApiController extends com.forgerock.sapi.gateway.ob.uk.rs.server.api.obie.payment.v3_1_9.internationalpayments.InternationalPaymentsApiController implements InternationalPaymentsApi {
@@ -34,16 +36,16 @@ public class InternationalPaymentsApiController extends com.forgerock.sapi.gatew
     public InternationalPaymentsApiController(
             InternationalPaymentSubmissionRepository paymentSubmissionRepository,
             PaymentSubmissionValidator paymentSubmissionValidator,
-            ConsentService consentService,
-            RiskValidationService riskValidationService,
-            FRAccountRepository frAccountRepository
+            InternationalPaymentConsentStoreClient consentStoreClient,
+            OBValidationService<OBWriteInternational3ValidationContext> paymentValidator,
+            RefundAccountService refundAccountService
     ) {
         super(
                 paymentSubmissionRepository,
                 paymentSubmissionValidator,
-                consentService,
-                riskValidationService,
-                frAccountRepository
+                consentStoreClient,
+                paymentValidator,
+                refundAccountService
         );
     }
 }

--- a/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/v3_1_5/domesticpayments/DomesticPaymentsApiController.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/v3_1_5/domesticpayments/DomesticPaymentsApiController.java
@@ -205,7 +205,8 @@ public class DomesticPaymentsApiController implements DomesticPaymentsApi {
     ) {
         FRWriteDataDomestic data = frPaymentSubmission.getPayment().getData();
 
-        final Optional<FRResponseDataRefund> refundAccountData = refundAccountService.getRefundAccountData(consent.getRequestObj().getData().getReadRefundAccount(), consent);
+        final Optional<FRResponseDataRefund> refundAccountData = refundAccountService.getDomesticPaymentRefundData(
+                consent.getRequestObj().getData().getReadRefundAccount(), consent);
 
         return new OBWriteDomesticResponse5()
                 .data(new OBWriteDomesticResponse5Data()

--- a/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/v3_1_5/domesticpayments/DomesticPaymentsApiController.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/v3_1_5/domesticpayments/DomesticPaymentsApiController.java
@@ -139,8 +139,7 @@ public class DomesticPaymentsApiController implements DomesticPaymentsApi {
         consumePaymentRequest.setApiClientId(apiClientId);
         consentStoreClient.consumeConsent(consumePaymentRequest);
 
-        return ResponseEntity.status(CREATED).body(responseEntity(consent, frPaymentSubmission)
-        );
+        return ResponseEntity.status(CREATED).body(responseEntity(consent, frPaymentSubmission));
     }
 
     @Override

--- a/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/v3_1_5/domesticscheduledpayments/DomesticScheduledPaymentsApiController.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/v3_1_5/domesticscheduledpayments/DomesticScheduledPaymentsApiController.java
@@ -217,7 +217,8 @@ public class DomesticScheduledPaymentsApiController implements DomesticScheduled
             FRDomesticScheduledPaymentSubmission frPaymentSubmission
     ) {
 
-        final Optional<FRResponseDataRefund> refundAccountData = refundAccountService.getRefundAccountData(consent.getRequestObj().getData().getReadRefundAccount(), consent);
+        final Optional<FRResponseDataRefund> refundAccountData = refundAccountService.getDomesticPaymentRefundData(
+                consent.getRequestObj().getData().getReadRefundAccount(), consent);
 
         FRWriteDataDomesticScheduled data = frPaymentSubmission.getScheduledPayment().getData();
         return new OBWriteDomesticScheduledResponse5()

--- a/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/v3_1_5/domesticstandingorders/DomesticStandingOrdersApiController.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/v3_1_5/domesticstandingorders/DomesticStandingOrdersApiController.java
@@ -210,7 +210,8 @@ public class DomesticStandingOrdersApiController implements DomesticStandingOrde
     private OBWriteDomesticStandingOrderResponse6 responseEntity(DomesticStandingOrderConsent consent,
                                                                  FRDomesticStandingOrderPaymentSubmission frPaymentSubmission) {
 
-        final Optional<FRResponseDataRefund> refundAccountData = refundAccountService.getRefundAccountData(consent.getRequestObj().getData().getReadRefundAccount(), consent);
+        final Optional<FRResponseDataRefund> refundAccountData = refundAccountService.getDomesticPaymentRefundData(
+                consent.getRequestObj().getData().getReadRefundAccount(), consent);
 
         FRWriteDataDomesticStandingOrder data = frPaymentSubmission.getStandingOrder().getData();
         return new OBWriteDomesticStandingOrderResponse6()

--- a/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/v3_1_5/internationalpayments/InternationalPaymentsApiController.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/v3_1_5/internationalpayments/InternationalPaymentsApiController.java
@@ -216,7 +216,8 @@ public class InternationalPaymentsApiController implements InternationalPayments
     ) {
         FRWriteInternationalData data = frPaymentSubmission.getPayment().getData();
 
-        final Optional<FRInternationalResponseDataRefund> refundAccountData = refundAccountService.getInternationalRefundAccountData(consent.getRequestObj().getData().getReadRefundAccount(),
+        final Optional<FRInternationalResponseDataRefund> refundAccountData = refundAccountService.getInternationalPaymentRefundData(
+                consent.getRequestObj().getData().getReadRefundAccount(),
                 consent.getRequestObj().getData().getInitiation().getCreditor(),
                 consent.getRequestObj().getData().getInitiation().getCreditorAgent(),
                 consent);

--- a/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/v3_1_5/internationalpayments/InternationalPaymentsApiController.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/v3_1_5/internationalpayments/InternationalPaymentsApiController.java
@@ -20,53 +20,59 @@
  */
 package com.forgerock.sapi.gateway.ob.uk.rs.server.api.obie.payment.v3_1_5.internationalpayments;
 
-import com.forgerock.sapi.gateway.ob.uk.common.datamodel.common.FRAccountIdentifier;
-import com.forgerock.sapi.gateway.ob.uk.common.datamodel.converter.common.FRResponseDataRefundConverter;
-import com.forgerock.sapi.gateway.ob.uk.common.datamodel.payment.FRInternationalResponseDataRefund;
-import com.forgerock.sapi.gateway.ob.uk.common.datamodel.payment.FRWriteInternational;
-import com.forgerock.sapi.gateway.ob.uk.common.datamodel.payment.FRWriteInternationalData;
-import com.forgerock.sapi.gateway.ob.uk.common.datamodel.payment.FRWriteInternationalDataInitiation;
-import com.forgerock.sapi.gateway.ob.uk.common.error.OBErrorException;
-import com.forgerock.sapi.gateway.ob.uk.common.error.OBErrorResponseException;
-import com.forgerock.sapi.gateway.ob.uk.common.error.OBRIErrorResponseCategory;
-import com.forgerock.sapi.gateway.ob.uk.common.error.OBRIErrorType;
-import com.forgerock.sapi.gateway.ob.uk.rs.obie.api.payment.v3_1_5.internationalpayments.InternationalPaymentsApi;
-import com.forgerock.sapi.gateway.ob.uk.rs.server.api.obie.payment.services.ConsentService;
-import com.forgerock.sapi.gateway.ob.uk.rs.server.api.obie.payment.services.validation.RiskValidationService;
-import com.forgerock.sapi.gateway.ob.uk.rs.server.common.refund.FRResponseDataRefundFactory;
-import com.forgerock.sapi.gateway.ob.uk.rs.server.common.util.PaymentApiResponseUtil;
-import com.forgerock.sapi.gateway.ob.uk.rs.server.common.util.VersionPathExtractor;
-import com.forgerock.sapi.gateway.ob.uk.rs.server.common.util.link.LinksHelper;
-import com.forgerock.sapi.gateway.rs.resource.store.repo.entity.account.FRAccount;
-import com.forgerock.sapi.gateway.rs.resource.store.repo.entity.payment.FRInternationalPaymentSubmission;
-import com.forgerock.sapi.gateway.ob.uk.rs.server.idempotency.IdempotentRepositoryAdapter;
-import com.forgerock.sapi.gateway.rs.resource.store.repo.mongo.accounts.accounts.FRAccountRepository;
-import com.forgerock.sapi.gateway.rs.resource.store.repo.mongo.payments.InternationalPaymentSubmissionRepository;
-import com.forgerock.sapi.gateway.ob.uk.rs.server.validator.PaymentSubmissionValidator;
-import com.forgerock.sapi.gateway.ob.uk.rs.server.validator.ResourceVersionValidator;
-import com.forgerock.sapi.gateway.uk.common.shared.api.meta.obie.OBVersion;
-import com.google.gson.JsonObject;
-import lombok.extern.slf4j.Slf4j;
-import org.joda.time.DateTime;
-import org.springframework.http.ResponseEntity;
-import org.springframework.stereotype.Controller;
-import uk.org.openbanking.datamodel.common.Meta;
-import uk.org.openbanking.datamodel.payment.*;
-
-import javax.servlet.http.HttpServletRequest;
-import javax.validation.Valid;
-import java.security.Principal;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.UUID;
-
 import static com.forgerock.sapi.gateway.ob.uk.common.datamodel.common.FRSubmissionStatus.PENDING;
 import static com.forgerock.sapi.gateway.ob.uk.common.datamodel.converter.common.FRAccountIdentifierConverter.toOBCashAccountDebtor4;
+import static com.forgerock.sapi.gateway.ob.uk.common.datamodel.converter.common.FRChargeConverter.toOBWriteDomesticConsentResponse5DataCharges;
 import static com.forgerock.sapi.gateway.ob.uk.common.datamodel.converter.common.FRSubmissionStatusConverter.toOBWriteInternationalResponse5DataStatus;
 import static com.forgerock.sapi.gateway.ob.uk.common.datamodel.converter.payment.FRWriteInternationalConsentConverter.toOBWriteInternational3DataInitiation;
+import static com.forgerock.sapi.gateway.ob.uk.common.datamodel.converter.payment.FRWriteInternationalConsentConverter.toOBWriteInternationalConsent5;
 import static com.forgerock.sapi.gateway.ob.uk.common.datamodel.converter.payment.FRWriteInternationalConverter.toFRWriteInternational;
 import static org.springframework.http.HttpStatus.BAD_REQUEST;
 import static org.springframework.http.HttpStatus.CREATED;
+
+import java.security.Principal;
+import java.util.Optional;
+import java.util.UUID;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.validation.Valid;
+
+import org.joda.time.DateTime;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+
+import com.forgerock.sapi.gateway.ob.uk.common.datamodel.converter.common.FRResponseDataRefundConverter;
+import com.forgerock.sapi.gateway.ob.uk.common.datamodel.converter.payment.FRExchangeRateConverter;
+import com.forgerock.sapi.gateway.ob.uk.common.datamodel.payment.FRInternationalResponseDataRefund;
+import com.forgerock.sapi.gateway.ob.uk.common.datamodel.payment.FRWriteInternational;
+import com.forgerock.sapi.gateway.ob.uk.common.datamodel.payment.FRWriteInternationalData;
+import com.forgerock.sapi.gateway.ob.uk.common.error.OBErrorResponseException;
+import com.forgerock.sapi.gateway.ob.uk.rs.obie.api.payment.v3_1_5.internationalpayments.InternationalPaymentsApi;
+import com.forgerock.sapi.gateway.ob.uk.rs.server.api.obie.payment.services.RefundAccountService;
+import com.forgerock.sapi.gateway.ob.uk.rs.server.common.util.PaymentApiResponseUtil;
+import com.forgerock.sapi.gateway.ob.uk.rs.server.common.util.VersionPathExtractor;
+import com.forgerock.sapi.gateway.ob.uk.rs.server.common.util.link.LinksHelper;
+import com.forgerock.sapi.gateway.ob.uk.rs.server.idempotency.IdempotentRepositoryAdapter;
+import com.forgerock.sapi.gateway.ob.uk.rs.server.validator.PaymentSubmissionValidator;
+import com.forgerock.sapi.gateway.ob.uk.rs.server.validator.ResourceVersionValidator;
+import com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.OBValidationService;
+import com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.payment.OBWriteInternational3Validator.OBWriteInternational3ValidationContext;
+import com.forgerock.sapi.gateway.rcs.consent.store.client.payment.international.v3_1_10.InternationalPaymentConsentStoreClient;
+import com.forgerock.sapi.gateway.rcs.consent.store.datamodel.payment.ConsumePaymentConsentRequest;
+import com.forgerock.sapi.gateway.rcs.consent.store.datamodel.payment.international.v3_1_10.InternationalPaymentConsent;
+import com.forgerock.sapi.gateway.rs.resource.store.repo.entity.payment.FRInternationalPaymentSubmission;
+import com.forgerock.sapi.gateway.rs.resource.store.repo.mongo.payments.InternationalPaymentSubmissionRepository;
+import com.forgerock.sapi.gateway.uk.common.shared.api.meta.obie.OBVersion;
+
+import lombok.extern.slf4j.Slf4j;
+import uk.org.openbanking.datamodel.common.Meta;
+import uk.org.openbanking.datamodel.payment.OBWriteInternational3;
+import uk.org.openbanking.datamodel.payment.OBWriteInternationalResponse5;
+import uk.org.openbanking.datamodel.payment.OBWriteInternationalResponse5Data;
+import uk.org.openbanking.datamodel.payment.OBWritePaymentDetailsResponse1;
+import uk.org.openbanking.datamodel.payment.OBWritePaymentDetailsResponse1Data;
+import uk.org.openbanking.datamodel.payment.OBWritePaymentDetailsResponse1DataPaymentStatus;
+import uk.org.openbanking.datamodel.payment.OBWritePaymentDetailsResponse1DataStatusDetail;
 
 @Controller("InternationalPaymentsApiV3.1.5")
 @Slf4j
@@ -74,22 +80,24 @@ public class InternationalPaymentsApiController implements InternationalPayments
 
     private final InternationalPaymentSubmissionRepository paymentSubmissionRepository;
     private final PaymentSubmissionValidator paymentSubmissionValidator;
-    private final ConsentService consentService;
-    private final RiskValidationService riskValidationService;
-    private final FRAccountRepository frAccountRepository;
+
+    private final InternationalPaymentConsentStoreClient consentStoreClient;
+
+    private final OBValidationService<OBWriteInternational3ValidationContext> paymentValidator;
+
+    private final RefundAccountService refundAccountService;
 
     public InternationalPaymentsApiController(
             InternationalPaymentSubmissionRepository paymentSubmissionRepository,
             PaymentSubmissionValidator paymentSubmissionValidator,
-            ConsentService consentService,
-            RiskValidationService riskValidationService,
-            FRAccountRepository frAccountRepository
-    ) {
+            InternationalPaymentConsentStoreClient consentStoreClient,
+            OBValidationService<OBWriteInternational3ValidationContext> paymentValidator,
+            RefundAccountService refundAccountService) {
         this.paymentSubmissionRepository = paymentSubmissionRepository;
         this.paymentSubmissionValidator = paymentSubmissionValidator;
-        this.consentService = consentService;
-        this.riskValidationService = riskValidationService;
-        this.frAccountRepository = frAccountRepository;
+        this.consentStoreClient = consentStoreClient;
+        this.paymentValidator = paymentValidator;
+        this.refundAccountService = refundAccountService;
     }
 
     @Override
@@ -102,6 +110,7 @@ public class InternationalPaymentsApiController implements InternationalPayments
             String xFapiCustomerIpAddress,
             String xFapiInteractionId,
             String xCustomerUserAgent,
+            String apiClientId,
             HttpServletRequest request,
             Principal principal
     ) throws OBErrorResponseException {
@@ -110,37 +119,18 @@ public class InternationalPaymentsApiController implements InternationalPayments
         paymentSubmissionValidator.validateIdempotencyKeyAndRisk(xIdempotencyKey, obWriteInternational3.getRisk());
 
         String consentId = obWriteInternational3.getData().getConsentId();
-        //get the consent
-        JsonObject intent = consentService.getIDMIntent(authorization, consentId);
-        log.debug("Retrieved consent from IDM");
 
-        //deserialize the intent to ob response object
-        OBWriteInternationalConsentResponse6 obConsentResponse = consentService.deserialize(
-                OBWriteInternationalConsentResponse6.class,
-                intent.getAsJsonObject("OBIntentObject"),
-                consentId
-        );
-        log.debug("Deserialized consent from IDM");
+        log.debug("Attempting to get consent: {}, clientId: {}", consentId, apiClientId);
+        final InternationalPaymentConsent consent = consentStoreClient.getConsent(consentId, apiClientId);
+        log.debug("Got consent from store: {}", consent);
 
         FRWriteInternational frInternationalPayment = toFRWriteInternational(obWriteInternational3);
         log.trace("Converted to: '{}'", frInternationalPayment);
 
         // validate the consent against the request
         log.debug("Validating International Payment submission");
-        try {
-            // validates the initiation
-            if (!obWriteInternational3.getData().getInitiation().equals(obConsentResponse.getData().getInitiation())) {
-                throw new OBErrorException(OBRIErrorType.PAYMENT_INVALID_INITIATION,
-                        "The initiation field from payment submitted does not match with the initiation field submitted for the consent"
-                );
-            }
-            riskValidationService.validate(obConsentResponse.getRisk(), obWriteInternational3.getRisk());
-        } catch (OBErrorException e) {
-            throw new OBErrorResponseException(
-                    e.getObriErrorType().getHttpStatus(),
-                    OBRIErrorResponseCategory.REQUEST_INVALID,
-                    e.getOBError());
-        }
+        paymentValidator.validate(new OBWriteInternational3ValidationContext(obWriteInternational3,
+                toOBWriteInternationalConsent5(consent.getRequestObj()), consent.getStatus()));
         log.debug("International Payment validation successful");
 
         FRInternationalPaymentSubmission frPaymentSubmission = FRInternationalPaymentSubmission.builder()
@@ -157,17 +147,12 @@ public class InternationalPaymentsApiController implements InternationalPayments
         frPaymentSubmission = new IdempotentRepositoryAdapter<>(paymentSubmissionRepository)
                 .idempotentSave(frPaymentSubmission);
 
-        OBWriteInternationalResponse5 entity = responseEntity(frPaymentSubmission, obConsentResponse);
+        final ConsumePaymentConsentRequest consumePaymentRequest = new ConsumePaymentConsentRequest();
+        consumePaymentRequest.setConsentId(consentId);
+        consumePaymentRequest.setApiClientId(apiClientId);
+        consentStoreClient.consumeConsent(consumePaymentRequest);
 
-        // update the entity with refund
-        setRefund(
-                obConsentResponse.getData().getReadRefundAccount(),
-                frPaymentSubmission.getPayment().getData().getInitiation(),
-                intent,
-                entity
-        );
-
-        return ResponseEntity.status(CREATED).body(entity);
+        return ResponseEntity.status(CREATED).body(responseEntity(consent, frPaymentSubmission));
     }
 
     @Override
@@ -178,6 +163,7 @@ public class InternationalPaymentsApiController implements InternationalPayments
             String xFapiCustomerIpAddress,
             String xFapiInteractionId,
             String xCustomerUserAgent,
+            String apiClientId,
             HttpServletRequest request,
             Principal principal
     ) {
@@ -192,26 +178,10 @@ public class InternationalPaymentsApiController implements InternationalPayments
             return PaymentApiResponseUtil.resourceConflictResponse(frPaymentSubmission, apiVersion);
         }
         //get the consent
-        JsonObject intent = consentService.getIDMIntent(authorization, frPaymentSubmission.getConsentId());
-        log.debug("Retrieved consent from IDM");
+        final InternationalPaymentConsent consent = consentStoreClient.getConsent(frPaymentSubmission.getConsentId(), apiClientId);
+        log.debug("Got consent from store: {}", consent);
 
-        // Get the consent to update the response
-        OBWriteInternationalConsentResponse6 obConsentResponse = consentService.deserialize(
-                OBWriteInternationalConsentResponse6.class,
-                intent.getAsJsonObject("OBIntentObject"),
-                frPaymentSubmission.getConsentId()
-        );
-        OBWriteInternationalResponse5 entity = responseEntity(frPaymentSubmission, obConsentResponse);
-
-        // update the entity with refund
-        setRefund(
-                obConsentResponse.getData().getReadRefundAccount(),
-                frPaymentSubmission.getPayment().getData().getInitiation(),
-                intent,
-                entity
-        );
-
-        return ResponseEntity.ok(entity);
+        return ResponseEntity.ok(responseEntity(consent, frPaymentSubmission));
     }
 
     @Override
@@ -222,6 +192,7 @@ public class InternationalPaymentsApiController implements InternationalPayments
             String xFapiCustomerIpAddress,
             String xFapiInteractionId,
             String xCustomerUserAgent,
+            String apiClientId,
             HttpServletRequest request,
             Principal principal
     ) {
@@ -240,13 +211,19 @@ public class InternationalPaymentsApiController implements InternationalPayments
     }
 
     private OBWriteInternationalResponse5 responseEntity(
-            FRInternationalPaymentSubmission frPaymentSubmission,
-            OBWriteInternationalConsentResponse6 obConsent
+            InternationalPaymentConsent consent,
+            FRInternationalPaymentSubmission frPaymentSubmission
     ) {
         FRWriteInternationalData data = frPaymentSubmission.getPayment().getData();
+
+        final Optional<FRInternationalResponseDataRefund> refundAccountData = refundAccountService.getInternationalRefundAccountData(consent.getRequestObj().getData().getReadRefundAccount(),
+                consent.getRequestObj().getData().getInitiation().getCreditor(),
+                consent.getRequestObj().getData().getInitiation().getCreditorAgent(),
+                consent);
+
         return new OBWriteInternationalResponse5()
                 .data(new OBWriteInternationalResponse5Data()
-                        .charges(obConsent.getData().getCharges())
+                        .charges(toOBWriteDomesticConsentResponse5DataCharges(consent.getCharges()))
                         .internationalPaymentId(frPaymentSubmission.getId())
                         .initiation(toOBWriteInternational3DataInitiation(data.getInitiation()))
                         .creationDateTime(frPaymentSubmission.getCreated())
@@ -254,7 +231,8 @@ public class InternationalPaymentsApiController implements InternationalPayments
                         .status(toOBWriteInternationalResponse5DataStatus(frPaymentSubmission.getStatus()))
                         .consentId(data.getConsentId())
                         .debtor(toOBCashAccountDebtor4(data.getInitiation().getDebtorAccount()))
-                        .exchangeRateInformation(obConsent.getData().getExchangeRateInformation()))
+                        .refund(refundAccountData.map(FRResponseDataRefundConverter::toOBWriteInternationalResponse5DataRefund).orElse(null))
+                        .exchangeRateInformation(FRExchangeRateConverter.toOBWriteInternationalConsentResponse6DataExchangeRateInformation(consent.getExchangeRateInformation())))
                 .links(LinksHelper.createInternationalPaymentLink(this.getClass(), frPaymentSubmission.getId()))
                 .meta(new Meta());
     }
@@ -284,33 +262,5 @@ public class InternationalPaymentsApiController implements InternationalPayments
                 )
                 .links(LinksHelper.createInternationalPaymentDetailsLink(this.getClass(), frInternationalPaymentSubmission.getId()))
                 .meta(new Meta());
-    }
-
-    private void setRefund(
-            OBReadRefundAccountEnum obReadRefundAccountEnum,
-            FRWriteInternationalDataInitiation initiation,
-            JsonObject intent,
-            OBWriteInternationalResponse5 entity
-    ) {
-        if (Objects.nonNull(obReadRefundAccountEnum) && obReadRefundAccountEnum.equals(OBReadRefundAccountEnum.YES)) {
-            String accountId = Objects.nonNull(intent.get("accountId")) ? intent.get("accountId").getAsString() : null;
-            log.debug("Account Id from consent '{}'", accountId);
-            if (Objects.nonNull(accountId)) {
-                FRAccount frAccount = Objects.nonNull(accountId) ? frAccountRepository.byAccountId(accountId) : null;
-                FRAccountIdentifier frAccountIdentifier = Objects.nonNull(frAccount) ?
-                        frAccount.getAccount().getFirstAccount() :
-                        null;
-                Optional<FRInternationalResponseDataRefund> refund = FRResponseDataRefundFactory.frInternationalResponseDataRefund(
-                        frAccountIdentifier,
-                        initiation
-                );
-
-                if(Objects.nonNull(refund)) {
-                    entity.getData().setRefund(
-                            refund.map(FRResponseDataRefundConverter::toOBWriteInternationalResponse5DataRefund).orElse(null)
-                    );
-                }
-            }
-        }
     }
 }

--- a/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/v3_1_6/internationalpayments/InternationalPaymentsApiController.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/v3_1_6/internationalpayments/InternationalPaymentsApiController.java
@@ -20,13 +20,15 @@
  */
 package com.forgerock.sapi.gateway.ob.uk.rs.server.api.obie.payment.v3_1_6.internationalpayments;
 
-import com.forgerock.sapi.gateway.ob.uk.rs.obie.api.payment.v3_1_6.internationalpayments.InternationalPaymentsApi;
-import com.forgerock.sapi.gateway.ob.uk.rs.server.api.obie.payment.services.ConsentService;
-import com.forgerock.sapi.gateway.ob.uk.rs.server.api.obie.payment.services.validation.RiskValidationService;
-import com.forgerock.sapi.gateway.rs.resource.store.repo.mongo.accounts.accounts.FRAccountRepository;
-import com.forgerock.sapi.gateway.rs.resource.store.repo.mongo.payments.InternationalPaymentSubmissionRepository;
-import com.forgerock.sapi.gateway.ob.uk.rs.server.validator.PaymentSubmissionValidator;
 import org.springframework.stereotype.Controller;
+
+import com.forgerock.sapi.gateway.ob.uk.rs.obie.api.payment.v3_1_6.internationalpayments.InternationalPaymentsApi;
+import com.forgerock.sapi.gateway.ob.uk.rs.server.api.obie.payment.services.RefundAccountService;
+import com.forgerock.sapi.gateway.ob.uk.rs.server.validator.PaymentSubmissionValidator;
+import com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.OBValidationService;
+import com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.payment.OBWriteInternational3Validator.OBWriteInternational3ValidationContext;
+import com.forgerock.sapi.gateway.rcs.consent.store.client.payment.international.v3_1_10.InternationalPaymentConsentStoreClient;
+import com.forgerock.sapi.gateway.rs.resource.store.repo.mongo.payments.InternationalPaymentSubmissionRepository;
 
 @Controller("InternationalPaymentsApiV3.1.6")
 public class InternationalPaymentsApiController extends com.forgerock.sapi.gateway.ob.uk.rs.server.api.obie.payment.v3_1_5.internationalpayments.InternationalPaymentsApiController implements InternationalPaymentsApi {
@@ -34,16 +36,16 @@ public class InternationalPaymentsApiController extends com.forgerock.sapi.gatew
     public InternationalPaymentsApiController(
             InternationalPaymentSubmissionRepository paymentSubmissionRepository,
             PaymentSubmissionValidator paymentSubmissionValidator,
-            ConsentService consentService,
-            RiskValidationService riskValidationService,
-            FRAccountRepository frAccountRepository
+            InternationalPaymentConsentStoreClient consentStoreClient,
+            OBValidationService<OBWriteInternational3ValidationContext> paymentValidator,
+            RefundAccountService refundAccountService
     ) {
         super(
                 paymentSubmissionRepository,
                 paymentSubmissionValidator,
-                consentService,
-                riskValidationService,
-                frAccountRepository
+                consentStoreClient,
+                paymentValidator,
+                refundAccountService
         );
     }
 }

--- a/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/v3_1_7/internationalpayments/InternationalPaymentsApiController.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/v3_1_7/internationalpayments/InternationalPaymentsApiController.java
@@ -20,13 +20,15 @@
  */
 package com.forgerock.sapi.gateway.ob.uk.rs.server.api.obie.payment.v3_1_7.internationalpayments;
 
-import com.forgerock.sapi.gateway.ob.uk.rs.obie.api.payment.v3_1_7.internationalpayments.InternationalPaymentsApi;
-import com.forgerock.sapi.gateway.ob.uk.rs.server.api.obie.payment.services.ConsentService;
-import com.forgerock.sapi.gateway.ob.uk.rs.server.api.obie.payment.services.validation.RiskValidationService;
-import com.forgerock.sapi.gateway.rs.resource.store.repo.mongo.accounts.accounts.FRAccountRepository;
-import com.forgerock.sapi.gateway.rs.resource.store.repo.mongo.payments.InternationalPaymentSubmissionRepository;
-import com.forgerock.sapi.gateway.ob.uk.rs.server.validator.PaymentSubmissionValidator;
 import org.springframework.stereotype.Controller;
+
+import com.forgerock.sapi.gateway.ob.uk.rs.obie.api.payment.v3_1_7.internationalpayments.InternationalPaymentsApi;
+import com.forgerock.sapi.gateway.ob.uk.rs.server.api.obie.payment.services.RefundAccountService;
+import com.forgerock.sapi.gateway.ob.uk.rs.server.validator.PaymentSubmissionValidator;
+import com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.OBValidationService;
+import com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.payment.OBWriteInternational3Validator.OBWriteInternational3ValidationContext;
+import com.forgerock.sapi.gateway.rcs.consent.store.client.payment.international.v3_1_10.InternationalPaymentConsentStoreClient;
+import com.forgerock.sapi.gateway.rs.resource.store.repo.mongo.payments.InternationalPaymentSubmissionRepository;
 
 @Controller("InternationalPaymentsApiV3.1.7")
 public class InternationalPaymentsApiController extends com.forgerock.sapi.gateway.ob.uk.rs.server.api.obie.payment.v3_1_6.internationalpayments.InternationalPaymentsApiController implements InternationalPaymentsApi {
@@ -34,16 +36,16 @@ public class InternationalPaymentsApiController extends com.forgerock.sapi.gatew
     public InternationalPaymentsApiController(
             InternationalPaymentSubmissionRepository paymentSubmissionRepository,
             PaymentSubmissionValidator paymentSubmissionValidator,
-            ConsentService consentService,
-            RiskValidationService riskValidationService,
-            FRAccountRepository frAccountRepository
+            InternationalPaymentConsentStoreClient consentStoreClient,
+            OBValidationService<OBWriteInternational3ValidationContext> paymentValidator,
+            RefundAccountService refundAccountService
     ) {
         super(
                 paymentSubmissionRepository,
                 paymentSubmissionValidator,
-                consentService,
-                riskValidationService,
-                frAccountRepository
+                consentStoreClient,
+                paymentValidator,
+                refundAccountService
         );
     }
 }

--- a/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/v3_1_8/internationalpayments/InternationalPaymentsApiController.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/v3_1_8/internationalpayments/InternationalPaymentsApiController.java
@@ -20,13 +20,15 @@
  */
 package com.forgerock.sapi.gateway.ob.uk.rs.server.api.obie.payment.v3_1_8.internationalpayments;
 
-import com.forgerock.sapi.gateway.ob.uk.rs.obie.api.payment.v3_1_8.internationalpayments.InternationalPaymentsApi;
-import com.forgerock.sapi.gateway.ob.uk.rs.server.api.obie.payment.services.ConsentService;
-import com.forgerock.sapi.gateway.ob.uk.rs.server.api.obie.payment.services.validation.RiskValidationService;
-import com.forgerock.sapi.gateway.rs.resource.store.repo.mongo.accounts.accounts.FRAccountRepository;
-import com.forgerock.sapi.gateway.rs.resource.store.repo.mongo.payments.InternationalPaymentSubmissionRepository;
-import com.forgerock.sapi.gateway.ob.uk.rs.server.validator.PaymentSubmissionValidator;
 import org.springframework.stereotype.Controller;
+
+import com.forgerock.sapi.gateway.ob.uk.rs.obie.api.payment.v3_1_8.internationalpayments.InternationalPaymentsApi;
+import com.forgerock.sapi.gateway.ob.uk.rs.server.api.obie.payment.services.RefundAccountService;
+import com.forgerock.sapi.gateway.ob.uk.rs.server.validator.PaymentSubmissionValidator;
+import com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.OBValidationService;
+import com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.payment.OBWriteInternational3Validator.OBWriteInternational3ValidationContext;
+import com.forgerock.sapi.gateway.rcs.consent.store.client.payment.international.v3_1_10.InternationalPaymentConsentStoreClient;
+import com.forgerock.sapi.gateway.rs.resource.store.repo.mongo.payments.InternationalPaymentSubmissionRepository;
 
 @Controller("InternationalPaymentsApiV3.1.8")
 public class InternationalPaymentsApiController extends com.forgerock.sapi.gateway.ob.uk.rs.server.api.obie.payment.v3_1_7.internationalpayments.InternationalPaymentsApiController implements InternationalPaymentsApi {
@@ -34,16 +36,16 @@ public class InternationalPaymentsApiController extends com.forgerock.sapi.gatew
     public InternationalPaymentsApiController(
             InternationalPaymentSubmissionRepository paymentSubmissionRepository,
             PaymentSubmissionValidator paymentSubmissionValidator,
-            ConsentService consentService,
-            RiskValidationService riskValidationService,
-            FRAccountRepository frAccountRepository
+            InternationalPaymentConsentStoreClient consentStoreClient,
+            OBValidationService<OBWriteInternational3ValidationContext> paymentValidator,
+            RefundAccountService refundAccountService
     ) {
         super(
                 paymentSubmissionRepository,
                 paymentSubmissionValidator,
-                consentService,
-                riskValidationService,
-                frAccountRepository
+                consentStoreClient,
+                paymentValidator,
+                refundAccountService
         );
     }
 }

--- a/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/v3_1_9/internationalpayments/InternationalPaymentsApiController.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/v3_1_9/internationalpayments/InternationalPaymentsApiController.java
@@ -20,13 +20,15 @@
  */
 package com.forgerock.sapi.gateway.ob.uk.rs.server.api.obie.payment.v3_1_9.internationalpayments;
 
-import com.forgerock.sapi.gateway.ob.uk.rs.obie.api.payment.v3_1_9.internationalpayments.InternationalPaymentsApi;
-import com.forgerock.sapi.gateway.ob.uk.rs.server.api.obie.payment.services.ConsentService;
-import com.forgerock.sapi.gateway.ob.uk.rs.server.api.obie.payment.services.validation.RiskValidationService;
-import com.forgerock.sapi.gateway.rs.resource.store.repo.mongo.accounts.accounts.FRAccountRepository;
-import com.forgerock.sapi.gateway.rs.resource.store.repo.mongo.payments.InternationalPaymentSubmissionRepository;
-import com.forgerock.sapi.gateway.ob.uk.rs.server.validator.PaymentSubmissionValidator;
 import org.springframework.stereotype.Controller;
+
+import com.forgerock.sapi.gateway.ob.uk.rs.obie.api.payment.v3_1_9.internationalpayments.InternationalPaymentsApi;
+import com.forgerock.sapi.gateway.ob.uk.rs.server.api.obie.payment.services.RefundAccountService;
+import com.forgerock.sapi.gateway.ob.uk.rs.server.validator.PaymentSubmissionValidator;
+import com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.OBValidationService;
+import com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.payment.OBWriteInternational3Validator.OBWriteInternational3ValidationContext;
+import com.forgerock.sapi.gateway.rcs.consent.store.client.payment.international.v3_1_10.InternationalPaymentConsentStoreClient;
+import com.forgerock.sapi.gateway.rs.resource.store.repo.mongo.payments.InternationalPaymentSubmissionRepository;
 
 @Controller("InternationalPaymentsApiV3.1.9")
 public class InternationalPaymentsApiController extends com.forgerock.sapi.gateway.ob.uk.rs.server.api.obie.payment.v3_1_8.internationalpayments.InternationalPaymentsApiController implements InternationalPaymentsApi {
@@ -34,16 +36,16 @@ public class InternationalPaymentsApiController extends com.forgerock.sapi.gatew
     public InternationalPaymentsApiController(
             InternationalPaymentSubmissionRepository paymentSubmissionRepository,
             PaymentSubmissionValidator paymentSubmissionValidator,
-            ConsentService consentService,
-            RiskValidationService riskValidationService,
-            FRAccountRepository frAccountRepository
+            InternationalPaymentConsentStoreClient consentStoreClient,
+            OBValidationService<OBWriteInternational3ValidationContext> paymentValidator,
+            RefundAccountService refundAccountService
     ) {
         super(
                 paymentSubmissionRepository,
                 paymentSubmissionValidator,
-                consentService,
-                riskValidationService,
-                frAccountRepository
+                consentStoreClient,
+                paymentValidator,
+                refundAccountService
         );
     }
 }

--- a/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/v3_1_9/vrp/DomesticVrpsApiController.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/v3_1_9/vrp/DomesticVrpsApiController.java
@@ -224,7 +224,8 @@ public class DomesticVrpsApiController implements DomesticVrpsApi {
     private OBDomesticVRPResponse responseEntity(DomesticVRPConsent consent, OBDomesticVRPRequest obDomesticVRPRequest,
                                                  FRDomesticVrpPaymentSubmission paymentSubmission) {
 
-        final Optional<FRResponseDataRefund> refundAccountData = refundAccountService.getRefundAccountData(consent.getRequestObj().getData().getReadRefundAccount(), consent);
+        final Optional<FRResponseDataRefund> refundAccountData = refundAccountService.getDomesticPaymentRefundData(
+                consent.getRequestObj().getData().getReadRefundAccount(), consent);
 
         OBDomesticVRPResponse response = new OBDomesticVRPResponse()
                 .data(

--- a/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/common/util/link/LinksHelper.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/common/util/link/LinksHelper.java
@@ -160,6 +160,10 @@ public class LinksHelper {
         return createSelfLink(controllerClass, INTERNATIONAL_PAYMENT_CONSENTS, id);
     }
 
+    public static Links createInternationalPaymentConsentsFundsConfirmationLink(Class<?> controllerClass, String id) {
+        return createSelfLink(controllerClass, INTERNATIONAL_PAYMENT_CONSENTS, id, FUNDS_CONFIRMATION);
+    }
+
     /**
      * Creates an instance of the OB {@link Links} class with only the 'self' link populated for an international
      * payment.

--- a/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/common/util/link/LinksHelper.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/common/util/link/LinksHelper.java
@@ -36,6 +36,7 @@ public class LinksHelper {
     private static final String DOMESTIC_STANDING_ORDER = "domestic-standing-orders";
     private static final String FILE_PAYMENT_CONSENTS = "file-payment-consents";
     private static final String FILE_PAYMENTS = "file-payments";
+    private static final String INTERNATIONAL_PAYMENT_CONSENTS = "international-payment-consents";
     private static final String INTERNATIONAL_PAYMENTS = "international-payments";
     private static final String INTERNATIONAL_SCHEDULED_PAYMENTS = "international-scheduled-payments";
     private static final String INTERNATIONAL_STANDING_ORDER = "international-standing-orders";
@@ -153,6 +154,10 @@ public class LinksHelper {
      */
     public static Links createFilePaymentsLink(Class<?> controllerClass, String id) {
         return createSelfLink(controllerClass, FILE_PAYMENTS, id);
+    }
+
+    public static Links createInternationalPaymentConsentsLink(Class<?> controllerClass, String id) {
+        return createSelfLink(controllerClass, INTERNATIONAL_PAYMENT_CONSENTS, id);
     }
 
     /**

--- a/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/configuration/ExchangeRateServiceConfiguration.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/configuration/ExchangeRateServiceConfiguration.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.ob.uk.rs.server.configuration;
+
+import java.math.BigDecimal;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.forgerock.sapi.gateway.ob.uk.rs.server.service.currency.DefaultExchangeRateService;
+import com.forgerock.sapi.gateway.ob.uk.rs.server.service.currency.ExchangeRateService;
+
+@Configuration
+public class ExchangeRateServiceConfiguration {
+
+    @Bean
+    @ConfigurationProperties(prefix = "rs.exchange.rates.pairs")
+    public Map<String, BigDecimal> exchangeRateConfig() {
+        return new HashMap<>();
+    }
+
+    @Bean
+    public ExchangeRateService exchangeRateService(Map<String, BigDecimal> exchangeRateConfig,
+                                                   @Value("${rs.exchange.rates.default:1.5}") BigDecimal defaultExchangeRate) {
+
+        return new DefaultExchangeRateService(exchangeRateConfig, defaultExchangeRate);
+    }
+}

--- a/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/configuration/ExchangeRateServiceConfiguration.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/configuration/ExchangeRateServiceConfiguration.java
@@ -27,6 +27,19 @@ import org.springframework.context.annotation.Configuration;
 import com.forgerock.sapi.gateway.ob.uk.rs.server.service.currency.DefaultExchangeRateService;
 import com.forgerock.sapi.gateway.ob.uk.rs.server.service.currency.ExchangeRateService;
 
+/**
+ * Configuration for the ExchangeRateService, loads exchange rate test data from config.
+ *
+ * Example config:
+ *   exchange:
+ *     rates:
+ *       default: "1.5123"
+ *       pairs:
+ *         GBPUSD: "1.3211"
+ *         GBPEUR: "1.1634"
+ *
+ * The default rate is used when no rate is defined for a particular currency pair.
+ */
 @Configuration
 public class ExchangeRateServiceConfiguration {
 

--- a/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/configuration/validation/DefaultOBValidationModule.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/configuration/validation/DefaultOBValidationModule.java
@@ -40,6 +40,8 @@ import com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.payment.OBWriteDomest
 import com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.payment.OBWriteFile2Validator;
 import com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.payment.OBWriteFile2Validator.OBWriteFile2ValidationContext;
 import com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.payment.OBWriteInternational3DataInitiationExchangeRateInformationValidator;
+import com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.payment.OBWriteInternational3Validator;
+import com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.payment.OBWriteInternational3Validator.OBWriteInternational3ValidationContext;
 import com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.payment.consent.OBDomesticVRPConsentRequestValidator;
 import com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.payment.consent.OBWriteDomesticConsent4Validator;
 import com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.payment.consent.OBWriteDomesticScheduledConsent4Validator;
@@ -147,5 +149,10 @@ public class DefaultOBValidationModule {
     public OBValidationService<OBWriteInternationalConsent5> internationalPaymentConsentValidator() {
         return new OBValidationService<>(new OBWriteInternationalConsent5Validator(instructedAmountValidator(),
                 currencyCodeValidator(), exchangeRateInformationValidator()));
+    }
+
+    @Bean
+    public OBValidationService<OBWriteInternational3ValidationContext> internationalPaymentValidator() {
+        return new OBValidationService<>(new OBWriteInternational3Validator());
     }
 }

--- a/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/configuration/validation/DefaultOBValidationModule.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/configuration/validation/DefaultOBValidationModule.java
@@ -16,7 +16,6 @@
 package com.forgerock.sapi.gateway.ob.uk.rs.server.configuration.validation;
 
 import java.util.Arrays;
-import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -28,6 +27,7 @@ import com.forgerock.sapi.gateway.ob.uk.rs.server.api.obie.payment.services.vali
 import com.forgerock.sapi.gateway.ob.uk.rs.server.common.Currencies;
 import com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.BaseOBValidator;
 import com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.OBValidationService;
+import com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.payment.CurrencyCodeValidator;
 import com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.payment.OBDomesticVRPRequestValidator;
 import com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.payment.OBDomesticVRPRequestValidator.OBDomesticVRPRequestValidationContext;
 import com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.payment.OBWriteDomestic2DataInitiationInstructedAmountValidator;
@@ -39,17 +39,20 @@ import com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.payment.OBWriteDomest
 import com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.payment.OBWriteDomesticStandingOrder3Validator.OBWriteDomesticStandingOrder3ValidationContext;
 import com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.payment.OBWriteFile2Validator;
 import com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.payment.OBWriteFile2Validator.OBWriteFile2ValidationContext;
+import com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.payment.OBWriteInternational3DataInitiationExchangeRateInformationValidator;
 import com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.payment.consent.OBDomesticVRPConsentRequestValidator;
 import com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.payment.consent.OBWriteDomesticConsent4Validator;
 import com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.payment.consent.OBWriteDomesticScheduledConsent4Validator;
 import com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.payment.consent.OBWriteDomesticStandingOrderConsent5Validator;
 import com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.payment.consent.OBWriteFileConsent3Validator;
+import com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.payment.consent.OBWriteInternationalConsent5Validator;
 
 import uk.org.openbanking.datamodel.payment.OBWriteDomestic2DataInitiationInstructedAmount;
 import uk.org.openbanking.datamodel.payment.OBWriteDomesticConsent4;
 import uk.org.openbanking.datamodel.payment.OBWriteDomesticScheduledConsent4;
 import uk.org.openbanking.datamodel.payment.OBWriteDomesticStandingOrderConsent5;
 import uk.org.openbanking.datamodel.payment.OBWriteFileConsent3;
+import uk.org.openbanking.datamodel.payment.OBWriteInternationalConsent5;
 import uk.org.openbanking.datamodel.vrp.OBDomesticVRPConsentRequest;
 
 /**
@@ -82,7 +85,7 @@ public class DefaultOBValidationModule {
 
     @Bean
     public BaseOBValidator<OBWriteDomestic2DataInitiationInstructedAmount> instructedAmountValidator() {
-        return new OBWriteDomestic2DataInitiationInstructedAmountValidator(validPaymentCurrencies());
+        return new OBWriteDomestic2DataInitiationInstructedAmountValidator(currencyCodeValidator());
     }
 
     @Bean
@@ -97,7 +100,7 @@ public class DefaultOBValidationModule {
 
     @Bean
     public OBValidationService<OBWriteDomesticStandingOrderConsent5> domesticStandingOrderConsentValidator() {
-        return new OBValidationService<>(new OBWriteDomesticStandingOrderConsent5Validator(validPaymentCurrencies()));
+        return new OBValidationService<>(new OBWriteDomesticStandingOrderConsent5Validator(currencyCodeValidator()));
     }
 
     @Bean
@@ -116,8 +119,8 @@ public class DefaultOBValidationModule {
     }
 
     @Bean
-    public Set<String> validPaymentCurrencies() {
-        return Arrays.stream(Currencies.values()).map(Currencies::getCode).collect(Collectors.toSet());
+    public BaseOBValidator<String> currencyCodeValidator() {
+        return new CurrencyCodeValidator(Arrays.stream(Currencies.values()).map(Currencies::getCode).collect(Collectors.toSet()));
     }
 
     @Bean
@@ -133,5 +136,16 @@ public class DefaultOBValidationModule {
     @Bean
     public OBValidationService<OBWriteFile2ValidationContext> filePaymentRequestValidator() {
         return new OBValidationService<>(new OBWriteFile2Validator());
+    }
+
+    @Bean
+    public OBWriteInternational3DataInitiationExchangeRateInformationValidator exchangeRateInformationValidator() {
+        return new OBWriteInternational3DataInitiationExchangeRateInformationValidator(currencyCodeValidator());
+    }
+
+    @Bean
+    public OBValidationService<OBWriteInternationalConsent5> internationalPaymentConsentValidator() {
+        return new OBValidationService<>(new OBWriteInternationalConsent5Validator(instructedAmountValidator(),
+                currencyCodeValidator(), exchangeRateInformationValidator()));
     }
 }

--- a/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/service/currency/DefaultExchangeRateService.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/service/currency/DefaultExchangeRateService.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.ob.uk.rs.server.service.currency;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.Map;
+import java.util.Objects;
+
+import org.joda.time.DateTime;
+
+import com.forgerock.sapi.gateway.ob.uk.common.datamodel.common.FRAmount;
+import com.forgerock.sapi.gateway.ob.uk.common.datamodel.common.FRExchangeRateInformation;
+import com.forgerock.sapi.gateway.ob.uk.common.datamodel.common.FRExchangeRateInformation.FRRateType;
+
+import uk.org.openbanking.datamodel.payment.OBWriteInternational3DataInitiationExchangeRateInformation;
+
+/**
+ * Default implementation of the ExchangeRateService.
+ *
+ * Uses a Map of currency pairs to exchange rate values, falling back on to a default value if no rate can be found
+ * for a particular pair.
+ */
+public class DefaultExchangeRateService implements ExchangeRateService {
+
+    /**
+     * Map of currencyPair to exchangeRate value
+     *
+     * currencyPair expected to be of the form: GBPUSD
+     */
+    private final Map<String, BigDecimal> exchangeRates;
+
+    /**
+     * Default rate to use when we do not have a rate defined in the exchangeRates map
+     */
+    private final BigDecimal defaultExchangeRate;
+
+    public DefaultExchangeRateService(Map<String, BigDecimal> exchangeRates, BigDecimal defaultExchangeRate) {
+        this.exchangeRates = Objects.requireNonNull(exchangeRates);
+        this.defaultExchangeRate = Objects.requireNonNull(defaultExchangeRate);
+    }
+
+    @Override
+    public FRExchangeRateInformation calculateExchangeRateInfo(String currencyOfTransfer, FRAmount instructedAmount,
+            OBWriteInternational3DataInitiationExchangeRateInformation consentRequestExchangeRateInfo) {
+
+        if (consentRequestExchangeRateInfo == null) {
+            return generateIndicativeQuote(currencyOfTransfer, instructedAmount.getCurrency());
+        } else {
+            switch (consentRequestExchangeRateInfo.getRateType()) {
+                case ACTUAL -> {
+                    return generateActualQuote(currencyOfTransfer, consentRequestExchangeRateInfo);
+                }
+                case AGREED -> {
+                    return generateAgreedQuote(consentRequestExchangeRateInfo);
+                }
+                case INDICATIVE -> {
+                    return generateIndicativeQuote(currencyOfTransfer, consentRequestExchangeRateInfo.getUnitCurrency());
+                }
+            }
+            throw new IllegalStateException("RateType: " + consentRequestExchangeRateInfo.getRateType() + " not supported");
+        }
+    }
+
+    private FRExchangeRateInformation generateActualQuote(String currencyOfTransfer, OBWriteInternational3DataInitiationExchangeRateInformation exchangeRateInformation) {
+        return FRExchangeRateInformation.builder().rateType(FRRateType.ACTUAL)
+                .exchangeRate(getExchangeRate(exchangeRateInformation.getUnitCurrency(), currencyOfTransfer))
+                .unitCurrency(exchangeRateInformation.getUnitCurrency())
+                .expirationDateTime(DateTime.now().plusMinutes(5))
+                .build();
+    }
+
+    private FRExchangeRateInformation generateAgreedQuote(OBWriteInternational3DataInitiationExchangeRateInformation exchangeRateInformation) {
+        return FRExchangeRateInformation.builder().rateType(FRRateType.AGREED)
+                .unitCurrency(exchangeRateInformation.getUnitCurrency())
+                .exchangeRate(exchangeRateInformation.getExchangeRate())
+                .contractIdentification(exchangeRateInformation.getContractIdentification())
+                .build();
+    }
+
+    private FRExchangeRateInformation generateIndicativeQuote(String currencyOfTransfer, String unitCurrency) {
+        return FRExchangeRateInformation.builder().rateType(FRRateType.INDICATIVE)
+                .exchangeRate(getExchangeRate(unitCurrency, currencyOfTransfer))
+                .unitCurrency(unitCurrency)
+                .build();
+    }
+
+    private BigDecimal getExchangeRate(String unitCurrency, String currencyOfTransfer) {
+        if (unitCurrency.equals(currencyOfTransfer)) {
+            return BigDecimal.ONE;
+        }
+
+        final String currencyPairKey = unitCurrency + currencyOfTransfer;
+        if (exchangeRates.containsKey(currencyPairKey)) {
+            return exchangeRates.get(currencyPairKey);
+        } else {
+            // See if we have the inverse rate configured and compute the inverse
+            final String inversePairKey = currencyOfTransfer + unitCurrency;
+            if (exchangeRates.containsKey(inversePairKey)) {
+                final BigDecimal inverseRate = exchangeRates.get(inversePairKey);
+                return BigDecimal.ONE.setScale(4).divide(inverseRate, RoundingMode.HALF_EVEN);
+            }
+            return defaultExchangeRate;
+        }
+    }
+}

--- a/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/service/currency/ExchangeRateService.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/service/currency/ExchangeRateService.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.ob.uk.rs.server.service.currency;
+
+import com.forgerock.sapi.gateway.ob.uk.common.datamodel.common.FRAmount;
+import com.forgerock.sapi.gateway.ob.uk.common.datamodel.common.FRExchangeRateInformation;
+
+import uk.org.openbanking.datamodel.payment.OBWriteInternational3DataInitiationExchangeRateInformation;
+
+/**
+ * Calculates Exchange Rates for Consent Responses
+ */
+public interface ExchangeRateService {
+
+    /**
+     * Calculates Exchange Rate Information to use in a Consent Response
+     *
+     * @param currencyOfTransfer             String currencyCode that the payment is being made in
+     * @param instructedAmount               FRAmount payment amount to be taken from the DebtorAccount
+     * @param consentRequestExchangeRateInfo OBWriteInternational3DataInitiationExchangeRateInformation, the
+     *                                       exchange rate information from the Consent Request. This is an optional field
+     *
+     * @return FRExchangeRateInformation populated with the exchange rate information to be returned in a Consent Response,
+     * for indicative and actual quotes this will include an exchangeRate value computed by this service.
+     */
+    FRExchangeRateInformation calculateExchangeRateInfo(String currencyOfTransfer, FRAmount instructedAmount,
+            OBWriteInternational3DataInitiationExchangeRateInformation consentRequestExchangeRateInfo);
+
+}

--- a/secure-api-gateway-ob-uk-rs-server/src/main/resources/application.yml
+++ b/secure-api-gateway-ob-uk-rs-server/src/main/resources/application.yml
@@ -68,3 +68,12 @@ rs:
     validation:
       # OBIE validation module to load, the "default" module is provided as standard with the simulator
       module: default
+
+  # Exchange rate values to use in FX quotes
+  exchange:
+    rates:
+      default: "1.5123"
+      pairs:
+        GBPUSD: "1.3211"
+        GBPEUR: "1.1634"
+

--- a/secure-api-gateway-ob-uk-rs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/factories/OBWriteInternationalConsentResponse6FactoryTest.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/factories/OBWriteInternationalConsentResponse6FactoryTest.java
@@ -21,7 +21,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.jupiter.api.Test;
 
-import com.forgerock.sapi.gateway.ob.uk.common.datamodel.converter.payment.FRExchangeRateConverter;
 import com.forgerock.sapi.gateway.ob.uk.rs.server.api.obie.payment.v3_1_10.domesticpayments.DomesticPaymentConsentsApiController;
 import com.forgerock.sapi.gateway.ob.uk.rs.server.api.obie.payment.v3_1_10.internationalpayments.InternationalPaymentConsentsApiControllerTest;
 import com.forgerock.sapi.gateway.rcs.consent.store.datamodel.payment.international.v3_1_10.InternationalPaymentConsent;
@@ -41,7 +40,7 @@ class OBWriteInternationalConsentResponse6FactoryTest {
     void testCreateOBWriteInternationalConsentResponse6() {
         final OBWriteInternationalConsent5 consentRequest = OBWriteInternationalConsentTestDataFactory.aValidOBWriteInternationalConsent5();
         final OBWriteInternationalConsent5Data requestData = consentRequest.getData();
-        final InternationalPaymentConsent internationalPaymentConsent = InternationalPaymentConsentsApiControllerTest.buildAwaitingAuthorisationConsent(consentRequest);
+        final InternationalPaymentConsent internationalPaymentConsent = InternationalPaymentConsentsApiControllerTest.buildAwaitingAuthorisationConsentForAgreedRate(consentRequest);
         final OBWriteInternationalConsentResponse6 response = factory.buildConsentResponse(internationalPaymentConsent, DomesticPaymentConsentsApiController.class);
 
         final OBWriteInternationalConsentResponse6Data responseData = response.getData();

--- a/secure-api-gateway-ob-uk-rs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/factories/OBWriteInternationalConsentResponse6FactoryTest.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/factories/OBWriteInternationalConsentResponse6FactoryTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.ob.uk.rs.server.api.obie.payment.factories;
+
+import static com.forgerock.sapi.gateway.ob.uk.common.datamodel.converter.payment.FRExchangeRateConverter.toOBWriteInternationalConsentResponse6DataExchangeRateInformation;
+import static com.forgerock.sapi.gateway.ob.uk.rs.server.util.BeanValidationTestUtils.verifyBeanValidationIsSuccessful;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+import com.forgerock.sapi.gateway.ob.uk.common.datamodel.converter.payment.FRExchangeRateConverter;
+import com.forgerock.sapi.gateway.ob.uk.rs.server.api.obie.payment.v3_1_10.domesticpayments.DomesticPaymentConsentsApiController;
+import com.forgerock.sapi.gateway.ob.uk.rs.server.api.obie.payment.v3_1_10.internationalpayments.InternationalPaymentConsentsApiControllerTest;
+import com.forgerock.sapi.gateway.rcs.consent.store.datamodel.payment.international.v3_1_10.InternationalPaymentConsent;
+
+import uk.org.openbanking.datamodel.payment.OBWriteInternationalConsent5;
+import uk.org.openbanking.datamodel.payment.OBWriteInternationalConsent5Data;
+import uk.org.openbanking.datamodel.payment.OBWriteInternationalConsentResponse6;
+import uk.org.openbanking.datamodel.payment.OBWriteInternationalConsentResponse6Data;
+import uk.org.openbanking.datamodel.payment.OBWriteInternationalConsentResponse6Data.StatusEnum;
+import uk.org.openbanking.testsupport.payment.OBWriteInternationalConsentTestDataFactory;
+
+class OBWriteInternationalConsentResponse6FactoryTest {
+
+    private final OBWriteInternationalConsentResponse6Factory factory = new OBWriteInternationalConsentResponse6Factory();
+
+    @Test
+    void testCreateOBWriteInternationalConsentResponse6() {
+        final OBWriteInternationalConsent5 consentRequest = OBWriteInternationalConsentTestDataFactory.aValidOBWriteInternationalConsent5();
+        final OBWriteInternationalConsent5Data requestData = consentRequest.getData();
+        final InternationalPaymentConsent internationalPaymentConsent = InternationalPaymentConsentsApiControllerTest.buildAwaitingAuthorisationConsent(consentRequest);
+        final OBWriteInternationalConsentResponse6 response = factory.buildConsentResponse(internationalPaymentConsent, DomesticPaymentConsentsApiController.class);
+
+        final OBWriteInternationalConsentResponse6Data responseData = response.getData();
+        assertThat(responseData.getStatus()).isEqualTo(StatusEnum.AWAITINGAUTHORISATION);
+        assertThat(responseData.getConsentId()).isEqualTo(internationalPaymentConsent.getId());
+        assertThat(responseData.getCreationDateTime()).isEqualTo(internationalPaymentConsent.getCreationDateTime());
+        assertThat(responseData.getStatusUpdateDateTime()).isEqualTo(internationalPaymentConsent.getStatusUpdateDateTime());
+        assertThat(responseData.getCharges()).isEqualTo(internationalPaymentConsent.getCharges());
+        assertThat(responseData.getExchangeRateInformation())
+                .isEqualTo(toOBWriteInternationalConsentResponse6DataExchangeRateInformation(
+                        internationalPaymentConsent.getExchangeRateInformation()));
+
+        // Verify data against original Consent Request
+        assertThat(responseData.getScASupportData()).isEqualTo(requestData.getScASupportData());
+        assertThat(responseData.getReadRefundAccount()).isEqualTo(requestData.getReadRefundAccount());
+        assertThat(responseData.getAuthorisation()).isEqualTo(requestData.getAuthorisation());
+        assertThat(responseData.getInitiation()).isEqualTo(requestData.getInitiation());
+
+        // Not currently generating data for these optional response fields
+        assertThat(responseData.getCutOffDateTime()).isNull();
+        assertThat(responseData.getExpectedExecutionDateTime()).isNull();
+        assertThat(responseData.getExpectedExecutionDateTime()).isNull();
+
+        assertThat(response.getRisk()).isEqualTo(consentRequest.getRisk());
+        assertThat(response.getLinks().getSelf().toString())
+                .endsWith("/open-banking/v3.1.10/pisp/international-payment-consents/" + internationalPaymentConsent.getId());
+        assertThat(response.getMeta()).isNotNull();
+
+        verifyBeanValidationIsSuccessful(response);
+    }
+}

--- a/secure-api-gateway-ob-uk-rs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/v3_1_10/internationalpayments/InternationalPaymentConsentsApiControllerTest.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/v3_1_10/internationalpayments/InternationalPaymentConsentsApiControllerTest.java
@@ -15,41 +15,298 @@
  */
 package com.forgerock.sapi.gateway.ob.uk.rs.server.api.obie.payment.v3_1_10.internationalpayments;
 
+import static com.forgerock.sapi.gateway.ob.uk.common.datamodel.converter.payment.FRExchangeRateConverter.*;
+import static com.forgerock.sapi.gateway.ob.uk.common.datamodel.converter.payment.FRWriteInternationalConsentConverter.*;
+import static com.forgerock.sapi.gateway.ob.uk.common.error.ErrorCode.OBRI_CONSENT_NOT_FOUND;
+import static com.forgerock.sapi.gateway.ob.uk.common.error.ErrorCode.OBRI_PERMISSION_INVALID;
+import static com.forgerock.sapi.gateway.ob.uk.rs.server.api.obie.payment.FundsConfirmationTestHelpers.validateConsentNotAuthorisedErrorResponse;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
+
 import java.math.BigDecimal;
 import java.util.List;
 
+import javax.annotation.PostConstruct;
+
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.ActiveProfiles;
 
-import com.forgerock.sapi.gateway.ob.uk.common.datamodel.common.FRExchangeRateInformation;
-import com.forgerock.sapi.gateway.ob.uk.common.datamodel.common.FRExchangeRateInformation.FRRateType;
-import com.forgerock.sapi.gateway.ob.uk.common.datamodel.converter.payment.FRWriteInternationalConsentConverter;
+import com.forgerock.sapi.gateway.ob.uk.common.error.ErrorCode;
+import com.forgerock.sapi.gateway.ob.uk.rs.server.service.balance.FundsAvailabilityService;
+import com.forgerock.sapi.gateway.ob.uk.rs.server.testsupport.api.HttpHeadersTestDataFactory;
+import com.forgerock.sapi.gateway.rcs.consent.store.client.ConsentStoreClientException;
+import com.forgerock.sapi.gateway.rcs.consent.store.client.ConsentStoreClientException.ErrorType;
+import com.forgerock.sapi.gateway.rcs.consent.store.client.payment.international.v3_1_10.InternationalPaymentConsentStoreClient;
+import com.forgerock.sapi.gateway.rcs.consent.store.datamodel.payment.international.v3_1_10.CreateInternationalPaymentConsentRequest;
 import com.forgerock.sapi.gateway.rcs.consent.store.datamodel.payment.international.v3_1_10.InternationalPaymentConsent;
 import com.forgerock.sapi.gateway.uk.common.shared.api.meta.share.IntentType;
 
+import uk.org.openbanking.datamodel.error.OBError1;
+import uk.org.openbanking.datamodel.error.OBErrorResponse1;
+import uk.org.openbanking.datamodel.error.OBStandardErrorCodes1;
+import uk.org.openbanking.datamodel.payment.OBExchangeRateType2Code;
+import uk.org.openbanking.datamodel.payment.OBWriteDomesticConsent4;
+import uk.org.openbanking.datamodel.payment.OBWriteFundsConfirmationResponse1;
+import uk.org.openbanking.datamodel.payment.OBWriteInternational3DataInitiationExchangeRateInformation;
 import uk.org.openbanking.datamodel.payment.OBWriteInternationalConsent5;
+import uk.org.openbanking.datamodel.payment.OBWriteInternationalConsentResponse6;
 import uk.org.openbanking.datamodel.payment.OBWriteInternationalConsentResponse6Data.StatusEnum;
+import uk.org.openbanking.testsupport.payment.OBWriteDomesticConsentTestDataFactory;
 import uk.org.openbanking.testsupport.payment.OBWriteInternationalConsentTestDataFactory;
 
+@SpringBootTest(webEnvironment = RANDOM_PORT)
+@ActiveProfiles("test")
 public class InternationalPaymentConsentsApiControllerTest {
 
-    private static OBWriteInternationalConsent5 createValidateConsentRequest() {
+    private static final String TEST_API_CLIENT_ID = "client_234093-49";
+
+    private static final HttpHeaders HTTP_HEADERS = HttpHeadersTestDataFactory.requiredPaymentsHttpHeadersWithApiClientId(TEST_API_CLIENT_ID);
+
+    @LocalServerPort
+    private int port;
+
+    @Autowired
+    private TestRestTemplate restTemplate;
+
+    @MockBean
+    private InternationalPaymentConsentStoreClient consentStoreClient;
+
+    @MockBean
+    private FundsAvailabilityService fundsAvailabilityService;
+
+    private String controllerBaseUri;
+
+    @PostConstruct
+    public void postConstruct() {
+        controllerBaseUri = "http://localhost:" + port + "/open-banking/v3.1.10/pisp/international-payment-consents";
+    }
+
+    @Test
+    public void testCreateConsentAgreedExchangeRate() {
+        final OBWriteInternationalConsent5 consentRequest = createValidateConsentRequestWithAgreedRate();
+        final OBWriteInternational3DataInitiationExchangeRateInformation exchangeRateInformation = consentRequest.getData().getInitiation().getExchangeRateInformation();
+        testCreateConsent(consentRequest, exchangeRateInformation);
+    }
+
+    @Test
+    public void testCreateConsentActualExchangeRate() {
+        final OBWriteInternationalConsent5 consentRequest = createValidateConsentRequestWithAgreedRate();
+        consentRequest.getData().getInitiation().setExchangeRateInformation(new OBWriteInternational3DataInitiationExchangeRateInformation().rateType(OBExchangeRateType2Code.ACTUAL).unitCurrency("GBP"));
+
+        final OBWriteInternational3DataInitiationExchangeRateInformation expectedResponseExchangeRateInformation = new OBWriteInternational3DataInitiationExchangeRateInformation();
+        expectedResponseExchangeRateInformation.exchangeRate(new BigDecimal("1.3211")).rateType(OBExchangeRateType2Code.ACTUAL).unitCurrency("GBP");
+        testCreateConsent(consentRequest, expectedResponseExchangeRateInformation);
+    }
+
+    @Test
+    public void testCreateConsentIndicativeExchangeRate() {
+        final OBWriteInternationalConsent5 consentRequest = createValidateConsentRequestWithAgreedRate();
+        consentRequest.getData().getInitiation().setExchangeRateInformation(new OBWriteInternational3DataInitiationExchangeRateInformation().rateType(OBExchangeRateType2Code.INDICATIVE).unitCurrency("GBP"));
+
+        final OBWriteInternational3DataInitiationExchangeRateInformation expectedResponseExchangeRateInformation = new OBWriteInternational3DataInitiationExchangeRateInformation();
+        expectedResponseExchangeRateInformation.exchangeRate(new BigDecimal("1.3211")).rateType(OBExchangeRateType2Code.INDICATIVE).unitCurrency("GBP");
+        testCreateConsent(consentRequest, expectedResponseExchangeRateInformation);
+    }
+
+    @Test
+    public void testCreateConsentNoExchangeRateInfoReturnsIndicativeExchangeRate() {
+        final OBWriteInternationalConsent5 consentRequest = createValidateConsentRequestWithAgreedRate();
+        consentRequest.getData().getInitiation().setExchangeRateInformation(null);
+
+        final OBWriteInternational3DataInitiationExchangeRateInformation expectedResponseExchangeRateInformation = new OBWriteInternational3DataInitiationExchangeRateInformation();
+        expectedResponseExchangeRateInformation.exchangeRate(new BigDecimal("1.3211")).rateType(OBExchangeRateType2Code.INDICATIVE).unitCurrency("GBP");
+        testCreateConsent(consentRequest, expectedResponseExchangeRateInformation);
+    }
+
+    private void testCreateConsent(OBWriteInternationalConsent5 consentRequest, OBWriteInternational3DataInitiationExchangeRateInformation expectedResponseExchangeRateInformation) {
+        final InternationalPaymentConsent consentStoreResponse = buildAwaitingAuthorisationConsent(consentRequest, expectedResponseExchangeRateInformation);
+        when(consentStoreClient.createConsent(any())).thenAnswer(invocation -> {
+            final CreateInternationalPaymentConsentRequest createConsentArg = invocation.getArgument(0, CreateInternationalPaymentConsentRequest.class);
+            assertThat(createConsentArg.getApiClientId()).isEqualTo(TEST_API_CLIENT_ID);
+            assertThat(createConsentArg.getConsentRequest()).isEqualTo(toFRWriteInternationalConsent(consentRequest));
+            assertThat(createConsentArg.getCharges()).isEmpty();
+            assertThat(createConsentArg.getExchangeRateInformation()).usingRecursiveComparison().ignoringFields("expirationDateTime")
+                    .isEqualTo(toFRExchangeRateInformation(expectedResponseExchangeRateInformation));
+            assertThat(createConsentArg.getIdempotencyKey()).isEqualTo(HTTP_HEADERS.getFirst("x-idempotency-key"));
+
+            return consentStoreResponse;
+        });
+
+        final HttpEntity<OBWriteInternationalConsent5> entity = new HttpEntity<>(consentRequest, HTTP_HEADERS);
+
+        final ResponseEntity<OBWriteInternationalConsentResponse6> createResponse = restTemplate.exchange(controllerBaseUri, HttpMethod.POST,
+                entity, OBWriteInternationalConsentResponse6.class);
+        assertThat(createResponse.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+        final OBWriteInternationalConsentResponse6 consentResponse = createResponse.getBody();
+        final String consentId = consentResponse.getData().getConsentId();
+        assertThat(consentId).isEqualTo(consentStoreResponse.getId());
+        assertThat(consentResponse.getData().getStatus()).isEqualTo(StatusEnum.AWAITINGAUTHORISATION);
+        assertThat(consentResponse.getData().getInitiation()).isEqualTo(consentRequest.getData().getInitiation());
+        assertThat(consentResponse.getData().getAuthorisation()).isEqualTo(consentRequest.getData().getAuthorisation());
+        assertThat(consentResponse.getData().getScASupportData()).isEqualTo(consentRequest.getData().getScASupportData());
+        assertThat(consentResponse.getData().getReadRefundAccount()).isEqualTo(consentRequest.getData().getReadRefundAccount());
+        assertThat(consentResponse.getData().getExchangeRateInformation()).usingRecursiveComparison().ignoringFields("expirationDateTime")
+                .isEqualTo(expectedResponseExchangeRateInformation);
+        assertThat(consentResponse.getData().getCreationDateTime()).isNotNull();
+        assertThat(consentResponse.getData().getStatusUpdateDateTime()).isNotNull();
+        assertThat(consentResponse.getRisk()).isEqualTo(consentRequest.getRisk());
+        final String selfLinkToConsent = consentResponse.getLinks().getSelf().toString();
+        assertThat(selfLinkToConsent).isEqualTo(controllerGetConsentUri(consentId));
+
+        // Get the consent and verify it matches the create response
+        when(consentStoreClient.getConsent(eq(consentId), eq(TEST_API_CLIENT_ID))).thenReturn(consentStoreResponse);
+
+        final ResponseEntity<OBWriteInternationalConsentResponse6> getConsentResponse = restTemplate.exchange(selfLinkToConsent,
+                HttpMethod.GET, new HttpEntity<>(HTTP_HEADERS), OBWriteInternationalConsentResponse6.class);
+
+        assertThat(getConsentResponse.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(getConsentResponse.getBody()).isEqualTo(consentResponse);
+    }
+
+    /**
+     * Validates that a Consent Request has an Agreed Exchange Rate Type, this allows us to do validation more easily
+     * as Agreed rate data in the consent matches that in the response.
+     */
+    private static void assertConsentHasAgreedRateType(OBWriteInternationalConsent5 consentRequest) {
+        assertThat(consentRequest.getData().getInitiation().getExchangeRateInformation().getRateType())
+                .withFailMessage("Test has been written to validate an AGREED Rate response")
+                .isEqualTo(OBExchangeRateType2Code.AGREED);
+    }
+
+    @Test
+    public void failsToCreateConsentIfRequestDoesNotPassJavaBeanValidation() {
+        final OBWriteDomesticConsent4 emptyConsent = new OBWriteDomesticConsent4();
+
+        final ResponseEntity<OBErrorResponse1> response = restTemplate.exchange(controllerBaseUri, HttpMethod.POST,
+                new HttpEntity<>(emptyConsent, HTTP_HEADERS), OBErrorResponse1.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+
+        final List<OBError1> errors = response.getBody().getErrors();
+        assertThat(errors).hasSize(2);
+        final String fieldMustNotBeNullErrMsg = "The field received is invalid. Reason 'must not be null'";
+        final String fieldInvalidErrCode = OBStandardErrorCodes1.UK_OBIE_FIELD_INVALID.toString();
+        assertThat(errors).containsExactlyInAnyOrder(new OBError1().errorCode(fieldInvalidErrCode).message(fieldMustNotBeNullErrMsg).path("risk"),
+                new OBError1().errorCode(fieldInvalidErrCode).message(fieldMustNotBeNullErrMsg).path("data"));
+
+        verifyNoMoreInteractions(consentStoreClient);
+    }
+
+    @Test
+    public void failsToCreateConsentIfRequestDoesNotPassBizLogicValidation() {
+        final OBWriteDomesticConsent4 consentWithInvalidAmount = OBWriteDomesticConsentTestDataFactory.aValidOBWriteDomesticConsent4();
+        consentWithInvalidAmount.getData().getInitiation().getInstructedAmount().setAmount("0"); // Invalid amount
+
+        final ResponseEntity<OBErrorResponse1> response = restTemplate.exchange(controllerBaseUri, HttpMethod.POST,
+                new HttpEntity<>(consentWithInvalidAmount, HTTP_HEADERS), OBErrorResponse1.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        final List<OBError1> errors = response.getBody().getErrors();
+        assertThat(errors).hasSize(1);
+        assertThat(errors.get(0).getErrorCode()).isEqualTo(ErrorCode.OBRI_DATA_REQUEST_INVALID.toString());
+        assertThat(errors.get(0).getMessage()).isEqualTo("Your data request is invalid: reason The amount 0 provided must be greater than 0");
+
+        verifyNoMoreInteractions(consentStoreClient);
+    }
+
+    @Test
+    public void failsToGetConsentThatDoesNotExist() {
+        when(consentStoreClient.getConsent(anyString(), anyString())).thenThrow(new ConsentStoreClientException(ErrorType.NOT_FOUND, "Consent Not Found"));
+        final ResponseEntity<OBErrorResponse1> consentNotFoundResponse = restTemplate.exchange(controllerGetConsentUri("unknown"),
+                HttpMethod.GET, new HttpEntity<>(HTTP_HEADERS), OBErrorResponse1.class);
+
+        assertThat(consentNotFoundResponse.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+        assertThat(consentNotFoundResponse.getBody().getCode()).isEqualTo(OBRI_CONSENT_NOT_FOUND.toString());
+    }
+
+    @Test
+    public void failsToGetConsentInvalidPermissions() {
+        when(consentStoreClient.getConsent(anyString(), anyString())).thenThrow(new ConsentStoreClientException(ErrorType.INVALID_PERMISSIONS, "ApiClient does not have permission to access Consent"));
+        final ResponseEntity<OBErrorResponse1> consentNotFoundResponse = restTemplate.exchange(controllerGetConsentUri("unknown"),
+                HttpMethod.GET, new HttpEntity<>(HTTP_HEADERS), OBErrorResponse1.class);
+
+        assertThat(consentNotFoundResponse.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
+        assertThat(consentNotFoundResponse.getBody().getCode()).isEqualTo(OBRI_PERMISSION_INVALID.toString());
+    }
+
+    @Test
+    public void testFundsConfirmation() {
+        final String accountId = "acc-1234344";
+        final OBWriteInternationalConsent5 consentRequest = createValidateConsentRequestWithAgreedRate();
+        final InternationalPaymentConsent consentStoreResponse = buildAuthorisedConsent(consentRequest, accountId);
+        when(consentStoreClient.getConsent(eq(consentStoreResponse.getId()), eq(TEST_API_CLIENT_ID))).thenReturn(consentStoreResponse);
+        when(fundsAvailabilityService.isFundsAvailable(eq(accountId), any())).thenReturn(Boolean.TRUE);
+
+        final String fundsConfirmationUri = controllerFundsConfirmationUri(consentStoreResponse.getId());
+        final ResponseEntity<OBWriteFundsConfirmationResponse1> fundsConfirmationResponse = restTemplate.exchange(fundsConfirmationUri,
+                HttpMethod.GET, new HttpEntity<>(HTTP_HEADERS), OBWriteFundsConfirmationResponse1.class);
+
+        assertThat(fundsConfirmationResponse.getStatusCode()).isEqualTo(HttpStatus.OK);
+        final OBWriteFundsConfirmationResponse1 fundsConfirmationResponseBody = fundsConfirmationResponse.getBody();
+        assertThat(fundsConfirmationResponseBody.getData().getFundsAvailableResult().getFundsAvailable()).isTrue();
+        assertThat(fundsConfirmationResponseBody.getLinks().getSelf().toString()).isEqualTo(fundsConfirmationUri);
+    }
+
+    @Test
+    public void failsToGetFundsConfirmationWhenConsentNotAuthorised() {
+        final InternationalPaymentConsent consentAwaitingAuthorisation = buildAwaitingAuthorisationConsentForAgreedRate(createValidateConsentRequestWithAgreedRate());
+        when(consentStoreClient.getConsent(eq(consentAwaitingAuthorisation.getId()), eq(TEST_API_CLIENT_ID))).thenReturn(consentAwaitingAuthorisation);
+
+        final String fundsConfirmationUri = controllerFundsConfirmationUri(consentAwaitingAuthorisation.getId());
+        final ResponseEntity<OBErrorResponse1> fundsConfirmationResponse = restTemplate.exchange(fundsConfirmationUri,
+                HttpMethod.GET, new HttpEntity<>(HTTP_HEADERS), OBErrorResponse1.class);
+
+        validateConsentNotAuthorisedErrorResponse(fundsConfirmationResponse);
+
+        verifyNoInteractions(fundsAvailabilityService);
+    }
+
+    private String controllerGetConsentUri(String consentId) {
+        return controllerBaseUri + "/" + consentId;
+    }
+
+    private String controllerFundsConfirmationUri(String consentId) {
+        return controllerGetConsentUri(consentId) + "/funds-confirmation";
+    }
+
+    private static OBWriteInternationalConsent5 createValidateConsentRequestWithAgreedRate() {
         final OBWriteInternationalConsent5 consentRequest = OBWriteInternationalConsentTestDataFactory.aValidOBWriteInternationalConsent5();
         consentRequest.getData().getAuthorisation().setCompletionDateTime(DateTime.now(DateTimeZone.UTC));
         return consentRequest;
     }
 
-    public static InternationalPaymentConsent buildAwaitingAuthorisationConsent(OBWriteInternationalConsent5 consentRequest) {
+    public static InternationalPaymentConsent buildAwaitingAuthorisationConsentForAgreedRate(OBWriteInternationalConsent5 consentRequest) {
+        assertConsentHasAgreedRateType(consentRequest);
+        return buildAwaitingAuthorisationConsent(consentRequest, consentRequest.getData().getInitiation().getExchangeRateInformation());
+    }
+
+    private static InternationalPaymentConsent buildAwaitingAuthorisationConsent(OBWriteInternationalConsent5 consentRequest,
+                                                                                 OBWriteInternational3DataInitiationExchangeRateInformation exchangeRateInformation) {
+
         final InternationalPaymentConsent consentStoreResponse = new InternationalPaymentConsent();
         consentStoreResponse.setId(IntentType.PAYMENT_INTERNATIONAL_CONSENT.generateIntentId());
-        consentStoreResponse.setRequestObj(FRWriteInternationalConsentConverter.toFRWriteInternationalConsent(consentRequest));
+        consentStoreResponse.setRequestObj(toFRWriteInternationalConsent(consentRequest));
         consentStoreResponse.setStatus(StatusEnum.AWAITINGAUTHORISATION.toString());
         consentStoreResponse.setCharges(List.of());
-        consentStoreResponse.setExchangeRateInformation(FRExchangeRateInformation.builder().rateType(FRRateType.AGREED).
-                exchangeRate(new BigDecimal("1.1")).
-                unitCurrency("GBP")
-                .contractIdentification("ct2334")
-                .build());
+        consentStoreResponse.setExchangeRateInformation(toFRExchangeRateInformation(exchangeRateInformation));
         final DateTime creationDateTime = DateTime.now();
         consentStoreResponse.setCreationDateTime(creationDateTime);
         consentStoreResponse.setStatusUpdateDateTime(creationDateTime);
@@ -57,7 +314,7 @@ public class InternationalPaymentConsentsApiControllerTest {
     }
 
     private static InternationalPaymentConsent buildAuthorisedConsent(OBWriteInternationalConsent5 consentRequest, String debtorAccountId) {
-        final InternationalPaymentConsent internationalPaymentConsent = buildAwaitingAuthorisationConsent(consentRequest);
+        final InternationalPaymentConsent internationalPaymentConsent = buildAwaitingAuthorisationConsentForAgreedRate(consentRequest);
         internationalPaymentConsent.setStatus(StatusEnum.AUTHORISED.toString());
         internationalPaymentConsent.setAuthorisedDebtorAccountId(debtorAccountId);
         return internationalPaymentConsent;

--- a/secure-api-gateway-ob-uk-rs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/v3_1_10/internationalpayments/InternationalPaymentConsentsApiControllerTest.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/v3_1_10/internationalpayments/InternationalPaymentConsentsApiControllerTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.ob.uk.rs.server.api.obie.payment.v3_1_10.internationalpayments;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+
+import com.forgerock.sapi.gateway.ob.uk.common.datamodel.common.FRExchangeRateInformation;
+import com.forgerock.sapi.gateway.ob.uk.common.datamodel.common.FRExchangeRateInformation.FRRateType;
+import com.forgerock.sapi.gateway.ob.uk.common.datamodel.converter.payment.FRWriteInternationalConsentConverter;
+import com.forgerock.sapi.gateway.rcs.consent.store.datamodel.payment.international.v3_1_10.InternationalPaymentConsent;
+import com.forgerock.sapi.gateway.uk.common.shared.api.meta.share.IntentType;
+
+import uk.org.openbanking.datamodel.payment.OBWriteInternationalConsent5;
+import uk.org.openbanking.datamodel.payment.OBWriteInternationalConsentResponse6Data.StatusEnum;
+import uk.org.openbanking.testsupport.payment.OBWriteInternationalConsentTestDataFactory;
+
+public class InternationalPaymentConsentsApiControllerTest {
+
+    private static OBWriteInternationalConsent5 createValidateConsentRequest() {
+        final OBWriteInternationalConsent5 consentRequest = OBWriteInternationalConsentTestDataFactory.aValidOBWriteInternationalConsent5();
+        consentRequest.getData().getAuthorisation().setCompletionDateTime(DateTime.now(DateTimeZone.UTC));
+        return consentRequest;
+    }
+
+    public static InternationalPaymentConsent buildAwaitingAuthorisationConsent(OBWriteInternationalConsent5 consentRequest) {
+        final InternationalPaymentConsent consentStoreResponse = new InternationalPaymentConsent();
+        consentStoreResponse.setId(IntentType.PAYMENT_INTERNATIONAL_CONSENT.generateIntentId());
+        consentStoreResponse.setRequestObj(FRWriteInternationalConsentConverter.toFRWriteInternationalConsent(consentRequest));
+        consentStoreResponse.setStatus(StatusEnum.AWAITINGAUTHORISATION.toString());
+        consentStoreResponse.setCharges(List.of());
+        consentStoreResponse.setExchangeRateInformation(FRExchangeRateInformation.builder().rateType(FRRateType.AGREED).
+                exchangeRate(new BigDecimal("1.1")).
+                unitCurrency("GBP")
+                .contractIdentification("ct2334")
+                .build());
+        final DateTime creationDateTime = DateTime.now();
+        consentStoreResponse.setCreationDateTime(creationDateTime);
+        consentStoreResponse.setStatusUpdateDateTime(creationDateTime);
+        return consentStoreResponse;
+    }
+
+    private static InternationalPaymentConsent buildAuthorisedConsent(OBWriteInternationalConsent5 consentRequest, String debtorAccountId) {
+        final InternationalPaymentConsent internationalPaymentConsent = buildAwaitingAuthorisationConsent(consentRequest);
+        internationalPaymentConsent.setStatus(StatusEnum.AUTHORISED.toString());
+        internationalPaymentConsent.setAuthorisedDebtorAccountId(debtorAccountId);
+        return internationalPaymentConsent;
+    }
+}

--- a/secure-api-gateway-ob-uk-rs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/v3_1_10/internationalpayments/InternationalPaymentConsentsApiControllerTest.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/v3_1_10/internationalpayments/InternationalPaymentConsentsApiControllerTest.java
@@ -15,8 +15,8 @@
  */
 package com.forgerock.sapi.gateway.ob.uk.rs.server.api.obie.payment.v3_1_10.internationalpayments;
 
-import static com.forgerock.sapi.gateway.ob.uk.common.datamodel.converter.payment.FRExchangeRateConverter.*;
-import static com.forgerock.sapi.gateway.ob.uk.common.datamodel.converter.payment.FRWriteInternationalConsentConverter.*;
+import static com.forgerock.sapi.gateway.ob.uk.common.datamodel.converter.payment.FRExchangeRateConverter.toFRExchangeRateInformation;
+import static com.forgerock.sapi.gateway.ob.uk.common.datamodel.converter.payment.FRWriteInternationalConsentConverter.toFRWriteInternationalConsent;
 import static com.forgerock.sapi.gateway.ob.uk.common.error.ErrorCode.OBRI_CONSENT_NOT_FOUND;
 import static com.forgerock.sapi.gateway.ob.uk.common.error.ErrorCode.OBRI_PERMISSION_INVALID;
 import static com.forgerock.sapi.gateway.ob.uk.rs.server.api.obie.payment.FundsConfirmationTestHelpers.validateConsentNotAuthorisedErrorResponse;
@@ -63,13 +63,11 @@ import uk.org.openbanking.datamodel.error.OBError1;
 import uk.org.openbanking.datamodel.error.OBErrorResponse1;
 import uk.org.openbanking.datamodel.error.OBStandardErrorCodes1;
 import uk.org.openbanking.datamodel.payment.OBExchangeRateType2Code;
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticConsent4;
 import uk.org.openbanking.datamodel.payment.OBWriteFundsConfirmationResponse1;
 import uk.org.openbanking.datamodel.payment.OBWriteInternational3DataInitiationExchangeRateInformation;
 import uk.org.openbanking.datamodel.payment.OBWriteInternationalConsent5;
 import uk.org.openbanking.datamodel.payment.OBWriteInternationalConsentResponse6;
 import uk.org.openbanking.datamodel.payment.OBWriteInternationalConsentResponse6Data.StatusEnum;
-import uk.org.openbanking.testsupport.payment.OBWriteDomesticConsentTestDataFactory;
 import uk.org.openbanking.testsupport.payment.OBWriteInternationalConsentTestDataFactory;
 
 @SpringBootTest(webEnvironment = RANDOM_PORT)
@@ -193,7 +191,7 @@ public class InternationalPaymentConsentsApiControllerTest {
 
     @Test
     public void failsToCreateConsentIfRequestDoesNotPassJavaBeanValidation() {
-        final OBWriteDomesticConsent4 emptyConsent = new OBWriteDomesticConsent4();
+        final OBWriteInternationalConsent5 emptyConsent = new OBWriteInternationalConsent5();
 
         final ResponseEntity<OBErrorResponse1> response = restTemplate.exchange(controllerBaseUri, HttpMethod.POST,
                 new HttpEntity<>(emptyConsent, HTTP_HEADERS), OBErrorResponse1.class);
@@ -212,7 +210,7 @@ public class InternationalPaymentConsentsApiControllerTest {
 
     @Test
     public void failsToCreateConsentIfRequestDoesNotPassBizLogicValidation() {
-        final OBWriteDomesticConsent4 consentWithInvalidAmount = OBWriteDomesticConsentTestDataFactory.aValidOBWriteDomesticConsent4();
+        final OBWriteInternationalConsent5 consentWithInvalidAmount = createValidateConsentRequestWithAgreedRate();
         consentWithInvalidAmount.getData().getInitiation().getInstructedAmount().setAmount("0"); // Invalid amount
 
         final ResponseEntity<OBErrorResponse1> response = restTemplate.exchange(controllerBaseUri, HttpMethod.POST,

--- a/secure-api-gateway-ob-uk-rs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/server/service/currency/DefaultExchangeRateServiceTest.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/server/service/currency/DefaultExchangeRateServiceTest.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.ob.uk.rs.server.service.currency;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.math.BigDecimal;
+import java.util.Map;
+
+import org.joda.time.DateTime;
+import org.junit.jupiter.api.Test;
+
+import com.forgerock.sapi.gateway.ob.uk.common.datamodel.common.FRAmount;
+import com.forgerock.sapi.gateway.ob.uk.common.datamodel.common.FRExchangeRateInformation;
+import com.forgerock.sapi.gateway.ob.uk.common.datamodel.common.FRExchangeRateInformation.FRRateType;
+
+import uk.org.openbanking.datamodel.payment.OBExchangeRateType2Code;
+import uk.org.openbanking.datamodel.payment.OBWriteInternational3DataInitiationExchangeRateInformation;
+
+class DefaultExchangeRateServiceTest {
+
+    private final BigDecimal defaultExchangeRate = new BigDecimal("1.99");
+    private final DefaultExchangeRateService exchangeRateService = new DefaultExchangeRateService(Map.of("GBPUSD", new BigDecimal("1.32"),
+                                                                                                         "GBPEUR", new BigDecimal("1.16")),
+                                                                                                  defaultExchangeRate);
+
+    @Test
+    void shouldGetIndicativeQuoteIfNoExchangeRateInfoInRequest() {
+        final FRExchangeRateInformation exchangeRateInformation = exchangeRateService.calculateExchangeRateInfo("EUR",
+                new FRAmount("100.00", "GBP"), null);
+
+        final BigDecimal expectedRate = new BigDecimal("1.16");
+        validateIndicativeQuote(exchangeRateInformation, expectedRate, "GBP");
+    }
+
+    @Test
+    void shouldGetIndicativeQuoteWhenRequested() {
+        final FRExchangeRateInformation exchangeRateInformation = exchangeRateService.calculateExchangeRateInfo("NZD",
+                new FRAmount("100.00", "GBP"),
+                new OBWriteInternational3DataInitiationExchangeRateInformation().rateType(OBExchangeRateType2Code.INDICATIVE).unitCurrency("GBP"));
+
+        final BigDecimal expectedRate = new BigDecimal("1.99");
+        validateIndicativeQuote(exchangeRateInformation, expectedRate, "GBP");
+    }
+
+    @Test
+    void shouldGetActualQuote() {
+        final FRExchangeRateInformation exchangeRateInformation = exchangeRateService.calculateExchangeRateInfo("GBP",
+                new FRAmount("100.00", "EUR"), new OBWriteInternational3DataInitiationExchangeRateInformation().rateType(OBExchangeRateType2Code.ACTUAL).unitCurrency("EUR"));
+
+        final BigDecimal expectedRate = new BigDecimal("0.8621");
+        validateActualQuote(exchangeRateInformation, expectedRate, "EUR");
+    }
+
+    @Test
+    void shouldGetAgreedQuote() {
+        final FRExchangeRateInformation exchangeRateInformation = exchangeRateService.calculateExchangeRateInfo("USD", new FRAmount("100.00", "GBP"),
+                new OBWriteInternational3DataInitiationExchangeRateInformation()
+                        .rateType(OBExchangeRateType2Code.AGREED)
+                        .exchangeRate(new BigDecimal("1.35"))
+                        .unitCurrency("GBP")
+                        .contractIdentification("contract12"));
+
+        validateAgreedQuote(exchangeRateInformation, new BigDecimal("1.35"), "GBP", "contract12");
+    }
+
+    private static void validateIndicativeQuote(FRExchangeRateInformation exchangeRateInformation, BigDecimal expectedRate, String expectedUnitCcy) {
+        assertThat(exchangeRateInformation.getRateType()).isEqualTo(FRRateType.INDICATIVE);
+        assertThat(exchangeRateInformation.getExchangeRate()).isEqualByComparingTo(expectedRate);
+        assertThat(exchangeRateInformation.getUnitCurrency()).isEqualTo(expectedUnitCcy);
+        assertThat(exchangeRateInformation.getContractIdentification()).isNull();
+        assertThat(exchangeRateInformation.getExpirationDateTime()).isNull();
+    }
+
+    private static void validateActualQuote(FRExchangeRateInformation exchangeRateInformation, BigDecimal expectedRate, String expectedUnitCcy) {
+        assertThat(exchangeRateInformation.getRateType()).isEqualTo(FRRateType.ACTUAL);
+        assertThat(exchangeRateInformation.getExchangeRate()).isEqualByComparingTo(expectedRate);
+        assertThat(exchangeRateInformation.getUnitCurrency()).isEqualTo(expectedUnitCcy);
+        assertThat(exchangeRateInformation.getContractIdentification()).isNull();
+        assertThat(exchangeRateInformation.getExpirationDateTime()).isNotNull().isGreaterThan(DateTime.now());
+    }
+
+    private static void validateAgreedQuote(FRExchangeRateInformation exchangeRateInformation, BigDecimal expectedRate, String expectedUnitCcy, String expectedContractId) {
+        assertThat(exchangeRateInformation.getRateType()).isEqualTo(FRRateType.AGREED);
+        assertThat(exchangeRateInformation.getExchangeRate()).isEqualByComparingTo(expectedRate);
+        assertThat(exchangeRateInformation.getUnitCurrency()).isEqualTo(expectedUnitCcy);
+        assertThat(exchangeRateInformation.getContractIdentification()).isEqualTo(expectedContractId);
+        assertThat(exchangeRateInformation.getExpirationDateTime()).isNull();
+    }
+
+}

--- a/secure-api-gateway-ob-uk-rs-validation/secure-api-gateway-ob-uk-rs-validation-obie/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/validation/obie/payment/CurrencyCodeValidator.java
+++ b/secure-api-gateway-ob-uk-rs-validation/secure-api-gateway-ob-uk-rs-validation-obie/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/validation/obie/payment/CurrencyCodeValidator.java
@@ -15,34 +15,28 @@
  */
 package com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.payment;
 
-import static java.math.BigDecimal.ZERO;
-
-import java.math.BigDecimal;
 import java.util.Objects;
+import java.util.Set;
 
 import com.forgerock.sapi.gateway.ob.uk.common.error.OBRIErrorType;
 import com.forgerock.sapi.gateway.ob.uk.rs.validation.ValidationResult;
 import com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.BaseOBValidator;
 
 import uk.org.openbanking.datamodel.error.OBError1;
-import uk.org.openbanking.datamodel.payment.OBWriteDomestic2DataInitiationInstructedAmount;
 
-public class OBWriteDomestic2DataInitiationInstructedAmountValidator extends BaseOBValidator<OBWriteDomestic2DataInitiationInstructedAmount> {
+public class CurrencyCodeValidator extends BaseOBValidator<String> {
 
-    private final BaseOBValidator<String> currencyCodeValidator;
+    private final Set<String> validCurrencyCodes;
 
-    public OBWriteDomestic2DataInitiationInstructedAmountValidator(BaseOBValidator<String> currencyCodeValidator) {
-        this.currencyCodeValidator = Objects.requireNonNull(currencyCodeValidator, "currencyCodeValidator must be supplied");
+    public CurrencyCodeValidator(Set<String> validCurrencyCodes) {
+        this.validCurrencyCodes = Objects.requireNonNull(validCurrencyCodes, "validCurrencyCodes must be supplied");
     }
 
     @Override
-    protected void validate(OBWriteDomestic2DataInitiationInstructedAmount instructedAmount, ValidationResult<OBError1> validationResult) {
-        final String amount = instructedAmount.getAmount();
-        if (new BigDecimal(amount).compareTo(ZERO) <= 0) {
+    protected void validate(String currencyCode, ValidationResult<OBError1> validationResult) {
+        if (!validCurrencyCodes.contains(currencyCode)) {
             validationResult.addError(OBRIErrorType.DATA_INVALID_REQUEST.toOBError1(
-                    String.format("The amount %s provided must be greater than 0", amount)));
+                    String.format("The currency %s provided is not supported", currencyCode)));
         }
-        final String currency = instructedAmount.getCurrency();
-        validationResult.mergeResults(currencyCodeValidator.validate(currency));
     }
 }

--- a/secure-api-gateway-ob-uk-rs-validation/secure-api-gateway-ob-uk-rs-validation-obie/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/validation/obie/payment/OBWriteInternational3DataInitiationExchangeRateInformationValidator.java
+++ b/secure-api-gateway-ob-uk-rs-validation/secure-api-gateway-ob-uk-rs-validation-obie/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/validation/obie/payment/OBWriteInternational3DataInitiationExchangeRateInformationValidator.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.payment;
+
+import java.util.Objects;
+
+import com.forgerock.sapi.gateway.ob.uk.common.error.OBRIErrorType;
+import com.forgerock.sapi.gateway.ob.uk.rs.validation.ValidationResult;
+import com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.BaseOBValidator;
+
+import uk.org.openbanking.datamodel.error.OBError1;
+import uk.org.openbanking.datamodel.payment.OBExchangeRateType2Code;
+import uk.org.openbanking.datamodel.payment.OBWriteInternational3DataInitiationExchangeRateInformation;
+
+public class OBWriteInternational3DataInitiationExchangeRateInformationValidator extends BaseOBValidator<OBWriteInternational3DataInitiationExchangeRateInformation> {
+
+    private final BaseOBValidator<String> currencyCodeValidator;
+
+    public OBWriteInternational3DataInitiationExchangeRateInformationValidator(BaseOBValidator<String> currencyCodeValidator) {
+        this.currencyCodeValidator = Objects.requireNonNull(currencyCodeValidator, "currencyCodeValidator must be supplied");
+    }
+
+    @Override
+    protected void validate(OBWriteInternational3DataInitiationExchangeRateInformation exchangeRateInfo,
+                            ValidationResult<OBError1> validationResult) {
+
+        validationResult.mergeResults(currencyCodeValidator.validate(exchangeRateInfo.getUnitCurrency()));
+
+        final OBExchangeRateType2Code rateType = exchangeRateInfo.getRateType();
+        if (rateType == OBExchangeRateType2Code.AGREED) {
+            if (exchangeRateInfo.getContractIdentification() == null || exchangeRateInfo.getExchangeRate() == null) {
+                validationResult.addError(OBRIErrorType.DATA_INVALID_REQUEST.toOBError1(
+                        "ExchangeRate and ContractIdentification must be specify when requesting an Agreed RateType."));
+            }
+        } else {
+            if (!(exchangeRateInfo.getExchangeRate() == null && exchangeRateInfo.getContractIdentification() == null)) {
+                validationResult.addError(OBRIErrorType.DATA_INVALID_REQUEST.toOBError1(
+                        String.format("A PISP must not specify ExchangeRate and/or ContractIdentification when requesting an %s RateType.", rateType)));
+            }
+        }
+
+    }
+
+}

--- a/secure-api-gateway-ob-uk-rs-validation/secure-api-gateway-ob-uk-rs-validation-obie/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/validation/obie/payment/OBWriteInternational3Validator.java
+++ b/secure-api-gateway-ob-uk-rs-validation/secure-api-gateway-ob-uk-rs-validation-obie/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/validation/obie/payment/OBWriteInternational3Validator.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.payment;
+
+import com.forgerock.sapi.gateway.ob.uk.rs.validation.ValidationResult;
+import com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.payment.OBWriteInternational3Validator.OBWriteInternational3ValidationContext;
+
+import uk.org.openbanking.datamodel.error.OBError1;
+import uk.org.openbanking.datamodel.payment.OBWriteInternational3;
+import uk.org.openbanking.datamodel.payment.OBWriteInternational3DataInitiation;
+import uk.org.openbanking.datamodel.payment.OBWriteInternationalConsent5;
+
+/**
+ * Validator of OBWriteInternational3 objects (International Payment Requests)
+ */
+public class OBWriteInternational3Validator extends BasePaymentRequestValidator<OBWriteInternational3ValidationContext, OBWriteInternational3, OBWriteInternational3DataInitiation> {
+
+    public static class OBWriteInternational3ValidationContext extends PaymentRequestValidationContext<OBWriteInternational3, OBWriteInternational3DataInitiation> {
+        public OBWriteInternational3ValidationContext(OBWriteInternational3 paymentRequest, OBWriteInternationalConsent5 consentRequest, String consentStatus) {
+            super(paymentRequest, () -> paymentRequest.getData().getInitiation(), paymentRequest::getRisk,
+                    consentStatus, () -> consentRequest.getData().getInitiation(), consentRequest::getRisk);
+        }
+    }
+
+    @Override
+    protected void doPaymentSpecificValidation(OBWriteInternational3ValidationContext paymentReqValidationCtxt,
+                                               ValidationResult<OBError1> validationResult) {
+
+        // Add any payment specific validation as required
+    }
+}

--- a/secure-api-gateway-ob-uk-rs-validation/secure-api-gateway-ob-uk-rs-validation-obie/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/validation/obie/payment/consent/OBWriteDomesticStandingOrderConsent5Validator.java
+++ b/secure-api-gateway-ob-uk-rs-validation/secure-api-gateway-ob-uk-rs-validation-obie/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/validation/obie/payment/consent/OBWriteDomesticStandingOrderConsent5Validator.java
@@ -19,7 +19,6 @@ import static java.math.BigDecimal.ZERO;
 
 import java.math.BigDecimal;
 import java.util.Objects;
-import java.util.Set;
 
 import com.forgerock.sapi.gateway.ob.uk.common.error.OBRIErrorType;
 import com.forgerock.sapi.gateway.ob.uk.rs.validation.ValidationResult;
@@ -32,15 +31,19 @@ import uk.org.openbanking.datamodel.payment.OBWriteDomesticStandingOrder3DataIni
 import uk.org.openbanking.datamodel.payment.OBWriteDomesticStandingOrder3DataInitiationRecurringPaymentAmount;
 import uk.org.openbanking.datamodel.payment.OBWriteDomesticStandingOrderConsent5;
 
+/**
+ * Validator of OBWriteDomesticStandingOrderConsent5 objects (OBIE Domestic Standing Order Consents)
+ */
 public class OBWriteDomesticStandingOrderConsent5Validator extends BaseOBValidator<OBWriteDomesticStandingOrderConsent5> {
 
     private static final String FIRST_PAYMENT_AMOUNT = "firstPaymentAmount";
     private static final String RECURRING_PAYMENT_AMOUNT = "recurringPaymentAmount";
     private static final String FINAL_PAYMENT_AMOUNT = "finalPaymentAmount";
-    private final Set<String> validPaymentCurrencies;
 
-    public OBWriteDomesticStandingOrderConsent5Validator(Set<String> validPaymentCurrencies) {
-        this.validPaymentCurrencies = Objects.requireNonNull(validPaymentCurrencies, "validPaymentCurrencies must be supplied");
+    private final BaseOBValidator<String> currencyCodeValidator;
+
+    public OBWriteDomesticStandingOrderConsent5Validator(BaseOBValidator<String> currencyCodeValidator) {
+        this.currencyCodeValidator = Objects.requireNonNull(currencyCodeValidator, "currencyCodeValidator must be supplied");
     }
 
     @Override
@@ -66,9 +69,6 @@ public class OBWriteDomesticStandingOrderConsent5Validator extends BaseOBValidat
             validationResult.addError(OBRIErrorType.DATA_INVALID_REQUEST.toOBError1(
                     String.format("Field: %s - the amount %s provided must be greater than 0", fieldName, amount)));
         }
-        if (!validPaymentCurrencies.contains(currency)) {
-            validationResult.addError(OBRIErrorType.DATA_INVALID_REQUEST.toOBError1(
-                    String.format("Field: %s - the currency %s provided is not supported", fieldName, currency)));
-        }
+        validationResult.mergeResults(currencyCodeValidator.validate(currency));
     }
 }

--- a/secure-api-gateway-ob-uk-rs-validation/secure-api-gateway-ob-uk-rs-validation-obie/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/validation/obie/payment/consent/OBWriteFileConsent3Validator.java
+++ b/secure-api-gateway-ob-uk-rs-validation/secure-api-gateway-ob-uk-rs-validation-obie/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/validation/obie/payment/consent/OBWriteFileConsent3Validator.java
@@ -21,6 +21,9 @@ import com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.BaseOBValidator;
 import uk.org.openbanking.datamodel.error.OBError1;
 import uk.org.openbanking.datamodel.payment.OBWriteFileConsent3;
 
+/**
+ * Validator of OBWriteFileConsent3 objects (OBIE File Payment Consents)
+ */
 public class OBWriteFileConsent3Validator extends BaseOBValidator<OBWriteFileConsent3> {
 
     @Override

--- a/secure-api-gateway-ob-uk-rs-validation/secure-api-gateway-ob-uk-rs-validation-obie/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/validation/obie/payment/consent/OBWriteInternationalConsent5Validator.java
+++ b/secure-api-gateway-ob-uk-rs-validation/secure-api-gateway-ob-uk-rs-validation-obie/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/validation/obie/payment/consent/OBWriteInternationalConsent5Validator.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.payment.consent;
+
+import java.util.Objects;
+
+import com.forgerock.sapi.gateway.ob.uk.rs.validation.ValidationResult;
+import com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.BaseOBValidator;
+
+import uk.org.openbanking.datamodel.error.OBError1;
+import uk.org.openbanking.datamodel.payment.OBWriteDomestic2DataInitiationInstructedAmount;
+import uk.org.openbanking.datamodel.payment.OBWriteInternational3DataInitiation;
+import uk.org.openbanking.datamodel.payment.OBWriteInternational3DataInitiationExchangeRateInformation;
+import uk.org.openbanking.datamodel.payment.OBWriteInternationalConsent5;
+
+/**
+ * Validator of OBWriteInternationalConsent5 objects (OBIE International Payment Consents)
+ */
+public class OBWriteInternationalConsent5Validator extends BaseOBValidator<OBWriteInternationalConsent5> {
+
+    private final BaseOBValidator<OBWriteDomestic2DataInitiationInstructedAmount> instructedAmountValidator;
+    private final BaseOBValidator<String> currencyCodeValidator;
+    private final BaseOBValidator<OBWriteInternational3DataInitiationExchangeRateInformation> exchangeRateInfoValidator;
+
+    public OBWriteInternationalConsent5Validator(BaseOBValidator<OBWriteDomestic2DataInitiationInstructedAmount> instructedAmountValidator,
+            BaseOBValidator<String> currencyCodeValidator, BaseOBValidator<OBWriteInternational3DataInitiationExchangeRateInformation> exchangeRateInfoValidator) {
+        this.instructedAmountValidator = Objects.requireNonNull(instructedAmountValidator);
+        this.currencyCodeValidator     = Objects.requireNonNull(currencyCodeValidator);
+        this.exchangeRateInfoValidator = Objects.requireNonNull(exchangeRateInfoValidator);
+    }
+
+    @Override
+    protected void validate(OBWriteInternationalConsent5 consent, ValidationResult<OBError1> validationResult) {
+        final OBWriteInternational3DataInitiation initiation = consent.getData().getInitiation();
+        validationResult.mergeResults(instructedAmountValidator.validate(initiation.getInstructedAmount()));
+        validationResult.mergeResults(currencyCodeValidator.validate(initiation.getCurrencyOfTransfer()));
+
+        if (initiation.getExchangeRateInformation() != null) {
+            validationResult.mergeResults(exchangeRateInfoValidator.validate(initiation.getExchangeRateInformation()));
+        }
+    }
+}

--- a/secure-api-gateway-ob-uk-rs-validation/secure-api-gateway-ob-uk-rs-validation-obie/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/validation/obie/payment/CurrencyCodeValidatorTest.java
+++ b/secure-api-gateway-ob-uk-rs-validation/secure-api-gateway-ob-uk-rs-validation-obie/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/validation/obie/payment/CurrencyCodeValidatorTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.payment;
+
+import static com.forgerock.sapi.gateway.ob.uk.rs.validation.ValidationResultTest.validateErrorResult;
+import static com.forgerock.sapi.gateway.ob.uk.rs.validation.ValidationResultTest.validateSuccessResult;
+
+import java.util.List;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+
+import com.forgerock.sapi.gateway.ob.uk.common.error.OBRIErrorType;
+
+public class CurrencyCodeValidatorTest {
+
+    public static CurrencyCodeValidator createCurrencyCodeValidator(String... currencies) {
+        return new CurrencyCodeValidator(Set.of(currencies));
+    }
+
+    @Test
+    public void testValidation() {
+        final String[] validCurrencies = new String[] {
+                "GBP", "EUR", "USD", "CHF", "AUD"
+        };
+
+        final CurrencyCodeValidator validator = createCurrencyCodeValidator(validCurrencies);
+        for (String currency : validCurrencies) {
+            validateSuccessResult(validator.validate(currency));
+        }
+
+        final String[] invalidCurrencies = new String[] {
+                "what is this?", "zzz", "ZZZ", "023232323"
+        };
+        for (String currency : invalidCurrencies) {
+            validateErrorResult(validator.validate(currency), List.of(OBRIErrorType.DATA_INVALID_REQUEST.toOBError1(
+                    "The currency " + currency + " provided is not supported")));
+        }
+    }
+
+}

--- a/secure-api-gateway-ob-uk-rs-validation/secure-api-gateway-ob-uk-rs-validation-obie/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/validation/obie/payment/OBWriteDomestic2DataInitiationInstructedAmountValidatorTest.java
+++ b/secure-api-gateway-ob-uk-rs-validation/secure-api-gateway-ob-uk-rs-validation-obie/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/validation/obie/payment/OBWriteDomestic2DataInitiationInstructedAmountValidatorTest.java
@@ -16,9 +16,9 @@
 package com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.payment;
 
 import static com.forgerock.sapi.gateway.ob.uk.rs.validation.ValidationResultTest.validateErrorResult;
+import static com.forgerock.sapi.gateway.ob.uk.rs.validation.ValidationResultTest.validateSuccessResult;
 
 import java.util.List;
-import java.util.Set;
 
 import org.junit.jupiter.api.Test;
 
@@ -28,11 +28,17 @@ import uk.org.openbanking.datamodel.payment.OBWriteDomestic2DataInitiationInstru
 public class OBWriteDomestic2DataInitiationInstructedAmountValidatorTest {
 
     public static OBWriteDomestic2DataInitiationInstructedAmountValidator createInstructedAmountValidator(String... currencies) {
-        return new OBWriteDomestic2DataInitiationInstructedAmountValidator(Set.of(currencies));
+        return new OBWriteDomestic2DataInitiationInstructedAmountValidator(CurrencyCodeValidatorTest.createCurrencyCodeValidator(currencies));
     }
 
 
     private final OBWriteDomestic2DataInitiationInstructedAmountValidator validator = createInstructedAmountValidator("USD", "GBP", "EUR", "CHF");
+
+    @Test
+    public void validationRulesPass() {
+        validateSuccessResult(validator.validate(
+                new OBWriteDomestic2DataInitiationInstructedAmount().amount("0.01").currency("GBP")));
+    }
 
     @Test
     public void failsValidationWhenInstructedAmountCurrencyInvalid() {

--- a/secure-api-gateway-ob-uk-rs-validation/secure-api-gateway-ob-uk-rs-validation-obie/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/validation/obie/payment/OBWriteDomestic2ValidatorTest.java
+++ b/secure-api-gateway-ob-uk-rs-validation/secure-api-gateway-ob-uk-rs-validation-obie/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/validation/obie/payment/OBWriteDomestic2ValidatorTest.java
@@ -99,7 +99,7 @@ class OBWriteDomestic2ValidatorTest {
 
             final OBWriteDomestic2ValidationContext validatorContext = new OBWriteDomestic2ValidationContext(paymentRequest, consent, invalidStatus.toString());
             validateErrorResult(obWriteDomestic2Validator.validate(validatorContext), List.of(new OBError1().errorCode("UK.OBIE.Resource.InvalidConsentStatus")
-                    .message("Confirmation is not allowed unless the consent status is Authorised. Currently, the consent is " + invalidStatus)));
+                    .message("Action can only be performed on consents with status: Authorised. Currently, the consent is: " + invalidStatus)));
         }
     }
 

--- a/secure-api-gateway-ob-uk-rs-validation/secure-api-gateway-ob-uk-rs-validation-obie/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/validation/obie/payment/OBWriteInternational3DataInitiationExchangeRateInformationValidatorTest.java
+++ b/secure-api-gateway-ob-uk-rs-validation/secure-api-gateway-ob-uk-rs-validation-obie/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/validation/obie/payment/OBWriteInternational3DataInitiationExchangeRateInformationValidatorTest.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.payment;
+
+import static com.forgerock.sapi.gateway.ob.uk.rs.validation.ValidationResultTest.validateErrorResult;
+import static com.forgerock.sapi.gateway.ob.uk.rs.validation.ValidationResultTest.validateSuccessResult;
+import static uk.org.openbanking.testsupport.payment.OBWriteInternationalConsentTestDataFactory.aValidOBWriteInternationalConsent5;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import com.forgerock.sapi.gateway.ob.uk.common.error.OBRIErrorType;
+
+import uk.org.openbanking.datamodel.payment.OBExchangeRateType2Code;
+import uk.org.openbanking.datamodel.payment.OBWriteInternational3DataInitiationExchangeRateInformation;
+
+
+public class OBWriteInternational3DataInitiationExchangeRateInformationValidatorTest {
+
+    public static OBWriteInternational3DataInitiationExchangeRateInformationValidator createExchangeRateInfoValidator(String... currencies) {
+        return new OBWriteInternational3DataInitiationExchangeRateInformationValidator(CurrencyCodeValidatorTest.createCurrencyCodeValidator(currencies));
+    }
+
+    private final OBWriteInternational3DataInitiationExchangeRateInformationValidator validator = createExchangeRateInfoValidator("USD", "GBP", "EUR");
+
+    private static OBWriteInternational3DataInitiationExchangeRateInformation createValidateExchangeRateInfo() {
+        return aValidOBWriteInternationalConsent5().getData().getInitiation().getExchangeRateInformation();
+    }
+
+    @Test
+    void validationRulesPass() {
+        validateSuccessResult(validator.validate(createValidateExchangeRateInfo()));
+    }
+
+    @Test
+    void failsValidationWhenUnitCurrencyInvalid() {
+        final OBWriteInternational3DataInitiationExchangeRateInformation exchangeRateInfo = createValidateExchangeRateInfo();
+        exchangeRateInfo.setUnitCurrency("ZZZ");
+        validateErrorResult(validator.validate(exchangeRateInfo), List.of(OBRIErrorType.DATA_INVALID_REQUEST.toOBError1(
+                "The currency ZZZ provided is not supported")));
+    }
+
+    @Test
+    void failsWhenAgreedRateTypeFieldsAreMissing() {
+        final OBWriteInternational3DataInitiationExchangeRateInformation invalidExchangeRateInfo = new OBWriteInternational3DataInitiationExchangeRateInformation()
+                .unitCurrency("GBP")
+                .rateType(OBExchangeRateType2Code.AGREED);
+
+        validateErrorResult(validator.validate(invalidExchangeRateInfo), List.of(OBRIErrorType.DATA_INVALID_REQUEST.toOBError1(
+                "ExchangeRate and ContractIdentification must be specify when requesting an Agreed RateType.")));
+
+        invalidExchangeRateInfo.exchangeRate(new BigDecimal("1.23456"));
+        validateErrorResult(validator.validate(invalidExchangeRateInfo), List.of(OBRIErrorType.DATA_INVALID_REQUEST.toOBError1(
+                "ExchangeRate and ContractIdentification must be specify when requesting an Agreed RateType.")));
+
+        invalidExchangeRateInfo.exchangeRate(null).contractIdentification("some contract id");
+        validateErrorResult(validator.validate(invalidExchangeRateInfo), List.of(OBRIErrorType.DATA_INVALID_REQUEST.toOBError1(
+                "ExchangeRate and ContractIdentification must be specify when requesting an Agreed RateType.")));
+    }
+
+    @Test
+    void failsWhenAgreedRateTypeFieldsArePresentForNonAgreedRate() {
+        final OBExchangeRateType2Code[] nonAgreedRateTypes = new OBExchangeRateType2Code[]{
+                OBExchangeRateType2Code.ACTUAL, OBExchangeRateType2Code.INDICATIVE
+        };
+
+        for (OBExchangeRateType2Code nonAgreedRateType : nonAgreedRateTypes) {
+            final OBWriteInternational3DataInitiationExchangeRateInformation invalidExchangeRateInfo = new OBWriteInternational3DataInitiationExchangeRateInformation()
+                    .unitCurrency("GBP")
+                    .contractIdentification("contract id")
+                    .exchangeRate(new BigDecimal("1.2343"))
+                    .rateType(nonAgreedRateType);
+
+            validateErrorResult(validator.validate(invalidExchangeRateInfo), List.of(OBRIErrorType.DATA_INVALID_REQUEST.toOBError1(
+                    "A PISP must not specify ExchangeRate and/or ContractIdentification when requesting an " + nonAgreedRateType + " RateType.")));
+
+            invalidExchangeRateInfo.contractIdentification(null);
+            validateErrorResult(validator.validate(invalidExchangeRateInfo), List.of(OBRIErrorType.DATA_INVALID_REQUEST.toOBError1(
+                    "A PISP must not specify ExchangeRate and/or ContractIdentification when requesting an " + nonAgreedRateType + " RateType.")));
+
+            invalidExchangeRateInfo.contractIdentification("some contract id").exchangeRate(null);
+            validateErrorResult(validator.validate(invalidExchangeRateInfo), List.of(OBRIErrorType.DATA_INVALID_REQUEST.toOBError1(
+                    "A PISP must not specify ExchangeRate and/or ContractIdentification when requesting an " + nonAgreedRateType + " RateType.")));
+        }
+    }
+
+}

--- a/secure-api-gateway-ob-uk-rs-validation/secure-api-gateway-ob-uk-rs-validation-obie/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/validation/obie/payment/OBWriteInternational3ValidatorTest.java
+++ b/secure-api-gateway-ob-uk-rs-validation/secure-api-gateway-ob-uk-rs-validation-obie/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/validation/obie/payment/OBWriteInternational3ValidatorTest.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.payment;
+
+import static com.forgerock.sapi.gateway.ob.uk.rs.validation.ValidationResultTest.validateErrorResult;
+import static com.forgerock.sapi.gateway.ob.uk.rs.validation.ValidationResultTest.validateSuccessResult;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.payment.OBWriteInternational3Validator.OBWriteInternational3ValidationContext;
+
+import uk.org.openbanking.datamodel.common.OBExternalPaymentContext1Code;
+import uk.org.openbanking.datamodel.common.OBRisk1;
+import uk.org.openbanking.datamodel.error.OBError1;
+import uk.org.openbanking.datamodel.payment.OBWriteDomestic2DataInitiationInstructedAmount;
+import uk.org.openbanking.datamodel.payment.OBWriteInternational3;
+import uk.org.openbanking.datamodel.payment.OBWriteInternational3Data;
+import uk.org.openbanking.datamodel.payment.OBWriteInternational3DataInitiation;
+import uk.org.openbanking.datamodel.payment.OBWriteInternationalConsent5;
+import uk.org.openbanking.datamodel.payment.OBWriteInternationalConsent5Data;
+import uk.org.openbanking.datamodel.payment.OBWriteInternationalConsentResponse6Data.StatusEnum;
+
+class OBWriteInternational3ValidatorTest {
+
+    private static final String AUTHORISED_STATUS = "Authorised";
+
+    private final OBWriteInternational3Validator validator = new OBWriteInternational3Validator();
+
+    @Test
+    public void validationSuccessWhenInitiationAndRiskMatchConsent() {
+        final OBWriteInternationalConsent5Data consentData = new OBWriteInternationalConsent5Data().initiation(createInitiation());
+        final OBWriteInternationalConsent5 consent = new OBWriteInternationalConsent5().data(consentData).risk(createRisk());
+
+        final OBWriteInternational3Data paymentData = new OBWriteInternational3Data().initiation(createInitiation());
+        final OBWriteInternational3 paymentRequest = new OBWriteInternational3().data(paymentData).risk(createRisk());
+
+        final OBWriteInternational3ValidationContext validatorContext = new OBWriteInternational3ValidationContext(paymentRequest, consent, AUTHORISED_STATUS);
+
+        validateSuccessResult(validator.validate(validatorContext));
+    }
+
+    @Test
+    public void validationFailsWhenInitiationDoesNotMatchConsent() {
+        final OBWriteInternationalConsent5Data consentData = new OBWriteInternationalConsent5Data().initiation(createInitiation());
+        final OBWriteInternationalConsent5 consent = new OBWriteInternationalConsent5().data(consentData).risk(createRisk());
+
+        final OBWriteInternational3Data paymentData = new OBWriteInternational3Data().initiation(createInitiation().endToEndIdentification("different value"));
+        final OBWriteInternational3 paymentRequest = new OBWriteInternational3().data(paymentData).risk(createRisk());
+
+        final OBWriteInternational3ValidationContext validatorContext = new OBWriteInternational3ValidationContext(paymentRequest, consent, AUTHORISED_STATUS);
+
+        validateErrorResult(validator.validate(validatorContext),
+                List.of(new OBError1().errorCode("OBRI.Payment.Invalid")
+                        .message("Payment invalid. Payment initiation received doesn't match the initial payment request: 'The Initiation field in the request does not match with the consent'")));
+    }
+
+    @Test
+    public void validationFailsWhenRiskDoesNotMatchConsent() {
+        final OBWriteInternationalConsent5Data consentData = new OBWriteInternationalConsent5Data().initiation(createInitiation());
+        final OBWriteInternationalConsent5 consent = new OBWriteInternationalConsent5().data(consentData).risk(createRisk());
+
+        final OBWriteInternational3Data paymentData = new OBWriteInternational3Data().initiation(createInitiation());
+        final OBWriteInternational3 paymentRequest = new OBWriteInternational3().data(paymentData).risk(createRisk().contractPresentInidicator(Boolean.TRUE));
+
+        final OBWriteInternational3ValidationContext validatorContext = new OBWriteInternational3ValidationContext(paymentRequest, consent, AUTHORISED_STATUS);
+
+        validateErrorResult(validator.validate(validatorContext),
+                List.of(new OBError1().errorCode("OBRI.Payment.Invalid")
+                        .message("Payment invalid. Payment risk received doesn't match the risk payment request: 'The Risk field in the request does not match with the consent'")));
+    }
+
+    @Test
+    public void validationFailsWhenConsentIsNotAuthorised() {
+        final StatusEnum[] invalidStatuses = new StatusEnum[] {
+                StatusEnum.CONSUMED, StatusEnum.REJECTED, StatusEnum.AWAITINGAUTHORISATION
+        };
+
+        for (StatusEnum invalidStatus : invalidStatuses) {
+            final OBWriteInternationalConsent5Data consentData = new OBWriteInternationalConsent5Data().initiation(createInitiation());
+            final OBWriteInternationalConsent5 consent = new OBWriteInternationalConsent5().data(consentData).risk(createRisk());
+
+            final OBWriteInternational3Data paymentData = new OBWriteInternational3Data().initiation(createInitiation());
+            final OBWriteInternational3 paymentRequest = new OBWriteInternational3().data(paymentData).risk(createRisk());
+
+            final OBWriteInternational3ValidationContext validatorContext = new OBWriteInternational3ValidationContext(paymentRequest, consent, invalidStatus.toString());
+            validateErrorResult(validator.validate(validatorContext), List.of(new OBError1().errorCode("UK.OBIE.Resource.InvalidConsentStatus")
+                    .message("Action can only be performed on consents with status: Authorised. Currently, the consent is: " + invalidStatus)));
+        }
+    }
+
+    private static OBRisk1 createRisk() {
+        return new OBRisk1().paymentContextCode(OBExternalPaymentContext1Code.BILLPAYMENT);
+    }
+
+    private static OBWriteInternational3DataInitiation createInitiation() {
+        return new OBWriteInternational3DataInitiation().localInstrument("INST1")
+                .instructedAmount(new OBWriteDomestic2DataInitiationInstructedAmount()
+                        .amount("123.45")
+                        .currency("GBP"));
+    }
+
+}

--- a/secure-api-gateway-ob-uk-rs-validation/secure-api-gateway-ob-uk-rs-validation-obie/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/validation/obie/payment/consent/OBWriteDomesticStandingOrderConsent5ValidatorTest.java
+++ b/secure-api-gateway-ob-uk-rs-validation/secure-api-gateway-ob-uk-rs-validation-obie/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/validation/obie/payment/consent/OBWriteDomesticStandingOrderConsent5ValidatorTest.java
@@ -19,11 +19,11 @@ import static com.forgerock.sapi.gateway.ob.uk.rs.validation.ValidationResultTes
 import static com.forgerock.sapi.gateway.ob.uk.rs.validation.ValidationResultTest.validateSuccessResult;
 
 import java.util.List;
-import java.util.Set;
 
 import org.junit.jupiter.api.Test;
 
 import com.forgerock.sapi.gateway.ob.uk.common.error.OBRIErrorType;
+import com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.payment.CurrencyCodeValidatorTest;
 
 import uk.org.openbanking.datamodel.common.OBRisk1;
 import uk.org.openbanking.datamodel.payment.OBWriteDomesticStandingOrder3DataInitiation;
@@ -35,7 +35,7 @@ import uk.org.openbanking.datamodel.payment.OBWriteDomesticStandingOrderConsent5
 
 class OBWriteDomesticStandingOrderConsent5ValidatorTest {
 
-    private final OBWriteDomesticStandingOrderConsent5Validator validator = new OBWriteDomesticStandingOrderConsent5Validator(Set.of("GBP", "EUR"));
+    private final OBWriteDomesticStandingOrderConsent5Validator validator = new OBWriteDomesticStandingOrderConsent5Validator(CurrencyCodeValidatorTest.createCurrencyCodeValidator("GBP", "EUR"));
 
     private static OBWriteDomesticStandingOrderConsent5 createValidConsent() {
         return new OBWriteDomesticStandingOrderConsent5().data(new OBWriteDomesticStandingOrderConsent5Data().initiation(
@@ -59,7 +59,7 @@ class OBWriteDomesticStandingOrderConsent5ValidatorTest {
         invalidConsent.getData().getInitiation().getFirstPaymentAmount().amount("0.0").currency("ZZZ");
         validateErrorResult(validator.validate(invalidConsent), List.of(
                 OBRIErrorType.DATA_INVALID_REQUEST.toOBError1("Field: firstPaymentAmount - the amount 0.0 provided must be greater than 0"),
-                OBRIErrorType.DATA_INVALID_REQUEST.toOBError1("Field: firstPaymentAmount - the currency ZZZ provided is not supported")));
+                OBRIErrorType.DATA_INVALID_REQUEST.toOBError1("The currency ZZZ provided is not supported")));
     }
 
     @Test
@@ -68,7 +68,7 @@ class OBWriteDomesticStandingOrderConsent5ValidatorTest {
         invalidConsent.getData().getInitiation().getRecurringPaymentAmount().amount("0.0").currency("ZZZ");
         validateErrorResult(validator.validate(invalidConsent), List.of(
                 OBRIErrorType.DATA_INVALID_REQUEST.toOBError1("Field: recurringPaymentAmount - the amount 0.0 provided must be greater than 0"),
-                OBRIErrorType.DATA_INVALID_REQUEST.toOBError1("Field: recurringPaymentAmount - the currency ZZZ provided is not supported")));
+                OBRIErrorType.DATA_INVALID_REQUEST.toOBError1("The currency ZZZ provided is not supported")));
     }
 
     @Test
@@ -77,7 +77,7 @@ class OBWriteDomesticStandingOrderConsent5ValidatorTest {
         invalidConsent.getData().getInitiation().getFinalPaymentAmount().amount("0.0").currency("ZZZ");
         validateErrorResult(validator.validate(invalidConsent), List.of(
                 OBRIErrorType.DATA_INVALID_REQUEST.toOBError1("Field: finalPaymentAmount - the amount 0.0 provided must be greater than 0"),
-                OBRIErrorType.DATA_INVALID_REQUEST.toOBError1("Field: finalPaymentAmount - the currency ZZZ provided is not supported")));
+                OBRIErrorType.DATA_INVALID_REQUEST.toOBError1("The currency ZZZ provided is not supported")));
     }
 
 }

--- a/secure-api-gateway-ob-uk-rs-validation/secure-api-gateway-ob-uk-rs-validation-obie/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/validation/obie/payment/consent/OBWriteInternationalConsent5ValidatorTest.java
+++ b/secure-api-gateway-ob-uk-rs-validation/secure-api-gateway-ob-uk-rs-validation-obie/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/validation/obie/payment/consent/OBWriteInternationalConsent5ValidatorTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.payment.consent;
+
+import static com.forgerock.sapi.gateway.ob.uk.rs.validation.ValidationResultTest.validateErrorResult;
+import static com.forgerock.sapi.gateway.ob.uk.rs.validation.ValidationResultTest.validateSuccessResult;
+import static com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.payment.CurrencyCodeValidatorTest.createCurrencyCodeValidator;
+import static com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.payment.OBWriteDomestic2DataInitiationInstructedAmountValidatorTest.createInstructedAmountValidator;
+import static com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.payment.OBWriteInternational3DataInitiationExchangeRateInformationValidatorTest.createExchangeRateInfoValidator;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import com.forgerock.sapi.gateway.ob.uk.common.error.OBRIErrorType;
+
+import uk.org.openbanking.datamodel.payment.OBExchangeRateType2Code;
+import uk.org.openbanking.datamodel.payment.OBWriteInternationalConsent5;
+import uk.org.openbanking.testsupport.payment.OBWriteInternationalConsentTestDataFactory;
+
+class OBWriteInternationalConsent5ValidatorTest {
+
+    private final String[] currencies = new String[]{"GBP", "USD", "EUR"};
+    private final OBWriteInternationalConsent5Validator validator = new OBWriteInternationalConsent5Validator(
+            createInstructedAmountValidator(currencies), createCurrencyCodeValidator(currencies), createExchangeRateInfoValidator(currencies));
+
+    @Test
+    void validationRulesPass() {
+        validateSuccessResult(validator.validate(OBWriteInternationalConsentTestDataFactory.aValidOBWriteInternationalConsent5()));
+        validateSuccessResult(validator.validate(OBWriteInternationalConsentTestDataFactory.aValidOBWriteInternationalConsent5MandatoryFields()));
+    }
+
+    @Test
+    void failsWhenCurrencyOfTransferInvalid() {
+        final OBWriteInternationalConsent5 consent = OBWriteInternationalConsentTestDataFactory.aValidOBWriteInternationalConsent5();
+        consent.getData().getInitiation().setCurrencyOfTransfer("ZZZ");
+
+        validateErrorResult(validator.validate(consent), List.of(OBRIErrorType.DATA_INVALID_REQUEST.toOBError1(
+                "The currency ZZZ provided is not supported")));
+    }
+
+    @Test
+    void failsWhenInstructedAmountInvalid() {
+        final OBWriteInternationalConsent5 consent = OBWriteInternationalConsentTestDataFactory.aValidOBWriteInternationalConsent5();
+        consent.getData().getInitiation().getInstructedAmount().amount("0.00");
+
+        validateErrorResult(validator.validate(consent), List.of(OBRIErrorType.DATA_INVALID_REQUEST.toOBError1(
+                "The amount 0.00 provided must be greater than 0")));
+    }
+
+    @Test
+    void failsWhenExchangeRateInformationInvalid() {
+        final OBWriteInternationalConsent5 consent = OBWriteInternationalConsentTestDataFactory.aValidOBWriteInternationalConsent5();
+        consent.getData().getInitiation().getExchangeRateInformation().rateType(OBExchangeRateType2Code.INDICATIVE).exchangeRate(new BigDecimal("1.2"));
+
+        validateErrorResult(validator.validate(consent), List.of(OBRIErrorType.DATA_INVALID_REQUEST.toOBError1(
+                "A PISP must not specify ExchangeRate and/or ContractIdentification when requesting an Indicative RateType.")));
+    }
+
+}


### PR DESCRIPTION
Implementing International Payment Consent API in RS.

Adding validators for Payment Consents.

Adding ExchangeRateService to calculate the exchange rate details used for a particular payment. Spring config can be used to adjust the test exchange rates used.

https://github.com/SecureApiGateway/SecureApiGateway/issues/1062