### PR TITLE
1089: Fixing concurrency issues and memory leak in the Discovery API

### DIFF
--- a/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/discovery/AvailableApiEndpoint.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/discovery/AvailableApiEndpoint.java
@@ -38,6 +38,13 @@ public class AvailableApiEndpoint {
     private OBGroupName groupName;
     private String version;
     private OBApiReference apiReference;
-    private String url;
+
+    /**
+     * The path portion of the URI that can be used to access this endpoint e.g. /open-banking/v3.1.10/pisp/domestic-payments
+     *
+     * This needs to be combined with the baseUri used to access this component, this can be done using Spring HATEOAS
+     */
+    private String uriPath;
+
     private ControllerMethod controllerMethod;
 }

--- a/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/discovery/ControllerEndpointBlacklistHandler.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/discovery/ControllerEndpointBlacklistHandler.java
@@ -16,7 +16,6 @@
 package com.forgerock.sapi.gateway.ob.uk.rs.server.api.discovery;
 
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.stereotype.Component;
 
 import java.lang.reflect.Method;
 import java.util.HashSet;
@@ -28,7 +27,6 @@ import java.util.Set;
  * needing to use regex matches (which may match the same URL, but the wrong HTTP method).
  */
 @Slf4j
-@Component
 public class ControllerEndpointBlacklistHandler {
     /**
      * Set of all controller methods that are not provided by the Discovery endpoint.

--- a/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/configuration/ApplicationStartupListener.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/configuration/ApplicationStartupListener.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.ob.uk.rs.server.configuration;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.ApplicationListener;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.stereotype.Component;
+
+import com.forgerock.sapi.gateway.ob.uk.rs.server.api.discovery.DiscoveryApiService;
+import com.forgerock.sapi.gateway.ob.uk.rs.server.web.DisabledEndpointInterceptor;
+
+/**
+ * Listener which processes {@link ApplicationReadyEvent} events. This event is fired just before the application is
+ * ready to start servicing requests.
+ *
+ * The listener is used to do late binding in order to resolve circular dependency issues in our Spring Beans
+ */
+@Component
+public class ApplicationStartupListener implements ApplicationListener<ApplicationReadyEvent> {
+
+    private final Logger logger = LoggerFactory.getLogger(getClass());
+
+    @Override
+    public void onApplicationEvent(final ApplicationReadyEvent event) {
+        final ConfigurableApplicationContext applicationContext = event.getApplicationContext();
+        configureDisableEndpointInterceptorServices(applicationContext);
+
+        logger.info("Application ready to receive requests");
+    }
+
+    /**
+     * See {@link DisabledEndpointInterceptor} documentation relating to the circular dependency for this component
+     */
+    private void configureDisableEndpointInterceptorServices(ConfigurableApplicationContext applicationContext) {
+        applicationContext.getBean(DisabledEndpointInterceptor.class).setDiscoveryApiService(applicationContext.getBean(DiscoveryApiService.class));
+    }
+}

--- a/secure-api-gateway-ob-uk-rs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/discovery/AvailableApiEndpointsResolverTest.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/discovery/AvailableApiEndpointsResolverTest.java
@@ -18,13 +18,9 @@ package com.forgerock.sapi.gateway.ob.uk.rs.server.api.discovery;
 import com.forgerock.sapi.gateway.ob.uk.rs.server.api.obie.payment.v3_1_5.domesticpayments.DomesticPaymentsApiController;
 import com.forgerock.sapi.gateway.ob.uk.rs.server.common.OBApiReference;
 import com.forgerock.sapi.gateway.uk.common.shared.api.meta.obie.OBGroupName;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.BDDMockito;
-import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.web.bind.annotation.RequestMethod;
-import org.springframework.web.context.request.RequestContextHolder;
-import org.springframework.web.context.request.ServletRequestAttributes;
 import org.springframework.web.method.HandlerMethod;
 import org.springframework.web.servlet.mvc.method.RequestMappingInfo;
 import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping;
@@ -43,16 +39,9 @@ import static org.mockito.Mockito.mock;
  */
 public class AvailableApiEndpointsResolverTest {
 
-    private static final String BASE_URL = "http://localhost";
     private static final String VERSION = "v3.1.5";
     private static final String CREATE_PAYMENT_URI = "/open-banking/" + VERSION + "/pisp/domestic-payments";
     private static final String GET_PAYMENT_URI = "/open-banking/" + VERSION + "/pisp/domestic-payments/{DomesticPaymentId}";
-
-    @BeforeEach
-    void setup() {
-        MockHttpServletRequest mockRequest = new MockHttpServletRequest();
-        RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(mockRequest));
-    }
 
     @Test
     public void shouldGetAvailableApiEndpoints() {
@@ -68,13 +57,13 @@ public class AvailableApiEndpointsResolverTest {
         AvailableApiEndpoint getPaymentEndpoint = getEndpoint(availableApiEndpoints, OBApiReference.GET_DOMESTIC_PAYMENT);
         assertThat(getPaymentEndpoint.getVersion()).isEqualTo(VERSION);
         assertThat(getPaymentEndpoint.getGroupName()).isEqualTo(OBGroupName.PISP);
-        assertThat(getPaymentEndpoint.getUrl()).isEqualTo(BASE_URL + GET_PAYMENT_URI);
+        assertThat(getPaymentEndpoint.getUriPath()).isEqualTo( GET_PAYMENT_URI);
         assertThat(getPaymentEndpoint.getControllerMethod()).isNotNull();
 
         AvailableApiEndpoint createPaymentEndpoint = getEndpoint(availableApiEndpoints, OBApiReference.CREATE_DOMESTIC_PAYMENT);
         assertThat(createPaymentEndpoint.getVersion()).isEqualTo(VERSION);
         assertThat(createPaymentEndpoint.getGroupName()).isEqualTo(OBGroupName.PISP);
-        assertThat(createPaymentEndpoint.getUrl()).isEqualTo(BASE_URL + CREATE_PAYMENT_URI);
+        assertThat(createPaymentEndpoint.getUriPath()).isEqualTo(CREATE_PAYMENT_URI);
         assertThat(createPaymentEndpoint.getControllerMethod()).isNotNull();
     }
 

--- a/secure-api-gateway-ob-uk-rs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/discovery/AvailableApiEndpointsResolverVersionMatcherTest.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/discovery/AvailableApiEndpointsResolverVersionMatcherTest.java
@@ -33,7 +33,7 @@ public class AvailableApiEndpointsResolverVersionMatcherTest {
         final String urlTemplate = "/open-banking/%s/pisp/domestic-payments";
         for (OBVersion version : OBVersion.values()) {
             final String url = String.format(urlTemplate, version.getCanonicalName());
-            assertTrue(resolver.matchUrlPattern(url).matches(), "url must be accepted: " + url);
+            assertTrue(resolver.matchUrlPattern(url).matches(), "uriPath must be accepted: " + url);
         }
     }
 }

--- a/secure-api-gateway-ob-uk-rs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/server/testsupport/discovery/AvailableApisTestDataFactory.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/server/testsupport/discovery/AvailableApisTestDataFactory.java
@@ -30,7 +30,7 @@ import java.util.List;
  */
 public class AvailableApisTestDataFactory {
 
-    public static final String BASE_URL = "http://rs/open-banking/";
+    public static final String BASE_URL = "/rs/open-banking/";
     public static final String VERSION_PREFIX = "v3.1.";
     public static final int PATCHES = 6;
 
@@ -86,7 +86,7 @@ public class AvailableApisTestDataFactory {
                         .groupName(groupName)
                         .version(VERSION_PREFIX + patch)
                         .apiReference(refAndPath.getKey())
-                        .url(url)
+                        .uriPath(url)
                         .build();
                 apiVersions.add(apiEndpoint);
             }


### PR DESCRIPTION
Initialising the AvailableApiEndpoint collection and blacklisted API collection at startup, as this data does not change. This fixes the memory leak and ConcurrentModificationExceptions by only building these collections once.

Changed AvailableApiEndpoint object to store a uriPath rather than a full uri that can be used externally, which removes any dynamic data from this object enabling us to do the processing once. A fully qualified externally callable uri is then built in the DiscoveryController using the request context data i.e. X-Forwarded-Host + X-Forwarded-Path.

In order to initialise the blacklist at startup, bean dependencies needed to be adjusted which resulted in a cyclic dependency on the Spring WebMvc. This issue has been resolved by doing late binding of the DiscoveryApiService in the DisabledEndpointInterceptor by using the new ApplicationStartupListener component.

https://github.com/SecureApiGateway/SecureApiGateway/issues/1089