### PR TITLE
1102: prepare release 2.0.1

### DIFF
--- a/_infra/helm/securebanking-openbanking-uk-rs/Chart.yaml
+++ b/_infra/helm/securebanking-openbanking-uk-rs/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: test-facility-bank
 description: Test facility bank service Helm chart for Kubernetes
 type: application
-version: 1.0.3
-appVersion: 1.0.3
+version: 2.0.1
+appVersion: 2.0.1

--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
 
     <properties>
         <uk.bom.version>2.0.0</uk.bom.version>
-        <consent.api.version>2.0.0</consent.api.version>
+        <consent.api.version>2.0.1</consent.api.version>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
- Upgrade helm chart to 2.0.1
- Bumped RS store client release 2.0.1

Issue: https://github.com/SecureApiGateway/SecureApiGateway/issues/1102