### PR TITLE
1090: Using custom data converter to decode Mongo Date objects as UTC

### DIFF
--- a/secure-api-gateway-ob-uk-rs-resource-store/secure-api-gateway-ob-uk-rs-resource-store-repo/src/main/java/com/forgerock/sapi/gateway/rs/resource/store/repo/ResourceStoreRepoConfiguration.java
+++ b/secure-api-gateway-ob-uk-rs-resource-store/secure-api-gateway-ob-uk-rs-resource-store-repo/src/main/java/com/forgerock/sapi/gateway/rs/resource/store/repo/ResourceStoreRepoConfiguration.java
@@ -15,15 +15,41 @@
  */
 package com.forgerock.sapi.gateway.rs.resource.store.repo;
 
-import com.forgerock.sapi.gateway.rs.resource.store.repo.mongo.MongoRepoPackageMarker;
+import java.util.List;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.convert.converter.Converter;
 import org.springframework.data.mongodb.config.EnableMongoAuditing;
+import org.springframework.data.mongodb.core.convert.MongoCustomConversions;
 import org.springframework.data.mongodb.repository.config.EnableMongoRepositories;
+
+import com.forgerock.sapi.gateway.rs.resource.store.repo.mongo.MongoRepoPackageMarker;
+import com.forgerock.sapi.gateway.uk.common.shared.spring.converter.DateToUTCDateTimeConverter;
 
 @Configuration
 @ComponentScan(basePackageClasses = ResourceStoreRepoConfiguration.class)
 @EnableMongoRepositories(basePackageClasses = MongoRepoPackageMarker.class)
 @EnableMongoAuditing
 public class ResourceStoreRepoConfiguration {
+
+    private final Logger logger = LoggerFactory.getLogger(getClass());
+
+    /**
+     * Create MongoCustomConversions instance with our custom data type converters.
+     * <p>
+     * {@link DateToUTCDateTimeConverter} is installed to convert Date objects in Mongo documents to joda DateTime
+     * objects specifying UTC timezone.
+     * Without this converter, the joda default converter will use the system's timezone instead which leads to issues
+     * when calling equals() on OB data-model objects due to TZ mismatch with data received via the REST API (which is always UTC).
+     */
+    @Bean
+    public MongoCustomConversions mongoCustomConversions() {
+        final List<Converter> customConverters = List.of(new DateToUTCDateTimeConverter());
+        logger.info("Installing custom converters for Mongo: {}", customConverters);
+        return new MongoCustomConversions(customConverters);
+    }
 }

--- a/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/RSServerApplication.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/RSServerApplication.java
@@ -15,21 +15,22 @@
  */
 package com.forgerock.sapi.gateway.ob.uk.rs.server;
 
-import com.forgerock.sapi.gateway.rs.resource.store.api.ResourceStoreApiModuleConfiguration;
-import com.forgerock.sapi.gateway.rs.resource.store.repo.mongo.MongoRepoPackageMarker;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Import;
-import org.springframework.data.mongodb.config.EnableMongoAuditing;
-import org.springframework.data.mongodb.repository.config.EnableMongoRepositories;
 
 import com.forgerock.sapi.gateway.ob.uk.rs.cloud.client.CloudClientModuleConfiguration;
 import com.forgerock.sapi.gateway.rcs.consent.store.client.ConsentStoreClientConfiguration;
+import com.forgerock.sapi.gateway.rs.resource.store.api.ResourceStoreApiModuleConfiguration;
+import com.forgerock.sapi.gateway.rs.resource.store.repo.ResourceStoreRepoConfiguration;
 
 @SpringBootApplication
-@Import({CloudClientModuleConfiguration.class, ConsentStoreClientConfiguration.class, ResourceStoreApiModuleConfiguration.class})
-@EnableMongoRepositories(basePackageClasses = MongoRepoPackageMarker.class)
-@EnableMongoAuditing
+@Import({
+        CloudClientModuleConfiguration.class,
+        ConsentStoreClientConfiguration.class,
+        ResourceStoreApiModuleConfiguration.class,
+        ResourceStoreRepoConfiguration.class
+})
 public class RSServerApplication {
 
     public static void main(String[] args) {


### PR DESCRIPTION
Creating MongoCustomConversions bean that has the DateToUTCDateTimeConverter converter installed.

Fixing RSServerApplication to delegate Mongo related configuration to ResourceStoreRepoConfiguration.

https://github.com/SecureApiGateway/SecureApiGateway/issues/1090