### PR TITLE
1092: Adding RCS IDEMPOTENCY_ERROR code translation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
 
     <properties>
         <uk.bom.version>2.0.0</uk.bom.version>
-        <consent.api.version>2.0.1</consent.api.version>
+        <consent.api.version>2.0.2-SNAPSHOT</consent.api.version>
     </properties>
 
     <dependencyManagement>

--- a/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/exceptions/GlobalExceptionHandler.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/exceptions/GlobalExceptionHandler.java
@@ -15,6 +15,7 @@
  */
 package com.forgerock.sapi.gateway.ob.uk.rs.server.exceptions;
 
+import static com.forgerock.sapi.gateway.ob.uk.common.error.ErrorCode.FR_OBRI_IDEMPOTENCY_KEY_REQUEST_BODY_CHANGED;
 import static com.forgerock.sapi.gateway.ob.uk.common.error.ErrorCode.OBRI_CONSENT_NOT_FOUND;
 import static com.forgerock.sapi.gateway.ob.uk.common.error.ErrorCode.OBRI_PERMISSION_INVALID;
 import static com.forgerock.sapi.gateway.ob.uk.common.error.ErrorCode.OBRI_SERVER_INTERNAL_ERROR;
@@ -344,27 +345,32 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
         final String errorCode;
         final String message;
         switch (ex.getErrorType()) {
-        case INVALID_PERMISSIONS:
-            httpStatus = HttpStatus.FORBIDDEN;
-            errorCode = OBRI_PERMISSION_INVALID.toString();
-            message = "You are not allowed to access this consent";
-            break;
-        case NOT_FOUND:
-            httpStatus = HttpStatus.NOT_FOUND;
-            errorCode = OBRI_CONSENT_NOT_FOUND.toString();
-            message = "Consent not found";
-            break;
-        case INVALID_STATE_TRANSITION:
-            httpStatus = HttpStatus.BAD_REQUEST;
-            errorCode = UK_OBIE_RESOURCE_INVALID_CONSENT_STATUS.toString();
-            message = ex.getMessage();
-            break;
-        default:
-            // Handle as an unexpected exception which yields internal server error, log stacktrace for debugging
-            log.warn("({}) Unexpected ConsentStoreClientException", fapiInteractionId, ex);
-            httpStatus = HttpStatus.INTERNAL_SERVER_ERROR;
-            errorCode = OBRI_SERVER_INTERNAL_ERROR.toString();
-            message = ex.getMessage();
+            case INVALID_PERMISSIONS:
+                httpStatus = HttpStatus.FORBIDDEN;
+                errorCode = OBRI_PERMISSION_INVALID.toString();
+                message = "You are not allowed to access this consent";
+                break;
+            case NOT_FOUND:
+                httpStatus = HttpStatus.NOT_FOUND;
+                errorCode = OBRI_CONSENT_NOT_FOUND.toString();
+                message = "Consent not found";
+                break;
+            case INVALID_STATE_TRANSITION:
+                httpStatus = HttpStatus.BAD_REQUEST;
+                errorCode = UK_OBIE_RESOURCE_INVALID_CONSENT_STATUS.toString();
+                message = ex.getMessage();
+                break;
+            case IDEMPOTENCY_ERROR:
+                httpStatus = HttpStatus.BAD_REQUEST;
+                errorCode = FR_OBRI_IDEMPOTENCY_KEY_REQUEST_BODY_CHANGED.toString();
+                message = ex.getMessage();
+                break;
+            default:
+                // Handle as an unexpected exception which yields internal server error, log stacktrace for debugging
+                log.warn("({}) Unexpected ConsentStoreClientException", fapiInteractionId, ex);
+                httpStatus = HttpStatus.INTERNAL_SERVER_ERROR;
+                errorCode = OBRI_SERVER_INTERNAL_ERROR.toString();
+                message = ex.getMessage();
         }
 
         final String errorResponseId = fapiInteractionId != null ? fapiInteractionId : UUID.randomUUID().toString();


### PR DESCRIPTION
Mapping IDEMPOTENCY_ERRORs from the RCS Consent Store API such that a HTTP 400 error is returned with an error code indicating the request body has changed. Without this mapping a HTTP 500 error is returned.

https://github.com/SecureApiGateway/SecureApiGateway/issues/1092