### PR TITLE
1082: Renaming ConsentRepoConfiguration to CloudClientConfiguration

### DIFF
--- a/_infra/helm/securebanking-openbanking-uk-rs/templates/deployment.yaml
+++ b/_infra/helm/securebanking-openbanking-uk-rs/templates/deployment.yaml
@@ -71,11 +71,11 @@ spec:
                 key: MONGODB_TEST_FACILITY_PASSWORD
           - name: SERVER_PORT
             value: {{ .Values.deployment.containerPort | quote }}
-          - name: CONSENT_REPO_URI
+          - name: CLOUD_CLIENT_BASE_URI
             valueFrom:
               configMapKeyRef:
                 name: deployment-config
-                key: CONSENT_REPO_URI
+                key: GATEWAY_DATA_REPO_URI
           - name: RCS_CONSENT_STORE_API_BASEURI
             valueFrom:
               configMapKeyRef:

--- a/secure-api-gateway-ob-uk-rs-cloud-client/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/cloud/client/configuration/CloudClientConfiguration.java
+++ b/secure-api-gateway-ob-uk-rs-cloud-client/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/cloud/client/configuration/CloudClientConfiguration.java
@@ -17,20 +17,21 @@ package com.forgerock.sapi.gateway.ob.uk.rs.cloud.client.configuration;
 
 import lombok.Data;
 
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.util.LinkedCaseInsensitiveMap;
 
 import java.util.Map;
 
