### PR TITLE
601: added funds confirmation as new API reference

### DIFF
--- a/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/common/OBApiReference.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/common/OBApiReference.java
@@ -70,8 +70,13 @@ public enum OBApiReference {
     /**
      * Funds Api
      **/
+    /**
+     * Funds Api
+     **/
+    CREATE_FUNDS_CONFIRMATION_CONSENT(CBPII,"CreateFundsConfirmationConsent", POST, "/cbpii/funds-confirmation-consents"),
+    GET_FUNDS_CONFIRMATION_CONSENT(CBPII,"GetFundsConfirmationConsent", GET, "/cbpii/funds-confirmation-consents/{ConsentId}"),
+    DELETE_FUNDS_CONFIRMATION_CONSENT(CBPII, "DeleteFundsConfirmationConsent", DELETE, "/cbpii/funds-confirmation-consents/{ConsentId}"),
     CREATE_FUNDS_CONFIRMATION(CBPII, "CreateFundsConfirmation", POST, "/cbpii/funds-confirmations"),
-    GET_FUNDS_CONFIRMATION(CBPII, "GetFundsConfirmation", GET, "/cbpii/funds-confirmations/{FundsConfirmationId}"),
 
     /**
      * Callback Api

--- a/secure-api-gateway-ob-uk-rs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/server/testsupport/discovery/AvailableApisTestDataFactory.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/server/testsupport/discovery/AvailableApisTestDataFactory.java
@@ -69,8 +69,7 @@ public class AvailableApisTestDataFactory {
 
     public static List<AvailableApiEndpoint> generateFundApis() {
         List<Pair<OBApiReference, String>> content = ImmutableList.of(
-                Pair.of(OBApiReference.CREATE_FUNDS_CONFIRMATION, "/cbpii/funds-confirmations"),
-                Pair.of(OBApiReference.GET_FUNDS_CONFIRMATION, "/cbpii/funds-confirmations/{FundsConfirmationId}")
+                Pair.of(OBApiReference.CREATE_FUNDS_CONFIRMATION, "/cbpii/funds-confirmations")
         );
         return generateApi(OBGroupName.CBPII, content);
     }

--- a/secure-api-gateway-ob-uk-rs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/server/testsupport/discovery/AvailableApisTestDataFactory.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/server/testsupport/discovery/AvailableApisTestDataFactory.java
@@ -69,6 +69,9 @@ public class AvailableApisTestDataFactory {
 
     public static List<AvailableApiEndpoint> generateFundApis() {
         List<Pair<OBApiReference, String>> content = ImmutableList.of(
+                Pair.of(OBApiReference.CREATE_FUNDS_CONFIRMATION_CONSENT, "/cbpii/funds-confirmation-consent"),
+                Pair.of(OBApiReference.GET_FUNDS_CONFIRMATION_CONSENT, "/cbpii/funds-confirmation-consent/{ConsentId}"),
+                Pair.of(OBApiReference.DELETE_FUNDS_CONFIRMATION_CONSENT, "/cbpii/funds-confirmation-consent/{ConsentId}"),
                 Pair.of(OBApiReference.CREATE_FUNDS_CONFIRMATION, "/cbpii/funds-confirmations")
         );
         return generateApi(OBGroupName.CBPII, content);


### PR DESCRIPTION
- Added funds confirmation consent in the API reference to be published in the discovery endpoint
- Delete Get funds confirmation by confirmationId, this api is not in the spec
- Added funds confirmation API entries to api test data factory

Issue: https://github.com/SecureApiGateway/SecureApiGateway/issues/601