### PR TITLE
1086: Porting OBRisk1Validator to use the validation framework

### DIFF
--- a/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/v3_1_5/internationalpayments/InternationalPaymentsApiController.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/v3_1_5/internationalpayments/InternationalPaymentsApiController.java
@@ -117,7 +117,7 @@ public class InternationalPaymentsApiController implements InternationalPayments
     ) throws OBErrorResponseException, OBErrorException {
         log.debug("Received payment submission: '{}'", obWriteInternational3);
 
-        paymentSubmissionValidator.validateIdempotencyKeyAndRisk(xIdempotencyKey, obWriteInternational3.getRisk());
+        paymentSubmissionValidator.validateIdempotencyKey(xIdempotencyKey);
 
         String consentId = obWriteInternational3.getData().getConsentId();
 

--- a/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/v3_1_5/internationalscheduledpayments/InternationalScheduledPaymentsApiController.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/v3_1_5/internationalscheduledpayments/InternationalScheduledPaymentsApiController.java
@@ -124,7 +124,7 @@ public class InternationalScheduledPaymentsApiController implements Internationa
     ) throws OBErrorResponseException, OBErrorException {
         log.debug("Received payment submission: '{}'", obWriteInternationalScheduled3);
 
-        paymentSubmissionValidator.validateIdempotencyKeyAndRisk(xIdempotencyKey, obWriteInternationalScheduled3.getRisk());
+        paymentSubmissionValidator.validateIdempotencyKey(xIdempotencyKey);
 
         String consentId = obWriteInternationalScheduled3.getData().getConsentId();
         //get the consent

--- a/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/v3_1_5/internationalstandingorders/InternationalStandingOrdersApiController.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/v3_1_5/internationalstandingorders/InternationalStandingOrdersApiController.java
@@ -123,7 +123,7 @@ public class InternationalStandingOrdersApiController implements InternationalSt
     ) throws OBErrorResponseException, OBErrorException {
         log.debug("Received payment submission: '{}'", obWriteInternationalStandingOrder4);
 
-        paymentSubmissionValidator.validateIdempotencyKeyAndRisk(xIdempotencyKey, obWriteInternationalStandingOrder4.getRisk());
+        paymentSubmissionValidator.validateIdempotencyKey(xIdempotencyKey);
 
         String consentId = obWriteInternationalStandingOrder4.getData().getConsentId();
         log.debug("Attempting to get consent: {}, clientId: {}", consentId, apiClientId);

--- a/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/v3_1_9/vrp/DomesticVrpsApiController.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/v3_1_9/vrp/DomesticVrpsApiController.java
@@ -181,7 +181,7 @@ public class DomesticVrpsApiController implements DomesticVrpsApi {
     ) throws OBErrorResponseException, OBErrorException {
         log.debug("Received VRP payment submission: '{}'", obDomesticVRPRequest);
 
-        paymentSubmissionValidator.validateIdempotencyKeyAndRisk(xIdempotencyKey, obDomesticVRPRequest.getRisk());
+        paymentSubmissionValidator.validateIdempotencyKey(xIdempotencyKey);
 
         String consentId = obDomesticVRPRequest.getData().getConsentId();
         final DomesticVRPConsent consent = consentStoreClient.getConsent(consentId, apiClientId);

--- a/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/configuration/validation/DefaultOBValidationModule.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/configuration/validation/DefaultOBValidationModule.java
@@ -18,6 +18,7 @@ package com.forgerock.sapi.gateway.ob.uk.rs.server.configuration.validation;
 import java.util.Arrays;
 import java.util.stream.Collectors;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -30,6 +31,7 @@ import com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.OBValidationService;
 import com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.payment.CurrencyCodeValidator;
 import com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.payment.OBDomesticVRPRequestValidator;
 import com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.payment.OBDomesticVRPRequestValidator.OBDomesticVRPRequestValidationContext;
+import com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.payment.OBRisk1Validator;
 import com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.payment.OBWriteDomestic2DataInitiationInstructedAmountValidator;
 import com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.payment.OBWriteDomestic2Validator;
 import com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.payment.OBWriteDomestic2Validator.OBWriteDomestic2ValidationContext;
@@ -55,6 +57,7 @@ import com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.payment.consent.OBWri
 import com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.payment.consent.OBWriteInternationalScheduledConsent5Validator;
 import com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.payment.consent.OBWriteInternationalStandingOrderConsent6Validator;
 
+import uk.org.openbanking.datamodel.common.OBRisk1;
 import uk.org.openbanking.datamodel.payment.OBWriteDomestic2DataInitiationInstructedAmount;
 import uk.org.openbanking.datamodel.payment.OBWriteDomesticConsent4;
 import uk.org.openbanking.datamodel.payment.OBWriteDomesticScheduledConsent4;
@@ -89,8 +92,8 @@ public class DefaultOBValidationModule {
     }
 
     @Bean
-    public OBValidationService<OBWriteDomesticConsent4> domesticPaymentConsentValidator() {
-        return new OBValidationService<>(new OBWriteDomesticConsent4Validator(instructedAmountValidator()));
+    public OBValidationService<OBWriteDomesticConsent4> domesticPaymentConsentValidator(BaseOBValidator<OBRisk1> riskValidator) {
+        return new OBValidationService<>(new OBWriteDomesticConsent4Validator(instructedAmountValidator(), riskValidator));
     }
 
     @Bean
@@ -99,8 +102,8 @@ public class DefaultOBValidationModule {
     }
 
     @Bean
-    public OBValidationService<OBWriteDomesticScheduledConsent4> domesticScheduledPaymentConsentValidator() {
-        return new OBValidationService<>(new OBWriteDomesticScheduledConsent4Validator(instructedAmountValidator()));
+    public OBValidationService<OBWriteDomesticScheduledConsent4> domesticScheduledPaymentConsentValidator(BaseOBValidator<OBRisk1> riskValidator) {
+        return new OBValidationService<>(new OBWriteDomesticScheduledConsent4Validator(instructedAmountValidator(), riskValidator));
     }
 
     @Bean
@@ -109,8 +112,8 @@ public class DefaultOBValidationModule {
     }
 
     @Bean
-    public OBValidationService<OBWriteDomesticStandingOrderConsent5> domesticStandingOrderConsentValidator() {
-        return new OBValidationService<>(new OBWriteDomesticStandingOrderConsent5Validator(currencyCodeValidator()));
+    public OBValidationService<OBWriteDomesticStandingOrderConsent5> domesticStandingOrderConsentValidator(BaseOBValidator<OBRisk1> riskValidator) {
+        return new OBValidationService<>(new OBWriteDomesticStandingOrderConsent5Validator(currencyCodeValidator(), riskValidator));
     }
 
     @Bean
@@ -119,8 +122,8 @@ public class DefaultOBValidationModule {
     }
 
     @Bean
-    public OBValidationService<OBDomesticVRPConsentRequest> domesticVRPConsentValidator() {
-        return new OBValidationService<>(new OBDomesticVRPConsentRequestValidator());
+    public OBValidationService<OBDomesticVRPConsentRequest> domesticVRPConsentValidator(BaseOBValidator<OBRisk1> riskValidator) {
+        return new OBValidationService<>(new OBDomesticVRPConsentRequestValidator(riskValidator));
     }
 
     @Bean
@@ -154,9 +157,9 @@ public class DefaultOBValidationModule {
     }
 
     @Bean
-    public OBValidationService<OBWriteInternationalConsent5> internationalPaymentConsentValidator() {
+    public OBValidationService<OBWriteInternationalConsent5> internationalPaymentConsentValidator(BaseOBValidator<OBRisk1> riskValidator) {
         return new OBValidationService<>(new OBWriteInternationalConsent5Validator(instructedAmountValidator(),
-                currencyCodeValidator(), exchangeRateInformationValidator()));
+                currencyCodeValidator(), exchangeRateInformationValidator(), riskValidator));
     }
 
     @Bean
@@ -165,9 +168,9 @@ public class DefaultOBValidationModule {
     }
 
     @Bean
-    public OBValidationService<OBWriteInternationalScheduledConsent5> internationalScheduledPaymentConsentValidator() {
+    public OBValidationService<OBWriteInternationalScheduledConsent5> internationalScheduledPaymentConsentValidator(BaseOBValidator<OBRisk1> riskValidator) {
         return new OBValidationService<>(new OBWriteInternationalScheduledConsent5Validator(instructedAmountValidator(),
-                currencyCodeValidator(), exchangeRateInformationValidator()));
+                currencyCodeValidator(), exchangeRateInformationValidator(), riskValidator));
     }
 
     @Bean
@@ -176,13 +179,21 @@ public class DefaultOBValidationModule {
     }
 
     @Bean
-    public OBValidationService<OBWriteInternationalStandingOrderConsent6> internationalStandingOrderConsentValidator() {
+    public OBValidationService<OBWriteInternationalStandingOrderConsent6> internationalStandingOrderConsentValidator(
+            BaseOBValidator<OBRisk1> riskValidator) {
+
         return new OBValidationService<>(new OBWriteInternationalStandingOrderConsent6Validator(instructedAmountValidator(),
-                                                                                                currencyCodeValidator()));
+                currencyCodeValidator(), riskValidator));
     }
 
     @Bean
     public OBValidationService<OBWriteInternationalStandingOrder4ValidationContext> internationalStandingOrderValidator() {
         return new OBValidationService<>(new OBWriteInternationalStandingOrder4Validator());
+    }
+
+    @Bean
+    public OBRisk1Validator paymentRiskValidator(@Value("${rs.obie.validation.config.payments.requirePaymentContextCode:false}")
+                                                 boolean requirePaymentContextCode) {
+        return new OBRisk1Validator(requirePaymentContextCode);
     }
 }

--- a/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/validator/OBRisk1Validator.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/validator/OBRisk1Validator.java
@@ -29,9 +29,11 @@ import uk.org.openbanking.datamodel.common.OBRisk1;
  * that the optional field {@code PaymentContextCode} within the {@code OBRisk1} class is provided.
  *
  * @see <a href="https://openbankinguk.github.io/read-write-api-site3/v3.1.5/profiles/payment-initiation-api-profile.html#obrisk1">OB specifications</a>
+ * @deprecated this validator has been ported to the rs-validation module, use {@link com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.payment.OBRisk1Validator}
  */
 @Component
 @Slf4j
+@Deprecated
 public class OBRisk1Validator {
 
     private boolean requirePaymentContextCode;

--- a/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/validator/PaymentSubmissionValidator.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/validator/PaymentSubmissionValidator.java
@@ -43,7 +43,11 @@ public class PaymentSubmissionValidator {
      * @param xIdempotencyKey The 'x-idempotency-key' header ensuring every request is processed only once per key.
      * @param obRisk1 Additional details for risk scoring a Payment.
      * @throws OBErrorResponseException if a validation error occurs.
+     * @deprecated obRisk1 should be validated as part of consent validation when the consent is submitted, this should
+     * be done by a validator in the rs-validation module.
+     * Example validator: {@link com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.payment.consent.OBWriteDomesticConsent4Validator}
      */
+    @Deprecated
     public void validateIdempotencyKeyAndRisk(String xIdempotencyKey, OBRisk1 obRisk1) throws OBErrorResponseException {
         try {
             idempotencyValidator.verifyIdempotencyKeyLength(xIdempotencyKey);

--- a/secure-api-gateway-ob-uk-rs-server/src/main/resources/application.yml
+++ b/secure-api-gateway-ob-uk-rs-server/src/main/resources/application.yml
@@ -68,7 +68,10 @@ rs:
     validation:
       # OBIE validation module to load, the "default" module is provided as standard with the simulator
       module: default
-
+      config:
+        payments:
+          # Controls whether the optional schema field in payment consents: consent.risk.paymentContextCode should be made mandatory
+          requirePaymentContextCode: false
   # Exchange rate values to use in FX quotes
   exchange:
     rates:

--- a/secure-api-gateway-ob-uk-rs-validation/secure-api-gateway-ob-uk-rs-validation-obie/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/validation/obie/payment/OBRisk1Validator.java
+++ b/secure-api-gateway-ob-uk-rs-validation/secure-api-gateway-ob-uk-rs-validation-obie/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/validation/obie/payment/OBRisk1Validator.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.payment;
+
+import com.forgerock.sapi.gateway.ob.uk.common.error.OBRIErrorType;
+import com.forgerock.sapi.gateway.ob.uk.rs.validation.ValidationResult;
+import com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.BaseOBValidator;
+
+import uk.org.openbanking.datamodel.common.OBRisk1;
+import uk.org.openbanking.datamodel.error.OBError1;
+
+/**
+ * Validator of {@link OBRisk1} objects, these objects are sent as part of Payment Consents and Requests.
+ */
+public class OBRisk1Validator extends BaseOBValidator<OBRisk1> {
+
+    private final boolean requirePaymentContextCode;
+
+    /**
+     * @param requirePaymentContextCode boolean flag - whether validation should require that risk's paymentContextCode field is set
+     */
+    public OBRisk1Validator(boolean requirePaymentContextCode) {
+        this.requirePaymentContextCode = requirePaymentContextCode;
+    }
+
+    @Override
+    protected void validate(OBRisk1 risk, ValidationResult<OBError1> validationResult) {
+        if (requirePaymentContextCode) {
+            if (risk.getPaymentContextCode() == null) {
+                validationResult.addError(OBRIErrorType.PAYMENT_CODE_CONTEXT_INVALID.toOBError1());
+            }
+        }
+    }
+}

--- a/secure-api-gateway-ob-uk-rs-validation/secure-api-gateway-ob-uk-rs-validation-obie/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/validation/obie/payment/consent/OBDomesticVRPConsentRequestValidator.java
+++ b/secure-api-gateway-ob-uk-rs-validation/secure-api-gateway-ob-uk-rs-validation-obie/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/validation/obie/payment/consent/OBDomesticVRPConsentRequestValidator.java
@@ -16,21 +16,31 @@
 package com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.payment.consent;
 
 import java.util.List;
+import java.util.Objects;
 
 import com.forgerock.sapi.gateway.ob.uk.common.error.OBRIErrorType;
 import com.forgerock.sapi.gateway.ob.uk.rs.validation.ValidationResult;
 import com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.BaseOBValidator;
 
+import uk.org.openbanking.datamodel.common.OBRisk1;
 import uk.org.openbanking.datamodel.error.OBError1;
 import uk.org.openbanking.datamodel.vrp.OBDomesticVRPConsentRequest;
 import uk.org.openbanking.datamodel.vrp.OBDomesticVRPControlParameters;
 
 public class OBDomesticVRPConsentRequestValidator extends BaseOBValidator<OBDomesticVRPConsentRequest> {
 
-    public static final String SWEEPING_VRP_TYPE = "UK.OBIE.VRPType.Sweeping";
+    private static final String SWEEPING_VRP_TYPE = "UK.OBIE.VRPType.Sweeping";
+
+    private final BaseOBValidator<OBRisk1> riskValidator;
+
+    public OBDomesticVRPConsentRequestValidator(BaseOBValidator<OBRisk1> riskValidator) {
+        this.riskValidator = Objects.requireNonNull(riskValidator, "riskValidator must be supplied");
+    }
 
     @Override
     protected void validate(OBDomesticVRPConsentRequest obj, ValidationResult<OBError1> validationResult) {
+        validationResult.mergeResults(riskValidator.validate(obj.getRisk()));
+
         final OBDomesticVRPControlParameters controlParameters = obj.getData().getControlParameters();
         validateVrpType(controlParameters.getVrPType(), validationResult);
     }

--- a/secure-api-gateway-ob-uk-rs-validation/secure-api-gateway-ob-uk-rs-validation-obie/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/validation/obie/payment/consent/OBWriteDomesticConsent4Validator.java
+++ b/secure-api-gateway-ob-uk-rs-validation/secure-api-gateway-ob-uk-rs-validation-obie/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/validation/obie/payment/consent/OBWriteDomesticConsent4Validator.java
@@ -20,6 +20,7 @@ import java.util.Objects;
 import com.forgerock.sapi.gateway.ob.uk.rs.validation.ValidationResult;
 import com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.BaseOBValidator;
 
+import uk.org.openbanking.datamodel.common.OBRisk1;
 import uk.org.openbanking.datamodel.error.OBError1;
 import uk.org.openbanking.datamodel.payment.OBWriteDomestic2DataInitiationInstructedAmount;
 import uk.org.openbanking.datamodel.payment.OBWriteDomesticConsent4;
@@ -30,13 +31,17 @@ import uk.org.openbanking.datamodel.payment.OBWriteDomesticConsent4;
 public class OBWriteDomesticConsent4Validator extends BaseOBValidator<OBWriteDomesticConsent4> {
 
     private final BaseOBValidator<OBWriteDomestic2DataInitiationInstructedAmount> instructedAmountValidator;
+    private final BaseOBValidator<OBRisk1> riskValidator;
 
-    public OBWriteDomesticConsent4Validator(BaseOBValidator<OBWriteDomestic2DataInitiationInstructedAmount> instructedAmountValidator) {
+    public OBWriteDomesticConsent4Validator(BaseOBValidator<OBWriteDomestic2DataInitiationInstructedAmount> instructedAmountValidator,
+                                            BaseOBValidator<OBRisk1> riskValidator) {
         this.instructedAmountValidator = Objects.requireNonNull(instructedAmountValidator, "instructedAmountValidator must be supplied");
+        this.riskValidator = Objects.requireNonNull(riskValidator, "riskValidator must be supplied");
     }
 
     @Override
     protected void validate(OBWriteDomesticConsent4 domesticPaymentConsent, ValidationResult<OBError1> validationResult) {
         validationResult.mergeResults(instructedAmountValidator.validate(domesticPaymentConsent.getData().getInitiation().getInstructedAmount()));
+        validationResult.mergeResults(riskValidator.validate(domesticPaymentConsent.getRisk()));
     }
 }

--- a/secure-api-gateway-ob-uk-rs-validation/secure-api-gateway-ob-uk-rs-validation-obie/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/validation/obie/payment/consent/OBWriteDomesticScheduledConsent4Validator.java
+++ b/secure-api-gateway-ob-uk-rs-validation/secure-api-gateway-ob-uk-rs-validation-obie/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/validation/obie/payment/consent/OBWriteDomesticScheduledConsent4Validator.java
@@ -21,9 +21,9 @@ import org.joda.time.DateTime;
 
 import com.forgerock.sapi.gateway.ob.uk.common.error.OBRIErrorType;
 import com.forgerock.sapi.gateway.ob.uk.rs.validation.ValidationResult;
-import com.forgerock.sapi.gateway.ob.uk.rs.validation.Validator;
 import com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.BaseOBValidator;
 
+import uk.org.openbanking.datamodel.common.OBRisk1;
 import uk.org.openbanking.datamodel.error.OBError1;
 import uk.org.openbanking.datamodel.payment.OBWriteDomestic2DataInitiationInstructedAmount;
 import uk.org.openbanking.datamodel.payment.OBWriteDomesticScheduledConsent4;
@@ -33,14 +33,18 @@ import uk.org.openbanking.datamodel.payment.OBWriteDomesticScheduledConsent4;
  */
 public class OBWriteDomesticScheduledConsent4Validator extends BaseOBValidator<OBWriteDomesticScheduledConsent4> {
 
-    private final Validator<OBWriteDomestic2DataInitiationInstructedAmount, OBError1> instructedAmountValidator;
+    private final BaseOBValidator<OBWriteDomestic2DataInitiationInstructedAmount> instructedAmountValidator;
+    private final BaseOBValidator<OBRisk1> riskValidator;
 
-    public OBWriteDomesticScheduledConsent4Validator(Validator<OBWriteDomestic2DataInitiationInstructedAmount, OBError1> instructedAmountValidator) {
+    public OBWriteDomesticScheduledConsent4Validator(BaseOBValidator<OBWriteDomestic2DataInitiationInstructedAmount> instructedAmountValidator,
+                                                     BaseOBValidator<OBRisk1> riskValidator) {
         this.instructedAmountValidator = Objects.requireNonNull(instructedAmountValidator, "instructedAmountValidator must be supplied");
+        this.riskValidator = Objects.requireNonNull(riskValidator, "riskValidator must be supplied");
     }
 
     @Override
     protected void validate(OBWriteDomesticScheduledConsent4 consent, ValidationResult<OBError1> validationResult) {
+        validationResult.mergeResults(riskValidator.validate(consent.getRisk()));
         validationResult.mergeResults(instructedAmountValidator.validate(consent.getData().getInitiation().getInstructedAmount()));
 
         final DateTime requestedExecutionDateTime = consent.getData().getInitiation().getRequestedExecutionDateTime();

--- a/secure-api-gateway-ob-uk-rs-validation/secure-api-gateway-ob-uk-rs-validation-obie/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/validation/obie/payment/consent/OBWriteDomesticStandingOrderConsent5Validator.java
+++ b/secure-api-gateway-ob-uk-rs-validation/secure-api-gateway-ob-uk-rs-validation-obie/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/validation/obie/payment/consent/OBWriteDomesticStandingOrderConsent5Validator.java
@@ -24,6 +24,7 @@ import com.forgerock.sapi.gateway.ob.uk.common.error.OBRIErrorType;
 import com.forgerock.sapi.gateway.ob.uk.rs.validation.ValidationResult;
 import com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.BaseOBValidator;
 
+import uk.org.openbanking.datamodel.common.OBRisk1;
 import uk.org.openbanking.datamodel.error.OBError1;
 import uk.org.openbanking.datamodel.payment.OBWriteDomesticStandingOrder3DataInitiation;
 import uk.org.openbanking.datamodel.payment.OBWriteDomesticStandingOrder3DataInitiationFinalPaymentAmount;
@@ -41,15 +42,19 @@ public class OBWriteDomesticStandingOrderConsent5Validator extends BaseOBValidat
     private static final String FINAL_PAYMENT_AMOUNT = "finalPaymentAmount";
 
     private final BaseOBValidator<String> currencyCodeValidator;
+    private final BaseOBValidator<OBRisk1> riskValidator;
 
-    public OBWriteDomesticStandingOrderConsent5Validator(BaseOBValidator<String> currencyCodeValidator) {
+    public OBWriteDomesticStandingOrderConsent5Validator(BaseOBValidator<String> currencyCodeValidator,
+                                                         BaseOBValidator<OBRisk1> riskValidator) {
         this.currencyCodeValidator = Objects.requireNonNull(currencyCodeValidator, "currencyCodeValidator must be supplied");
+        this.riskValidator = Objects.requireNonNull(riskValidator, "riskValidator must be supplied");
     }
 
     @Override
     protected void validate(OBWriteDomesticStandingOrderConsent5 consent, ValidationResult<OBError1> validationResult) {
-        final OBWriteDomesticStandingOrder3DataInitiation initiation = consent.getData().getInitiation();
+        validationResult.mergeResults(riskValidator.validate(consent.getRisk()));
 
+        final OBWriteDomesticStandingOrder3DataInitiation initiation = consent.getData().getInitiation();
         final OBWriteDomesticStandingOrder3DataInitiationFirstPaymentAmount firstPaymentAmount = initiation.getFirstPaymentAmount();
         validateAmount(firstPaymentAmount.getAmount(), firstPaymentAmount.getCurrency(), FIRST_PAYMENT_AMOUNT, validationResult);
 

--- a/secure-api-gateway-ob-uk-rs-validation/secure-api-gateway-ob-uk-rs-validation-obie/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/validation/obie/payment/consent/OBWriteInternationalConsent5Validator.java
+++ b/secure-api-gateway-ob-uk-rs-validation/secure-api-gateway-ob-uk-rs-validation-obie/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/validation/obie/payment/consent/OBWriteInternationalConsent5Validator.java
@@ -20,6 +20,7 @@ import java.util.Objects;
 import com.forgerock.sapi.gateway.ob.uk.rs.validation.ValidationResult;
 import com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.BaseOBValidator;
 
+import uk.org.openbanking.datamodel.common.OBRisk1;
 import uk.org.openbanking.datamodel.error.OBError1;
 import uk.org.openbanking.datamodel.payment.OBWriteDomestic2DataInitiationInstructedAmount;
 import uk.org.openbanking.datamodel.payment.OBWriteInternational3DataInitiation;
@@ -34,16 +35,22 @@ public class OBWriteInternationalConsent5Validator extends BaseOBValidator<OBWri
     private final BaseOBValidator<OBWriteDomestic2DataInitiationInstructedAmount> instructedAmountValidator;
     private final BaseOBValidator<String> currencyCodeValidator;
     private final BaseOBValidator<OBWriteInternational3DataInitiationExchangeRateInformation> exchangeRateInfoValidator;
+    private final BaseOBValidator<OBRisk1> riskValidator;
 
     public OBWriteInternationalConsent5Validator(BaseOBValidator<OBWriteDomestic2DataInitiationInstructedAmount> instructedAmountValidator,
-            BaseOBValidator<String> currencyCodeValidator, BaseOBValidator<OBWriteInternational3DataInitiationExchangeRateInformation> exchangeRateInfoValidator) {
+                                                 BaseOBValidator<String> currencyCodeValidator,
+                                                 BaseOBValidator<OBWriteInternational3DataInitiationExchangeRateInformation> exchangeRateInfoValidator,
+                                                 BaseOBValidator<OBRisk1> riskValidator) {
         this.instructedAmountValidator = Objects.requireNonNull(instructedAmountValidator);
         this.currencyCodeValidator     = Objects.requireNonNull(currencyCodeValidator);
         this.exchangeRateInfoValidator = Objects.requireNonNull(exchangeRateInfoValidator);
+        this.riskValidator             = Objects.requireNonNull(riskValidator);
     }
 
     @Override
     protected void validate(OBWriteInternationalConsent5 consent, ValidationResult<OBError1> validationResult) {
+        validationResult.mergeResults(riskValidator.validate(consent.getRisk()));
+
         final OBWriteInternational3DataInitiation initiation = consent.getData().getInitiation();
         validationResult.mergeResults(instructedAmountValidator.validate(initiation.getInstructedAmount()));
         validationResult.mergeResults(currencyCodeValidator.validate(initiation.getCurrencyOfTransfer()));

--- a/secure-api-gateway-ob-uk-rs-validation/secure-api-gateway-ob-uk-rs-validation-obie/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/validation/obie/payment/consent/OBWriteInternationalScheduledConsent5Validator.java
+++ b/secure-api-gateway-ob-uk-rs-validation/secure-api-gateway-ob-uk-rs-validation-obie/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/validation/obie/payment/consent/OBWriteInternationalScheduledConsent5Validator.java
@@ -23,6 +23,7 @@ import com.forgerock.sapi.gateway.ob.uk.common.error.OBRIErrorType;
 import com.forgerock.sapi.gateway.ob.uk.rs.validation.ValidationResult;
 import com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.BaseOBValidator;
 
+import uk.org.openbanking.datamodel.common.OBRisk1;
 import uk.org.openbanking.datamodel.error.OBError1;
 import uk.org.openbanking.datamodel.payment.OBWriteDomestic2DataInitiationInstructedAmount;
 import uk.org.openbanking.datamodel.payment.OBWriteInternational3DataInitiationExchangeRateInformation;
@@ -37,16 +38,22 @@ public class OBWriteInternationalScheduledConsent5Validator extends BaseOBValida
     private final BaseOBValidator<OBWriteDomestic2DataInitiationInstructedAmount> instructedAmountValidator;
     private final BaseOBValidator<String> currencyCodeValidator;
     private final BaseOBValidator<OBWriteInternational3DataInitiationExchangeRateInformation> exchangeRateInfoValidator;
+    private final BaseOBValidator<OBRisk1> riskValidator;
 
     public OBWriteInternationalScheduledConsent5Validator(BaseOBValidator<OBWriteDomestic2DataInitiationInstructedAmount> instructedAmountValidator,
-            BaseOBValidator<String> currencyCodeValidator, BaseOBValidator<OBWriteInternational3DataInitiationExchangeRateInformation> exchangeRateInfoValidator) {
+                                                          BaseOBValidator<String> currencyCodeValidator,
+                                                          BaseOBValidator<OBWriteInternational3DataInitiationExchangeRateInformation> exchangeRateInfoValidator,
+                                                          BaseOBValidator<OBRisk1> riskValidator) {
         this.instructedAmountValidator = Objects.requireNonNull(instructedAmountValidator);
         this.currencyCodeValidator     = Objects.requireNonNull(currencyCodeValidator);
         this.exchangeRateInfoValidator = Objects.requireNonNull(exchangeRateInfoValidator);
+        this.riskValidator             = Objects.requireNonNull(riskValidator);
     }
 
     @Override
     protected void validate(OBWriteInternationalScheduledConsent5 consent, ValidationResult<OBError1> validationResult) {
+        validationResult.mergeResults(riskValidator.validate(consent.getRisk()));
+
         final OBWriteInternationalScheduled3DataInitiation initiation = consent.getData().getInitiation();
         validationResult.mergeResults(instructedAmountValidator.validate(initiation.getInstructedAmount()));
         validationResult.mergeResults(currencyCodeValidator.validate(initiation.getCurrencyOfTransfer()));

--- a/secure-api-gateway-ob-uk-rs-validation/secure-api-gateway-ob-uk-rs-validation-obie/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/validation/obie/payment/consent/OBWriteInternationalStandingOrderConsent6Validator.java
+++ b/secure-api-gateway-ob-uk-rs-validation/secure-api-gateway-ob-uk-rs-validation-obie/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/validation/obie/payment/consent/OBWriteInternationalStandingOrderConsent6Validator.java
@@ -20,6 +20,7 @@ import java.util.Objects;
 import com.forgerock.sapi.gateway.ob.uk.rs.validation.ValidationResult;
 import com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.BaseOBValidator;
 
+import uk.org.openbanking.datamodel.common.OBRisk1;
 import uk.org.openbanking.datamodel.error.OBError1;
 import uk.org.openbanking.datamodel.payment.OBWriteDomestic2DataInitiationInstructedAmount;
 import uk.org.openbanking.datamodel.payment.OBWriteInternationalStandingOrder4DataInitiation;
@@ -32,16 +33,20 @@ public class OBWriteInternationalStandingOrderConsent6Validator extends BaseOBVa
 
     private final BaseOBValidator<OBWriteDomestic2DataInitiationInstructedAmount> instructedAmountValidator;
     private final BaseOBValidator<String> currencyCodeValidator;
+    private final BaseOBValidator<OBRisk1> riskValidator;
 
     public OBWriteInternationalStandingOrderConsent6Validator(BaseOBValidator<OBWriteDomestic2DataInitiationInstructedAmount> instructedAmountValidator,
-                                                              BaseOBValidator<String> currencyCodeValidator) {
+                                                              BaseOBValidator<String> currencyCodeValidator, BaseOBValidator<OBRisk1> riskValidator) {
         this.instructedAmountValidator = Objects.requireNonNull(instructedAmountValidator, "instructedAmountValidator must be supplied");
         this.currencyCodeValidator = Objects.requireNonNull(currencyCodeValidator, "currencyCodeValidator must be supplied");
+        this.riskValidator = Objects.requireNonNull(riskValidator, "riskValidator must be supplied");
     }
 
     @Override
-    protected void validate(OBWriteInternationalStandingOrderConsent6 obj, ValidationResult<OBError1> validationResult) {
-        final OBWriteInternationalStandingOrder4DataInitiation initiation = obj.getData().getInitiation();
+    protected void validate(OBWriteInternationalStandingOrderConsent6 consent, ValidationResult<OBError1> validationResult) {
+        validationResult.mergeResults(riskValidator.validate(consent.getRisk()));
+
+        final OBWriteInternationalStandingOrder4DataInitiation initiation = consent.getData().getInitiation();
         validationResult.mergeResults(currencyCodeValidator.validate(initiation.getCurrencyOfTransfer()));
         validationResult.mergeResults(instructedAmountValidator.validate(initiation.getInstructedAmount()));
     }

--- a/secure-api-gateway-ob-uk-rs-validation/secure-api-gateway-ob-uk-rs-validation-obie/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/validation/obie/payment/OBRisk1ValidatorTest.java
+++ b/secure-api-gateway-ob-uk-rs-validation/secure-api-gateway-ob-uk-rs-validation-obie/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/validation/obie/payment/OBRisk1ValidatorTest.java
@@ -27,18 +27,32 @@ import com.forgerock.sapi.gateway.ob.uk.common.error.OBRIErrorType;
 import uk.org.openbanking.datamodel.common.OBExternalPaymentContext1Code;
 import uk.org.openbanking.datamodel.common.OBRisk1;
 
-class OBRisk1ValidatorTest {
+public class OBRisk1ValidatorTest {
+
+    /**
+     * @return OBRisk1Validator with the default validation rules, currently no rules applied
+     */
+    public static OBRisk1Validator createDefaultRiskValidator() {
+        return new OBRisk1Validator(false);
+    }
+
+    /**
+     * @return OBRisk1Validator with risk.paymentContextCode validation rule enabled
+     */
+    public static OBRisk1Validator createPaymentContextCodeRiskValidator() {
+        return new OBRisk1Validator(true);
+    }
 
     @Test
     void shouldAllowEmptyPaymentContextCodeBasedOnConfig() {
-        final OBRisk1Validator obRisk1Validator = new OBRisk1Validator(false);
+        final OBRisk1Validator obRisk1Validator = createDefaultRiskValidator();
         validateSuccessResult(obRisk1Validator.validate(new OBRisk1()));
         validateSuccessResult(obRisk1Validator.validate(new OBRisk1().paymentContextCode(OBExternalPaymentContext1Code.BILLPAYMENT)));
     }
 
     @Test
     void shouldRequirePaymentContextCodeBasedOnConfig() {
-        final OBRisk1Validator obRisk1Validator = new OBRisk1Validator(true);
+        final OBRisk1Validator obRisk1Validator = createPaymentContextCodeRiskValidator();
         validateSuccessResult(obRisk1Validator.validate(new OBRisk1().paymentContextCode(OBExternalPaymentContext1Code.BILLPAYMENT)));
         validateErrorResult(obRisk1Validator.validate(new OBRisk1()), List.of(OBRIErrorType.PAYMENT_CODE_CONTEXT_INVALID.toOBError1()));
     }

--- a/secure-api-gateway-ob-uk-rs-validation/secure-api-gateway-ob-uk-rs-validation-obie/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/validation/obie/payment/OBRisk1ValidatorTest.java
+++ b/secure-api-gateway-ob-uk-rs-validation/secure-api-gateway-ob-uk-rs-validation-obie/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/validation/obie/payment/OBRisk1ValidatorTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.payment;
+
+import static com.forgerock.sapi.gateway.ob.uk.rs.validation.ValidationResultTest.validateErrorResult;
+import static com.forgerock.sapi.gateway.ob.uk.rs.validation.ValidationResultTest.validateSuccessResult;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import com.forgerock.sapi.gateway.ob.uk.common.error.OBRIErrorType;
+
+import uk.org.openbanking.datamodel.common.OBExternalPaymentContext1Code;
+import uk.org.openbanking.datamodel.common.OBRisk1;
+
+class OBRisk1ValidatorTest {
+
+    @Test
+    void shouldAllowEmptyPaymentContextCodeBasedOnConfig() {
+        final OBRisk1Validator obRisk1Validator = new OBRisk1Validator(false);
+        validateSuccessResult(obRisk1Validator.validate(new OBRisk1()));
+        validateSuccessResult(obRisk1Validator.validate(new OBRisk1().paymentContextCode(OBExternalPaymentContext1Code.BILLPAYMENT)));
+    }
+
+    @Test
+    void shouldRequirePaymentContextCodeBasedOnConfig() {
+        final OBRisk1Validator obRisk1Validator = new OBRisk1Validator(true);
+        validateSuccessResult(obRisk1Validator.validate(new OBRisk1().paymentContextCode(OBExternalPaymentContext1Code.BILLPAYMENT)));
+        validateErrorResult(obRisk1Validator.validate(new OBRisk1()), List.of(OBRIErrorType.PAYMENT_CODE_CONTEXT_INVALID.toOBError1()));
+    }
+}

--- a/secure-api-gateway-ob-uk-rs-validation/secure-api-gateway-ob-uk-rs-validation-obie/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/validation/obie/payment/consent/OBDomesticVRPConsentRequestValidatorTest.java
+++ b/secure-api-gateway-ob-uk-rs-validation/secure-api-gateway-ob-uk-rs-validation-obie/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/validation/obie/payment/consent/OBDomesticVRPConsentRequestValidatorTest.java
@@ -17,6 +17,7 @@ package com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.payment.consent;
 
 import static com.forgerock.sapi.gateway.ob.uk.rs.validation.ValidationResultTest.validateErrorResult;
 import static com.forgerock.sapi.gateway.ob.uk.rs.validation.ValidationResultTest.validateSuccessResult;
+import static com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.payment.OBRisk1ValidatorTest.createDefaultRiskValidator;
 
 import java.util.List;
 
@@ -29,7 +30,7 @@ import uk.org.openbanking.testsupport.vrp.OBDomesticVrpConsentRequestTestDataFac
 
 class OBDomesticVRPConsentRequestValidatorTest {
 
-    private final OBDomesticVRPConsentRequestValidator validator = new OBDomesticVRPConsentRequestValidator();
+    private final OBDomesticVRPConsentRequestValidator validator = new OBDomesticVRPConsentRequestValidator(createDefaultRiskValidator());
 
     private static OBDomesticVRPConsentRequest createValidConsent() {
         return OBDomesticVrpConsentRequestTestDataFactory.aValidOBDomesticVRPConsentRequestMandatoryFields();


### PR DESCRIPTION
- Creating com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.payment.OBRisk1Validator impl in RS validation framework module
  - Existing validation logic ported over
  - Adding spring config to control payment context code validation: `rs.obie.validation.config.payments.requirePaymentContextCode` by default this is false
- Deprecating:
  - Original validator: com.forgerock.sapi.gateway.ob.uk.rs.server.validator.OBRisk1Validator
  - com.forgerock.sapi.gateway.ob.uk.rs.server.validator.PaymentSubmissionValidator.validateIdempotencyKeyAndRisk removing calls to it from the latest payment controllers (they will use the validation framework)

By default, the OBRisk1Validator applies no validation rules. Specific deployments can customise the behaviour by Spring config to enable paymentContextCode validation or by supplying a different validator implementation with custom validation logic.