-@Configuration
-@ConfigurationProperties(prefix = "consent.repo")
-@Data
-public class ConsentRepoConfiguration {
+import javax.annotation.PostConstruct;
 
-    @Value("${consent.repo.uri}")
+@Configuration
+@ConfigurationProperties(prefix = "cloud.client")
+@Data
+public class CloudClientConfiguration {
+
     private String baseUri;
+
     /*
      * Spring maps the properties, the keys from file will be the map keys
      * @see: application-test.yml
@@ -40,8 +41,14 @@ public class ConsentRepoConfiguration {
      */
     private Map<String, String> contextsUser = new LinkedCaseInsensitiveMap<>();
 
-
-    public String getConsentRepoBaseUri() {
-        return baseUri;
+    @PostConstruct
+    private void validateConfig() {
+        if (baseUri == null || baseUri.isBlank()) {
+            throw new IllegalStateException("Required configuration: cloud.client.baseUri is missing");
+        }
+        if (contextsUser.isEmpty()) {
+            throw new IllegalStateException("Required configuration: cloud.client.contextsUser map is missing");
+        }
     }
+
 }

--- a/secure-api-gateway-ob-uk-rs-cloud-client/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/cloud/client/services/UserClientService.java
+++ b/secure-api-gateway-ob-uk-rs-cloud-client/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/cloud/client/services/UserClientService.java
@@ -15,7 +15,7 @@
  */
 package com.forgerock.sapi.gateway.ob.uk.rs.cloud.client.services;
 
-import com.forgerock.sapi.gateway.ob.uk.rs.cloud.client.configuration.ConsentRepoConfiguration;
+import com.forgerock.sapi.gateway.ob.uk.rs.cloud.client.configuration.CloudClientConfiguration;
 import com.forgerock.sapi.gateway.ob.uk.rs.cloud.client.exceptions.ErrorClient;
 import com.forgerock.sapi.gateway.ob.uk.rs.cloud.client.exceptions.ErrorType;
 import com.forgerock.sapi.gateway.ob.uk.rs.cloud.client.exceptions.ExceptionClient;
@@ -41,11 +41,11 @@ import static org.springframework.http.HttpMethod.GET;
 @Slf4j
 public class UserClientService {
     private final RestTemplate restTemplate;
-    private final ConsentRepoConfiguration consentRepoConfiguration;
+    private final CloudClientConfiguration cloudClientConfiguration;
 
-    public UserClientService(RestTemplate restTemplate, ConsentRepoConfiguration consentRepoConfiguration) {
+    public UserClientService(RestTemplate restTemplate, CloudClientConfiguration cloudClientConfiguration) {
         this.restTemplate = restTemplate;
-        this.consentRepoConfiguration = consentRepoConfiguration;
+        this.cloudClientConfiguration = cloudClientConfiguration;
     }
 
     public User getUserByName(String userName) throws ExceptionClient {
@@ -68,9 +68,9 @@ public class UserClientService {
 
     private User request(String userName, HttpMethod httpMethod) throws ExceptionClient {
         String userFilter = "?_queryFilter=userName+eq+\"" + userName + "\"";
-        String userFilterURL = consentRepoConfiguration.getConsentRepoBaseUri() +
+        String userFilterURL = cloudClientConfiguration.getBaseUri() +
                 UrlContext.UrlUserQueryFilter(
-                        consentRepoConfiguration.getContextsUser().get(httpMethod.name()),
+                        cloudClientConfiguration.getContextsUser().get(httpMethod.name()),
                         userFilter);
 
         log.debug("(UserServiceClient#request) request the user details from platform: {}", userFilterURL);

--- a/secure-api-gateway-ob-uk-rs-cloud-client/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/cloud/client/configuration/CloudClientConfigurationTest.java
+++ b/secure-api-gateway-ob-uk-rs-cloud-client/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/cloud/client/configuration/CloudClientConfigurationTest.java
@@ -27,19 +27,19 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
- * Unit test for {@link ConsentRepoConfiguration}
+ * Unit test for {@link CloudClientConfiguration}
  */
 @ExtendWith(SpringExtension.class)
-@ContextConfiguration(classes = {ConsentRepoConfiguration.class}, initializers = ConfigFileApplicationContextInitializer.class)
-@EnableConfigurationProperties(value = ConsentRepoConfiguration.class)
+@ContextConfiguration(classes = {CloudClientConfiguration.class}, initializers = ConfigFileApplicationContextInitializer.class)
+@EnableConfigurationProperties(value = CloudClientConfiguration.class)
 @ActiveProfiles("test")
-public class ConsentRepoConfigurationTest {
+public class CloudClientConfigurationTest {
 
     @Autowired
-    private ConsentRepoConfiguration consentRepoConfiguration;
+    private CloudClientConfiguration cloudClientConfiguration;
 
     @Test
     public void shouldConfigureIgBaseUri(){
-        assertThat(consentRepoConfiguration.getConsentRepoBaseUri()).isEqualTo("http://ig:80");
+        assertThat(cloudClientConfiguration.getBaseUri()).isEqualTo("http://ig:80");
     }
 }

--- a/secure-api-gateway-ob-uk-rs-cloud-client/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/cloud/client/services/UserClientServiceTest.java
+++ b/secure-api-gateway-ob-uk-rs-cloud-client/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/cloud/client/services/UserClientServiceTest.java
@@ -15,7 +15,7 @@
  */
 package com.forgerock.sapi.gateway.ob.uk.rs.cloud.client.services;
 
-import com.forgerock.sapi.gateway.ob.uk.rs.cloud.client.configuration.ConsentRepoConfiguration;
+import com.forgerock.sapi.gateway.ob.uk.rs.cloud.client.configuration.CloudClientConfiguration;
 import com.forgerock.sapi.gateway.ob.uk.rs.cloud.client.exceptions.ErrorType;
 import com.forgerock.sapi.gateway.ob.uk.rs.cloud.client.exceptions.ExceptionClient;
 import com.forgerock.sapi.gateway.ob.uk.rs.cloud.client.model.User;
@@ -52,7 +52,7 @@ public class UserClientServiceTest {
     private UserClientService userClientService;
 
     @Mock
-    protected ConsentRepoConfiguration configurationPropertiesClient;
+    protected CloudClientConfiguration configurationPropertiesClient;
 
     @Mock
     protected RestTemplate restTemplate;

--- a/secure-api-gateway-ob-uk-rs-cloud-client/src/test/resources/application-test.yml
+++ b/secure-api-gateway-ob-uk-rs-cloud-client/src/test/resources/application-test.yml
@@ -1,13 +1,8 @@
-consent:
-  repo:
-    uri: http://ig:80
+cloud:
+  client:
+    baseUri: http://ig:80
     contexts_user:
       get: /repo/users/@UserId@
       put: /repo/users/@UserId@
       patch: /repo/users/@UserId@
       delete: /repo/users/@UserId@
-    contexts_repo_consent:
-      get: /repo/consents/@IntentId@
-      put: /repo/consents/@IntentId@
-      patch: /repo/consents/@IntentId@
-      delete: /repo/consents/@IntentId@

--- a/secure-api-gateway-ob-uk-rs-resource-store/secure-api-gateway-ob-uk-rs-resource-store-api/src/test/resources/application-test.yml
+++ b/secure-api-gateway-ob-uk-rs-resource-store/secure-api-gateway-ob-uk-rs-resource-store-api/src/test/resources/application-test.yml
@@ -6,14 +6,9 @@
 #      # force SpringBoot tests to use a random port for mongo
 #      port: 0
 
-consent:
-  repo:
-    uri: http://ig:80
-    contexts_repo_consent:
-      get: /repo/consents/@IntentId@
-      put: /repo/consents/@IntentId@
-      patch: /repo/consents/@IntentId@
-      delete: /repo/consents/@IntentId@
+cloud:
+  client:
+    baseUri: http://ig:80
     contexts_user:
       get: /repo/users/@UserId@
       put: /repo/users/@UserId@

--- a/secure-api-gateway-ob-uk-rs-server/src/main/resources/application.yml
+++ b/secure-api-gateway-ob-uk-rs-server/src/main/resources/application.yml
@@ -5,11 +5,11 @@
 # application, this config is deployment specific.
 #
 #
-# Consent Repo Configuration
-#consent:
-#  repo:
-#    # Connection string to the Consent Repo base URI
-#    uri:
+# Cloud Client API settings
+#cloud:
+#  client:
+#    # Connection string to connect to the Cloud Data API
+#    baseUri:
 #
 #rs:
 #  discovery:
@@ -41,15 +41,10 @@ logging:
     com.forgerock: DEBUG
     uk.org.openbanking: DEBUG
 
-# Configuration for calling the Consent Repository
-# See: com.forgerock.sapi.gateway.ob.uk.rs.cloud.client.configuration.ConsentRepoConfiguration
-consent:
-  repo:
-    contexts_repo_consent:
-      get: /repo/consents/@IntentId@
-      put: /repo/consents/@IntentId@
-      patch: /repo/consents/@IntentId@
-      delete: /repo/consents/@IntentId@
+# Configuration for calling the Cloud Data API
+# com.forgerock.sapi.gateway.ob.uk.rs.cloud.client.configuration.CloudClientConfiguration
+cloud:
+  client:
     contexts_user:
       get: /repo/users/@UserId@
       put: /repo/users/@UserId@

--- a/secure-api-gateway-ob-uk-rs-server/src/test/resources/application-test.yml
+++ b/secure-api-gateway-ob-uk-rs-server/src/test/resources/application-test.yml
@@ -6,14 +6,9 @@ spring:
       # force SpringBoot tests to use a random port for mongo
       port: 0
 
-consent:
-  repo:
-    uri: http://ig:80
-    contexts_repo_consent:
-      get: /repo/consents/@IntentId@
-      put: /repo/consents/@IntentId@
-      patch: /repo/consents/@IntentId@
-      delete: /repo/consents/@IntentId@
+cloud:
+  client:
+    baseUri: http://ig:80
     contexts_user:
       get: /repo/users/@UserId@
       put: /repo/users/@UserId@


### PR DESCRIPTION
CloudClientConfiguration is responsible for configuring the rcs-cloud-client module.

Renamed Spring config properties to use the cloud.client prefix

Updated helm chart to set the cloud.client.baseUri property to GATEWAY_DATA_REPO_URI from the configmap

https://github.com/SecureApiGateway/SecureApiGateway/issues/1082