### PR TITLE
1076: Fixing issue building docker image using old jars

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -43,7 +43,7 @@ jobs:
 
       - name: test
         run: |
-          make verify
+          make install
 
       - name: Deploy artifact package
         run: mvn -B deploy -DskipTests -DskipITs -DdockerCompose.skip -Ddockerfile.skip

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -60,7 +60,7 @@ jobs:
 
       - name: test
         run: |
-          make verify
+          make install
 
       - run: |
           gcloud auth configure-docker

--- a/Makefile
+++ b/Makefile
@@ -9,11 +9,11 @@ all: clean test package
 clean:
 	mvn clean
 
-verify: clean
-	mvn -U verify
+install: clean
+	mvn -U install
 
 docker: clean
-	mvn install dockerfile:build dockerfile:push -DskipTests -DskipITs -Dtag=${tag} \
+	mvn dockerfile:build dockerfile:push -DskipTests -DskipITs -Dtag=${tag} \
 	  -DgcrRepo=${repo} --file secure-api-gateway-ob-uk-rs-server/pom.xml
 
 package_helm:


### PR DESCRIPTION
Fixing how the docker image gets build by ensuring that maven install command has been run beforehand.

Previously this was done when the artifacts were being deployed, but we have now removed this step for stability.

https://github.com/SecureApiGateway/SecureApiGateway/issues/1076