### PR TITLE
998: events backoffice event notification api

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
     </parent>
 
     <properties>
-        <uk.bom.version>2.0.0</uk.bom.version>
+        <uk.bom.version>2.0.2-SNAPSHOT</uk.bom.version>
         <consent.api.version>2.0.2-SNAPSHOT</consent.api.version>
     </properties>
 

--- a/secure-api-gateway-ob-uk-rs-resource-store/secure-api-gateway-ob-uk-rs-resource-store-api/src/main/java/com/forgerock/sapi/gateway/rs/resource/store/api/admin/events/DataEventsApi.java
+++ b/secure-api-gateway-ob-uk-rs-resource-store/secure-api-gateway-ob-uk-rs-resource-store-api/src/main/java/com/forgerock/sapi/gateway/rs/resource/store/api/admin/events/DataEventsApi.java
@@ -16,8 +16,6 @@
 package com.forgerock.sapi.gateway.rs.resource.store.api.admin.events;
 
 
-import java.util.Collection;
-
 import javax.validation.Valid;
 
 import org.springframework.http.ResponseEntity;
@@ -26,6 +24,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 
+import com.forgerock.sapi.gateway.ob.uk.common.error.OBErrorException;
 import com.forgerock.sapi.gateway.ob.uk.common.error.OBErrorResponseException;
 import com.forgerock.sapi.gateway.rs.resource.store.datamodel.events.FREventMessages;
 
@@ -43,7 +42,7 @@ public interface DataEventsApi {
             @ApiParam(value = "Default", required = true)
             @Valid
             @RequestBody FREventMessages frEventMessages
-    ) throws OBErrorResponseException;
+    ) throws OBErrorException;
 
     @RequestMapping(value = "/events",
             produces = {"application/json; charset=utf-8"},
@@ -53,36 +52,27 @@ public interface DataEventsApi {
             @ApiParam(value = "Default", required = true)
             @Valid
             @RequestBody FREventMessages frEventMessages
-    ) throws OBErrorResponseException;
-
-    @RequestMapping(value = "/events/all",
-            produces = {"application/json; charset=utf-8"},
-            method = RequestMethod.GET
-    )
-    ResponseEntity<Collection<FREventMessages>> exportEvents();
+    ) throws OBErrorException;
 
     @RequestMapping(value = "/events",
             produces = {"application/json; charset=utf-8"},
             method = RequestMethod.GET
     )
-    ResponseEntity<FREventMessages> exportEventsByTppId(
+    ResponseEntity<FREventMessages> exportEvents(
             @ApiParam(value = "Default", required = true)
             @Valid
-            @RequestParam String tppId
-    );
+            @RequestParam String apiClientId
+    ) throws OBErrorException;
 
     @RequestMapping(value = "/events",
             method = RequestMethod.DELETE
     )
-    ResponseEntity<Void> removeEvents(
-            @ApiParam(value = "The client ID")
-            @RequestParam(value = "tppId") String tppId,
+    ResponseEntity removeEvents(
+            @ApiParam(value = "The client ID", required = true)
+            @Valid
+            @RequestParam(value = "apiClientId") String apiClientId,
             @ApiParam(value = "Unique identification of event message")
             @RequestParam(value = "jti", required = false) String jti
-    );
+    ) throws OBErrorException;
 
-    @RequestMapping(value = "/events/all",
-            method = RequestMethod.DELETE
-    )
-    ResponseEntity<Void> removeAllEvents();
 }

--- a/secure-api-gateway-ob-uk-rs-resource-store/secure-api-gateway-ob-uk-rs-resource-store-api/src/main/java/com/forgerock/sapi/gateway/rs/resource/store/api/admin/events/DataEventsApi.java
+++ b/secure-api-gateway-ob-uk-rs-resource-store/secure-api-gateway-ob-uk-rs-resource-store-api/src/main/java/com/forgerock/sapi/gateway/rs/resource/store/api/admin/events/DataEventsApi.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.rs.resource.store.api.admin.events;
+
+
+import java.util.Collection;
+
+import javax.validation.Valid;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import com.forgerock.sapi.gateway.ob.uk.common.error.OBErrorResponseException;
+import com.forgerock.sapi.gateway.rs.resource.store.datamodel.events.FREventMessages;
+
+import io.swagger.annotations.ApiParam;
+
+
+@RequestMapping("/admin/data")
+public interface DataEventsApi {
+
+    @RequestMapping(value = "/events",
+            produces = {"application/json; charset=utf-8"},
+            consumes = {"application/json; charset=utf-8"},
+            method = RequestMethod.POST)
+    ResponseEntity<FREventMessages> importEvents(
+            @ApiParam(value = "Default", required = true)
+            @Valid
+            @RequestBody FREventMessages frEventMessages
+    ) throws OBErrorResponseException;
+
+    @RequestMapping(value = "/events",
+            produces = {"application/json; charset=utf-8"},
+            consumes = {"application/json; charset=utf-8"},
+            method = RequestMethod.PUT)
+    ResponseEntity<FREventMessages> updateEvents(
+            @ApiParam(value = "Default", required = true)
+            @Valid
+            @RequestBody FREventMessages frEventMessages
+    ) throws OBErrorResponseException;
+
+    @RequestMapping(value = "/events/all",
+            produces = {"application/json; charset=utf-8"},
+            method = RequestMethod.GET
+    )
+    ResponseEntity<Collection<FREventMessages>> exportEvents();
+
+    @RequestMapping(value = "/events",
+            produces = {"application/json; charset=utf-8"},
+            method = RequestMethod.GET
+    )
+    ResponseEntity<FREventMessages> exportEventsByTppId(
+            @ApiParam(value = "Default", required = true)
+            @Valid
+            @RequestParam String tppId
+    );
+
+    @RequestMapping(value = "/events",
+            method = RequestMethod.DELETE
+    )
+    ResponseEntity<Void> removeEvents(
+            @ApiParam(value = "The client ID")
+            @RequestParam(value = "tppId") String tppId,
+            @ApiParam(value = "Unique identification of event message")
+            @RequestParam(value = "jti", required = false) String jti
+    );
+
+    @RequestMapping(value = "/events/all",
+            method = RequestMethod.DELETE
+    )
+    ResponseEntity<Void> removeAllEvents();
+}

--- a/secure-api-gateway-ob-uk-rs-resource-store/secure-api-gateway-ob-uk-rs-resource-store-api/src/main/java/com/forgerock/sapi/gateway/rs/resource/store/api/admin/events/DataEventsApiController.java
+++ b/secure-api-gateway-ob-uk-rs-resource-store/secure-api-gateway-ob-uk-rs-resource-store-api/src/main/java/com/forgerock/sapi/gateway/rs/resource/store/api/admin/events/DataEventsApiController.java
@@ -1,0 +1,188 @@
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.rs.resource.store.api.admin.events;
+
+import static com.forgerock.sapi.gateway.rs.resource.store.api.admin.events.FRDataEventsConverter.toFREventMessage;
+import static com.forgerock.sapi.gateway.rs.resource.store.api.admin.events.FRDataEventsConverter.toFREventMessageEntity;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+
+import com.forgerock.sapi.gateway.ob.uk.common.error.OBErrorException;
+import com.forgerock.sapi.gateway.ob.uk.common.error.OBErrorResponseException;
+import com.forgerock.sapi.gateway.ob.uk.common.error.OBRIErrorResponseCategory;
+import com.forgerock.sapi.gateway.ob.uk.common.error.OBRIErrorType;
+import com.forgerock.sapi.gateway.rs.resource.store.datamodel.events.FREventMessage;
+import com.forgerock.sapi.gateway.rs.resource.store.datamodel.events.FREventMessages;
+import com.forgerock.sapi.gateway.rs.resource.store.repo.entity.event.FREventMessageEntity;
+import com.forgerock.sapi.gateway.rs.resource.store.repo.mongo.events.FREventMessageRepository;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Controller("DataEventsApi")
+@Slf4j
+public class DataEventsApiController implements DataEventsApi {
+    private final FREventMessageRepository frEventMessageRepository;
+
+    @Autowired
+    public DataEventsApiController(
+            FREventMessageRepository frEventMessageRepository
+    ) {
+        this.frEventMessageRepository = frEventMessageRepository;
+    }
+
+    @Override
+    public ResponseEntity<FREventMessages> importEvents(FREventMessages frEventMessages) throws OBErrorResponseException {
+        try {
+            return new ResponseEntity<>(createEvents(frEventMessages), HttpStatus.CREATED);
+        } catch (Exception exception) {
+            throw handleError(exception);
+        }
+    }
+
+    @Override
+    public ResponseEntity<FREventMessages> updateEvents(FREventMessages frEventMessages) throws OBErrorResponseException {
+        try {
+            FREventMessages eventUpdated = FREventMessages.builder().tppId(frEventMessages.getTppId()).build();
+            frEventMessages.getEvents().forEach(frEventMessage -> {
+                Optional<FREventMessageEntity> optionalFREventNotification =
+                        frEventMessageRepository.findByApiClientIdAndJti(
+                                frEventMessages.getTppId(), frEventMessage.getJti()
+                        );
+                optionalFREventNotification.ifPresent(entity -> {
+                            entity.setSet(frEventMessage.getSet());
+                            FREventMessageEntity entityUpdated = frEventMessageRepository.save(entity);
+                            eventUpdated.eventItem(toFREventMessage(entityUpdated));
+                        }
+                );
+            });
+            return ResponseEntity.ok(eventUpdated);
+        } catch (Exception exception) {
+            throw handleError(exception);
+        }
+    }
+
+    @Override
+    public ResponseEntity<Collection<FREventMessages>> exportEvents() {
+        log.debug("Find all Events");
+        List<FREventMessages> frEventMessages = new ArrayList<>();
+        List<FREventMessageEntity> entities = frEventMessageRepository.findAll();
+        if (!entities.isEmpty()) {
+            // Get the apiClients
+            List<String> apiClients = entities
+                    .stream().map(
+                            entity -> entity.getApiClientId()
+                    ).distinct().collect(Collectors.toList());
+            // create a list of SETs per apiClient
+            apiClients.forEach(apiClient -> {
+                List<FREventMessage> clientEvents = entities.stream()
+                        .filter(entity -> entity.getApiClientId().equals(apiClient))
+                        .map(entity -> toFREventMessage(entity))
+                        .collect(Collectors.toList());
+
+                frEventMessages.add(FREventMessages.builder().tppId(apiClient).events(clientEvents).build());
+            });
+        }
+
+        return ResponseEntity.ok(frEventMessages);
+    }
+
+    @Override
+    public ResponseEntity<FREventMessages> exportEventsByTppId(String tppId) {
+        log.debug("Find all Events for TPP:{}", tppId);
+        Collection<FREventMessageEntity> entities = frEventMessageRepository.findByApiClientId(tppId);
+        FREventMessages dataEvent = FREventMessages.builder().tppId(tppId).events(Collections.EMPTY_LIST).build();
+        if (!entities.isEmpty()) {
+            dataEvent.events(entities.stream().map(entity -> toFREventMessage(entity)).collect(Collectors.toList()));
+        }
+
+        return ResponseEntity.ok(dataEvent);
+    }
+
+    @Override
+    public ResponseEntity<Void> removeEvents(String tppId, String jti) {
+        if (Objects.nonNull(jti)) {
+            log.debug("Remove Event with jti: {} for TPP:{}", jti, tppId);
+            frEventMessageRepository.deleteByApiClientIdAndJti(tppId, jti);
+        } else {
+            log.debug("Remove all Events for TPP:{}", tppId);
+            frEventMessageRepository.deleteByApiClientId(tppId);
+        }
+        return new ResponseEntity(Void.class, HttpStatus.NO_CONTENT);
+    }
+
+    @Override
+    public ResponseEntity<Void> removeAllEvents() {
+        frEventMessageRepository.deleteAll();
+        return new ResponseEntity(Void.class, HttpStatus.NO_CONTENT);
+    }
+
+    /**
+     * Create new events
+     *
+     * @param frEventMessages the entity body {@link FREventMessages}
+     */
+    private FREventMessages createEvents(FREventMessages frEventMessages) {
+        log.debug("creating event messages\n{}", frEventMessages);
+        FREventMessages frEventMessagesCreated = FREventMessages.builder().tppId(frEventMessages.getTppId()).build();
+
+        frEventMessages.getEvents().forEach(
+                eventMessage -> {
+                    FREventMessageEntity entity = toFREventMessageEntity(frEventMessages.getTppId(), eventMessage);
+                    entity.setApiClientId(frEventMessages.getTppId());
+                    log.debug("Create event message {}", entity);
+                    frEventMessagesCreated.eventItem(toFREventMessage(frEventMessageRepository.save(entity)));
+                }
+        );
+        return frEventMessagesCreated;
+    }
+
+
+    /**
+     * Handle the exception and reformat to {@link OBErrorResponseException}
+     *
+     * @param exception the exception to handle
+     * @return {@link OBErrorResponseException} the response exception
+     */
+    private OBErrorResponseException handleError(Exception exception) {
+        log.error("DataEvents API Error: {}", exception);
+        if (exception instanceof OBErrorException) {
+            OBErrorException obErrorException = (OBErrorException) exception;
+            return new OBErrorResponseException(obErrorException.getObriErrorType().getHttpStatus(),
+                    OBRIErrorResponseCategory.SERVER_INTERNAL_ERROR,
+                    obErrorException.getOBError());
+        } else if (exception instanceof OBErrorResponseException) {
+            return (OBErrorResponseException) exception;
+        } else if (exception.getCause() != null && exception.getCause() instanceof OBErrorResponseException) {
+            return (OBErrorResponseException) exception.getCause();
+        } else {
+            return new OBErrorResponseException(
+                    OBRIErrorType.SERVER_ERROR.getHttpStatus(),
+                    OBRIErrorResponseCategory.SERVER_INTERNAL_ERROR,
+                    OBRIErrorType.SERVER_ERROR.toOBError1(exception.getMessage()));
+        }
+    }
+}

--- a/secure-api-gateway-ob-uk-rs-resource-store/secure-api-gateway-ob-uk-rs-resource-store-api/src/main/java/com/forgerock/sapi/gateway/rs/resource/store/api/admin/events/DataEventsApiController.java
+++ b/secure-api-gateway-ob-uk-rs-resource-store/secure-api-gateway-ob-uk-rs-resource-store-api/src/main/java/com/forgerock/sapi/gateway/rs/resource/store/api/admin/events/DataEventsApiController.java
@@ -15,27 +15,23 @@
  */
 package com.forgerock.sapi.gateway.rs.resource.store.api.admin.events;
 
+import static com.forgerock.sapi.gateway.ob.uk.common.error.OBRIErrorType.DATA_INVALID_REQUEST;
 import static com.forgerock.sapi.gateway.rs.resource.store.api.admin.events.FRDataEventsConverter.toFREventMessage;
 import static com.forgerock.sapi.gateway.rs.resource.store.api.admin.events.FRDataEventsConverter.toFREventMessageEntity;
 
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 
 import com.forgerock.sapi.gateway.ob.uk.common.error.OBErrorException;
-import com.forgerock.sapi.gateway.ob.uk.common.error.OBErrorResponseException;
-import com.forgerock.sapi.gateway.ob.uk.common.error.OBRIErrorResponseCategory;
-import com.forgerock.sapi.gateway.ob.uk.common.error.OBRIErrorType;
-import com.forgerock.sapi.gateway.rs.resource.store.datamodel.events.FREventMessage;
 import com.forgerock.sapi.gateway.rs.resource.store.datamodel.events.FREventMessages;
 import com.forgerock.sapi.gateway.rs.resource.store.repo.entity.event.FREventMessageEntity;
 import com.forgerock.sapi.gateway.rs.resource.store.repo.mongo.events.FREventMessageRepository;
@@ -46,98 +42,144 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class DataEventsApiController implements DataEventsApi {
     private final FREventMessageRepository frEventMessageRepository;
+    private final Integer eventsLimit;
 
     @Autowired
     public DataEventsApiController(
-            FREventMessageRepository frEventMessageRepository
+            FREventMessageRepository frEventMessageRepository,
+            @Value("${rs.data.upload.limit.events}") Integer eventsLimit
     ) {
         this.frEventMessageRepository = frEventMessageRepository;
+        this.eventsLimit = eventsLimit;
     }
 
     @Override
-    public ResponseEntity<FREventMessages> importEvents(FREventMessages frEventMessages) throws OBErrorResponseException {
-        try {
-            return new ResponseEntity<>(createEvents(frEventMessages), HttpStatus.CREATED);
-        } catch (Exception exception) {
-            throw handleError(exception);
-        }
+    public ResponseEntity<FREventMessages> importEvents(FREventMessages frEventMessages) throws OBErrorException {
+        validateApiClientId(frEventMessages.getApiClientId());
+        limitValidation(frEventMessages);
+        log.debug("Import events {}", frEventMessages);
+        return new ResponseEntity<>(createEvents(frEventMessages), HttpStatus.CREATED);
     }
 
     @Override
-    public ResponseEntity<FREventMessages> updateEvents(FREventMessages frEventMessages) throws OBErrorResponseException {
-        try {
-            FREventMessages eventUpdated = FREventMessages.builder().tppId(frEventMessages.getTppId()).build();
-            frEventMessages.getEvents().forEach(frEventMessage -> {
-                Optional<FREventMessageEntity> optionalFREventNotification =
-                        frEventMessageRepository.findByApiClientIdAndJti(
-                                frEventMessages.getTppId(), frEventMessage.getJti()
-                        );
-                optionalFREventNotification.ifPresent(entity -> {
-                            entity.setSet(frEventMessage.getSet());
-                            FREventMessageEntity entityUpdated = frEventMessageRepository.save(entity);
-                            eventUpdated.eventItem(toFREventMessage(entityUpdated));
-                        }
-                );
-            });
-            return ResponseEntity.ok(eventUpdated);
-        } catch (Exception exception) {
-            throw handleError(exception);
-        }
+    public ResponseEntity<FREventMessages> updateEvents(FREventMessages frEventMessages) throws OBErrorException {
+        validateApiClientId(frEventMessages.getApiClientId());
+        validatePayloadEventsLimit(frEventMessages.getEvents().size());
+        log.debug("Update events {}", frEventMessages);
+        FREventMessages eventUpdated = FREventMessages.builder().apiClientId(frEventMessages.getApiClientId()).build();
+        frEventMessages.getEvents().forEach(frEventMessage -> {
+            Optional<FREventMessageEntity> optionalFREventNotification =
+                    frEventMessageRepository.findByApiClientIdAndJti(
+                            frEventMessages.getApiClientId(), frEventMessage.getJti()
+                    );
+            optionalFREventNotification.ifPresent(entity -> {
+                        entity.setSet(frEventMessage.getSet());
+                        FREventMessageEntity entityUpdated = frEventMessageRepository.save(entity);
+                        eventUpdated.eventItem(toFREventMessage(entityUpdated));
+                    }
+            );
+        });
+        return ResponseEntity.ok(eventUpdated);
     }
 
     @Override
-    public ResponseEntity<Collection<FREventMessages>> exportEvents() {
-        log.debug("Find all Events");
-        List<FREventMessages> frEventMessages = new ArrayList<>();
-        List<FREventMessageEntity> entities = frEventMessageRepository.findAll();
+    public ResponseEntity<FREventMessages> exportEvents(String apiClientId) throws OBErrorException {
+        validateApiClientId(apiClientId);
+        log.debug("Export all Events for apiClient:{}", apiClientId);
+        Collection<FREventMessageEntity> entities = frEventMessageRepository.findByApiClientId(apiClientId);
+        FREventMessages dataEvent = FREventMessages.builder().apiClientId(apiClientId).events(Collections.EMPTY_LIST).build();
         if (!entities.isEmpty()) {
-            // Get the apiClients
-            List<String> apiClients = entities
-                    .stream().map(
-                            entity -> entity.getApiClientId()
-                    ).distinct().collect(Collectors.toList());
-            // create a list of SETs per apiClient
-            apiClients.forEach(apiClient -> {
-                List<FREventMessage> clientEvents = entities.stream()
-                        .filter(entity -> entity.getApiClientId().equals(apiClient))
-                        .map(entity -> toFREventMessage(entity))
-                        .collect(Collectors.toList());
-
-                frEventMessages.add(FREventMessages.builder().tppId(apiClient).events(clientEvents).build());
-            });
-        }
-
-        return ResponseEntity.ok(frEventMessages);
-    }
-
-    @Override
-    public ResponseEntity<FREventMessages> exportEventsByTppId(String tppId) {
-        log.debug("Find all Events for TPP:{}", tppId);
-        Collection<FREventMessageEntity> entities = frEventMessageRepository.findByApiClientId(tppId);
-        FREventMessages dataEvent = FREventMessages.builder().tppId(tppId).events(Collections.EMPTY_LIST).build();
-        if (!entities.isEmpty()) {
-            dataEvent.events(entities.stream().map(entity -> toFREventMessage(entity)).collect(Collectors.toList()));
+            dataEvent.events(entities.stream().map(FRDataEventsConverter::toFREventMessage).collect(Collectors.toList()));
         }
 
         return ResponseEntity.ok(dataEvent);
     }
 
     @Override
-    public ResponseEntity<Void> removeEvents(String tppId, String jti) {
+    public ResponseEntity removeEvents(String apiClientId, String jti) throws OBErrorException {
+        validateApiClientId(apiClientId);
         if (Objects.nonNull(jti)) {
-            log.debug("Remove Event with jti: {} for TPP:{}", jti, tppId);
-            frEventMessageRepository.deleteByApiClientIdAndJti(tppId, jti);
+            log.debug("Remove Event with jti: {} for apiClient:{}", jti, apiClientId);
+            frEventMessageRepository.deleteByApiClientIdAndJti(apiClientId, jti);
         } else {
-            log.debug("Remove all Events for TPP:{}", tppId);
-            frEventMessageRepository.deleteByApiClientId(tppId);
+            log.debug("Remove all Events for apiClient:{}", apiClientId);
+            frEventMessageRepository.deleteByApiClientId(apiClientId);
         }
         return new ResponseEntity(Void.class, HttpStatus.NO_CONTENT);
     }
 
-    @Override
-    public ResponseEntity<Void> removeAllEvents() {
-        frEventMessageRepository.deleteAll();
-        return new ResponseEntity(Void.class, HttpStatus.NO_CONTENT);
+    /**
+     * Checks apiClientId property
+     *
+     * @param apiClientId
+     * @throws OBErrorException
+     */
+    private void validateApiClientId(String apiClientId) throws OBErrorException {
+        if (Objects.isNull(apiClientId) || apiClientId.isEmpty() || apiClientId.isBlank()) {
+            throw new OBErrorException(
+                    DATA_INVALID_REQUEST,
+                    "The apiClientId cannot be null or empty"
+            );
+        }
+    }
+
+    /**
+     * Checks the limit of events supported by the system depending on the configuration (rs.data.upload.limit.events)
+     *
+     * @param frEventMessages
+     * @throws OBErrorException
+     */
+    private void limitValidation(FREventMessages frEventMessages) throws OBErrorException {
+        validatePayloadEventsLimit(frEventMessages.getEvents().size());
+        validateStoredEvents(frEventMessages);
+        validateTotalEventsToImport(frEventMessages);
+    }
+
+    /**
+     * Checks the number of events provided in the payload
+     *
+     * @param numOfEvents
+     * @throws OBErrorException
+     */
+    private void validatePayloadEventsLimit(Integer numOfEvents) throws OBErrorException {
+        if (numOfEvents > eventsLimit) {
+            throw new OBErrorException(
+                    DATA_INVALID_REQUEST,
+                    String.format("The number of events provided in the payload (%d) exceeded maximum limit of %s", numOfEvents, eventsLimit));
+        }
+    }
+
+    /**
+     * Checks if the current stored events in the system has reached the limit
+     *
+     * @param frEventMessages
+     * @throws OBErrorException
+     */
+    private void validateStoredEvents(FREventMessages frEventMessages) throws OBErrorException {
+        Collection<FREventMessageEntity> entities = frEventMessageRepository.findByApiClientId(frEventMessages.getApiClientId());
+        if (entities.size() >= eventsLimit) {
+            throw new OBErrorException(
+                    DATA_INVALID_REQUEST,
+                    String.format("Cannot add events as it the stored events in the system has reached the maximum limit of %s, current events in the system %d", eventsLimit, entities.size())
+            );
+        }
+    }
+
+    /**
+     * Checks if the total events to import will reach the limit
+     *
+     * @param frEventMessages
+     * @throws OBErrorException
+     */
+    private void validateTotalEventsToImport(FREventMessages frEventMessages) throws OBErrorException {
+        Collection<FREventMessageEntity> entities = frEventMessageRepository.findByApiClientId(frEventMessages.getApiClientId());
+        Integer totalEvents = entities.size() + frEventMessages.getEvents().size();
+        if (totalEvents > eventsLimit) {
+            throw new OBErrorException(
+                    DATA_INVALID_REQUEST,
+                    String.format("Cannot add events as it will exceeded maximum limit of %s, current events in the system %d", eventsLimit, entities.size())
+            );
+        }
     }
 
     /**
@@ -146,13 +188,11 @@ public class DataEventsApiController implements DataEventsApi {
      * @param frEventMessages the entity body {@link FREventMessages}
      */
     private FREventMessages createEvents(FREventMessages frEventMessages) {
-        log.debug("creating event messages\n{}", frEventMessages);
-        FREventMessages frEventMessagesCreated = FREventMessages.builder().tppId(frEventMessages.getTppId()).build();
-
+        FREventMessages frEventMessagesCreated = FREventMessages.builder().apiClientId(frEventMessages.getApiClientId()).build();
         frEventMessages.getEvents().forEach(
                 eventMessage -> {
-                    FREventMessageEntity entity = toFREventMessageEntity(frEventMessages.getTppId(), eventMessage);
-                    entity.setApiClientId(frEventMessages.getTppId());
+                    FREventMessageEntity entity = toFREventMessageEntity(frEventMessages.getApiClientId(), eventMessage);
+                    entity.setApiClientId(frEventMessages.getApiClientId());
                     log.debug("Create event message {}", entity);
                     frEventMessagesCreated.eventItem(toFREventMessage(frEventMessageRepository.save(entity)));
                 }
@@ -160,29 +200,4 @@ public class DataEventsApiController implements DataEventsApi {
         return frEventMessagesCreated;
     }
 
-
-    /**
-     * Handle the exception and reformat to {@link OBErrorResponseException}
-     *
-     * @param exception the exception to handle
-     * @return {@link OBErrorResponseException} the response exception
-     */
-    private OBErrorResponseException handleError(Exception exception) {
-        log.error("DataEvents API Error: {}", exception);
-        if (exception instanceof OBErrorException) {
-            OBErrorException obErrorException = (OBErrorException) exception;
-            return new OBErrorResponseException(obErrorException.getObriErrorType().getHttpStatus(),
-                    OBRIErrorResponseCategory.SERVER_INTERNAL_ERROR,
-                    obErrorException.getOBError());
-        } else if (exception instanceof OBErrorResponseException) {
-            return (OBErrorResponseException) exception;
-        } else if (exception.getCause() != null && exception.getCause() instanceof OBErrorResponseException) {
-            return (OBErrorResponseException) exception.getCause();
-        } else {
-            return new OBErrorResponseException(
-                    OBRIErrorType.SERVER_ERROR.getHttpStatus(),
-                    OBRIErrorResponseCategory.SERVER_INTERNAL_ERROR,
-                    OBRIErrorType.SERVER_ERROR.toOBError1(exception.getMessage()));
-        }
-    }
 }

--- a/secure-api-gateway-ob-uk-rs-resource-store/secure-api-gateway-ob-uk-rs-resource-store-api/src/main/java/com/forgerock/sapi/gateway/rs/resource/store/api/admin/events/FRDataEventsConverter.java
+++ b/secure-api-gateway-ob-uk-rs-resource-store/secure-api-gateway-ob-uk-rs-resource-store-api/src/main/java/com/forgerock/sapi/gateway/rs/resource/store/api/admin/events/FRDataEventsConverter.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.rs.resource.store.api.admin.events;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+import com.forgerock.sapi.gateway.ob.uk.common.datamodel.converter.mapper.FRModelMapper;
+import com.forgerock.sapi.gateway.rs.resource.store.datamodel.events.FREventMessages;
+import com.forgerock.sapi.gateway.rs.resource.store.datamodel.events.FREventMessage;
+import com.forgerock.sapi.gateway.rs.resource.store.repo.entity.event.FREventMessageEntity;
+
+public class FRDataEventsConverter {
+
+    public static final FREventMessageEntity toFREventMessageEntity(String apiClientId, FREventMessage frEventMessage) {
+        Objects.requireNonNull(apiClientId, "api client Id must not be null");
+        FREventMessageEntity entity = FRModelMapper.map(frEventMessage, FREventMessageEntity.class);
+        entity.setApiClientId(apiClientId);
+        return entity;
+    }
+
+    public static final List<FREventMessageEntity> toFREventMessageEntityList(FREventMessages frEventMessages) {
+        List<FREventMessageEntity> frEventMessageEntityList = new ArrayList<>();
+        frEventMessages.getEvents().forEach(
+                frEventMessage -> {
+                    FREventMessageEntity eventMessageEntity = toFREventMessageEntity(frEventMessages.getTppId(), frEventMessage);
+                    frEventMessageEntityList.add(eventMessageEntity);
+                }
+        );
+        return frEventMessageEntityList;
+    }
+
+    public static final FREventMessage toFREventMessage(FREventMessageEntity entity) {
+        return FRModelMapper.map(entity, FREventMessage.class);
+    }
+
+}

--- a/secure-api-gateway-ob-uk-rs-resource-store/secure-api-gateway-ob-uk-rs-resource-store-api/src/main/java/com/forgerock/sapi/gateway/rs/resource/store/api/admin/events/FRDataEventsConverter.java
+++ b/secure-api-gateway-ob-uk-rs-resource-store/secure-api-gateway-ob-uk-rs-resource-store-api/src/main/java/com/forgerock/sapi/gateway/rs/resource/store/api/admin/events/FRDataEventsConverter.java
@@ -37,7 +37,7 @@ public class FRDataEventsConverter {
         List<FREventMessageEntity> frEventMessageEntityList = new ArrayList<>();
         frEventMessages.getEvents().forEach(
                 frEventMessage -> {
-                    FREventMessageEntity eventMessageEntity = toFREventMessageEntity(frEventMessages.getTppId(), frEventMessage);
+                    FREventMessageEntity eventMessageEntity = toFREventMessageEntity(frEventMessages.getApiClientId(), frEventMessage);
                     frEventMessageEntityList.add(eventMessageEntity);
                 }
         );

--- a/secure-api-gateway-ob-uk-rs-resource-store/secure-api-gateway-ob-uk-rs-resource-store-api/src/main/java/com/forgerock/sapi/gateway/rs/resource/store/api/admin/events/events.md
+++ b/secure-api-gateway-ob-uk-rs-resource-store/secure-api-gateway-ob-uk-rs-resource-store-api/src/main/java/com/forgerock/sapi/gateway/rs/resource/store/api/admin/events/events.md
@@ -1,0 +1,360 @@
+# Data Events
+
+## Objects
+
+### FRDataEvent
+
+| Field | Description | Class | Occurrence |
+| --- | --- | --- | --- |
+| tppId | The tpp user name, user for import, update and export | Max 128 text | 1..1 |
+| jti | JWT ID to export and update | Max 128 text | 0..1 |  
+| events | Event to import and update | OBEventNotification2 Object | 0..1 |
+
+### OBEventNotification2
+
+| Field | Description | Class | Occurrence |
+| --- | --- | --- | --- |
+| iat | Issued at | int | 1..1 |
+| jti | JWT ID | Max 128 text | 1..1 |
+| sub | Subject | anyURI | 1..1 |
+| aud | Audience | Max 128 text | 1..1 |
+| txn | Transaction Identifier | Max 128 text | 1..1 |
+| toe | Time of event | int | 1..1 |
+| events | Collection of events | OBEvent | 1..1 |
+
+## Context 
+- GET `/api/data/events`: export event by tppId
+- GET `/api/data/events/all`: export all events
+- POST `/api/data/events`: import events
+- PUT `/api/data/events`: update events
+
+## Request Examples
+### GET `/api/data/events` export events by tppId
+> The field `tppId` is mandatory.
+```json
+{ "tppId": "3ffb98cc-be98-4b10-a405-bde41e88c2c7"}
+```
+### GET `/api/data/events/all` export all events
+- EMPTY Body
+
+### POST `/api/data/events` import events by tppId
+> The field `tppId` is mandatory.
+
+> The Array field `events` cannot be empty.
+```json
+{ 
+"apiClientId": "3ffb98cc-be98-4b10-a405-bde41e88c2c7",
+"events":
+  [
+    {"set": "eyJraWQiOiJkOGFiMzI4N2QxZTI4M....." }      
+  ]
+}
+```
+**Stored FREventNotification example**
+```json
+{
+  "_id": {
+    "$oid": "605b4e69dc6d66001587b759"
+  },
+  "jti": "5a9658ba-590e-4daf-b18f-86fc1e558510",
+  "set": "eyJraWQiOiJkOGFiMzI4N2QxZTI4MDc0NDFjMWM4Yjc0MGNjYWQ3MTBiMjM2MDI4IiwiYWxnIjoiUFMyNTYifQ.eyJhdWQiOiI3dW14NW5UUjMzODExUXlRZmkiLCJzdWIiOiJodHRwczpcL1wvZXhhbXBsZWJhbmsuY29tXC9hcGlcL29wZW4tYmFua2luZ1wvdjMuMS4yXC9waXNwXC9kb21lc3RpYy1wYXltZW50c1wvcG10LTcyOTAtMDAzIiwiaXNzIjoiaHR0cHM6XC9cL2FzLmFzcHNwLnNhbmRib3gubGxveWRzYmFua2luZy5jb21cL29hdXRoMiIsInR4biI6ImRmYzUxNjI4LTM0NzktNGI4MS1hZDYwLTIxMGI0M2QwMjMwNiIsInRvZSI6MTUxNjIzOTAyMiwiaWF0IjoxNjE2NTk2NTg1LCJqdGkiOiJkYzY0OTkzMy0zMDc3LTRhZGItOGFjNy0xYmRjODA1Y2M2MTEiLCJldmVudHMiOnsidXJuOnVrOm9yZzpvcGVuYmFua2luZzpldmVudHM6cmVzb3VyY2UtdXBkYXRlIjp7InN1YmplY3QiOnsiaHR0cDpcL1wvb3BlbmJhbmtpbmcub3JnLnVrXC9yaWQiOiJwbXQtNzI5MC0wMDMiLCJzdWJqZWN0X3R5cGUiOiJodHRwOlwvXC9vcGVuYmFua2luZy5vcmcudWtcL3JpZF9odHRwOlwvXC9vcGVuYmFua2luZy5vcmcudWtcL3J0eSIsImh0dHA6XC9cL29wZW5iYW5raW5nLm9yZy51a1wvcmxrIjpbeyJsaW5rIjoiaHR0cHM6XC9cL2V4YW1wbGViYW5rLmNvbVwvYXBpXC9vcGVuLWJhbmtpbmdcL3YzLjEuMlwvcGlzcFwvZG9tZXN0aWMtcGF5bWVudHNcL3BtdC03MjkwLTAwMyIsInZlcnNpb24iOiIzLjEuMiJ9XSwiaHR0cDpcL1wvb3BlbmJhbmtpbmcub3JnLnVrXC9ydHkiOiJkb21lc3RpYy1wYXltZW50In19fX0.kgaGq6mN3Gso7er_bKXLQF0cTc4LtHKaVRErtTOhIYzLds2af8NKPhCHcqs74epEfYb_IZc8onKJEUpjiCKDKCipLyzHUD2DFxPd3BCTVAlP1eXDTDuWSa5ZwcrINEwNfeBLbyqOp1oTS5VUJ_ld9d7ovERr271DipZ4OXTC5AR04T2BzK4GlU4ekjqOaYulVD3GLWNZuFfoVXeyPPr9t-q1SPZLGmR_e3kRETxn_v32JzIQx8iN8ACOkOvMEXYA_mKhbSiwj4i_9_O9lOYBJo2BQClfC5vcxrnNSmg5tu0V-nYw-4q4IajwhNKBIbO7yZhS6y7QWXPgeUbZEv3luA",
+  "apiClientId": "6a067bec-a0e7-43d9-9f93-bf42d4ee2f75",
+  "created": {
+    "$date": "2021-03-24T14:36:25.643Z"
+  },
+  "updated": {
+    "$date": "2021-03-24T14:36:41.767Z"
+  },
+  "errors": {
+    "error": "jwtIss",
+    "description": "Issuer is invalid or could not be verified"
+  },
+  "_class": "com.forgerock.openbanking.common.model.openbanking.persistence.event.FREventNotification"
+}
+```
+        
+### PUT `/api/data/events` update events by tppId
+> The field `tppId` is mandatory.
+
+> The field `events[].jti` must be an existing jti.
+```json
+{ 
+"apiClientId": "3ffb98cc-be98-4b10-a405-bde41e88c2c7",
+"events":
+  [
+    {
+      "iss": "https://examplebank.com/",
+      "iat": "1516239022",
+      "jti": "b460a07c-4962-43d1-85ee-9dc10fbb8f6c",
+      "sub": "https://examplebank.com/api/open-banking/v3.0/pisp/domestic-payments/pmt-7290-003",
+      "aud": "7umx5nTR33811QyQfi",
+      "txn": "dfc51628-3479-4b81-ad60-210b43d02306",
+      "toe": "1516239022",
+      "events": {
+        "urn:uk:org:openbanking:events:resource-update": {
+          "subject": {
+            "subject_type": "http://openbanking.org.uk/rid_http://openbanking.org.uk/rty",
+            "http://openbanking.org.uk/rid": "pmt-7290-003",
+            "http://openbanking.org.uk/rty": "domestic-payment",
+            "http://openbanking.org.uk/rlk": [
+              {
+                "version": "v3.0",
+                "link": "https://examplebank.com/api/open-banking/v3.0/pisp/domestic-payments/pmt-7290-003"
+              },
+              {
+                "version": "v1.1",
+                "link": "https://examplebank.com/api/open-banking/v1.1/payment-submissions/pmt-7290-003"
+              }
+            ]
+          }
+        }
+      }
+    }
+  ]
+}
+```
+## The Swagger Specification for Event
+[read write api specs swagger](https://github.com/OpenBankingUK/read-write-api-specs)
+
+```json
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "Event Notification API Specification - TPP Endpoints",
+    "description": "Swagger for Event Notification API Specification - TPP Endpoints",
+    "termsOfService": "https://www.openbanking.org.uk/terms",
+    "contact": {
+      "name": "Service Desk",
+      "email": "ServiceDesk@openbanking.org.uk"
+    },
+    "license": {
+      "name": "open-licence",
+      "url": "https://www.openbanking.org.uk/open-licence"
+    },
+    "version": "v3.0.0"
+  },
+  "basePath": "/open-banking/v3.0",
+  "schemes": [
+    "https"
+  ],
+  "paths": {
+    "/event-notifications": {
+      "post": {
+        "summary": "Send an event notification",
+        "operationId": "CreateEventNotification",
+        "consumes": [
+          "application/jwt"
+        ],
+        "tags": [
+          "Event Notification"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/parameters/OBEventNotification1Param"
+          },
+          {
+            "$ref": "#/parameters/x-fapi-financial-id-Param"
+          },
+          {
+            "$ref": "#/parameters/x-fapi-interaction-id-Param"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Accepted"
+          }
+        }
+      }
+    }
+  },
+  "parameters": {
+    "OBEventNotification1Param": {
+      "in": "body",
+      "name": "OBEventNotification1Param",
+      "description": "Create an Callback URI",
+      "required": true,
+      "schema": {
+        "type": "string",
+        "format": "base64"
+      }
+    },
+    "x-fapi-financial-id-Param": {
+      "in": "header",
+      "name": "x-fapi-financial-id",
+      "type": "string",
+      "required": true,
+      "description": "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB."
+    },
+    "x-fapi-interaction-id-Param": {
+      "in": "header",
+      "name": "x-fapi-interaction-id",
+      "type": "string",
+      "required": false,
+      "description": "An RFC4122 UID used as a correlation id."
+    }
+  },
+  "securityDefinitions": {
+    "TPPOAuth2Security": {
+      "type": "oauth2",
+      "flow": "application",
+      "tokenUrl": "https://authserver.example/token",
+      "scopes": {
+        "accounts": "Ability to read Accounts information",
+        "fundsconfirmation": "Ability to confirm funds",
+        "payments": "Generic payment scope"
+      },
+      "description": "TPP client credential authorisation flow with the ASPSP"
+    }
+  },
+  "definitions": {
+    "OBEvent1": {
+      "description": "Events.",
+      "type": "object",
+      "properties": {
+        "urn:uk:org:openbanking:events:resource-update": {
+          "$ref": "#/definitions/OBEventResourceUpdate1"
+        }
+      },
+      "required": [
+        "urn:uk:org:openbanking:events:resource-update"
+      ],
+      "additionalProperties": false
+    },
+    "OBEventLink1": {
+      "description": "Resource links to other available versions of the resource.",
+      "type": "object",
+      "properties": {
+        "version": {
+          "description": "Resource version.",
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 10
+        },
+        "link": {
+          "description": "Resource link.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "version",
+        "link"
+      ],
+      "additionalProperties": false,
+      "minProperties": 1
+    },
+    "OBEventNotification1": {
+      "description": "The resource-update event.",
+      "type": "object",
+      "properties": {
+        "iss": {
+          "description": "Issuer.",
+          "type": "string"
+        },
+        "iat": {
+          "description": "Issued At. ",
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 10,
+          "pattern": "[0-9]{1,10}"
+        },
+        "jti": {
+          "description": "JWT ID.",
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 128
+        },
+        "aud": {
+          "description": "Audience.",
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 128
+        },
+        "sub": {
+          "description": "Subject",
+          "type": "string",
+          "format": "uri"
+        },
+        "txn": {
+          "description": "Transaction Identifier.",
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 128
+        },
+        "toe": {
+          "description": "Time of Event.",
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 10,
+          "pattern": "[0-9]{1,10}"
+        },
+        "events": {
+          "$ref": "#/definitions/OBEvent1"
+        }
+      },
+      "required": [
+        "iss",
+        "iat",
+        "jti",
+        "aud",
+        "sub",
+        "txn",
+        "toe",
+        "events"
+      ],
+      "additionalProperties": false
+    },
+    "OBEventResourceUpdate1": {
+      "description": "Resource-Update Event.",
+      "type": "object",
+      "properties": {
+        "subject": {
+          "$ref": "#/definitions/OBEventSubject1"
+        }
+      },
+      "required": [
+        "subject"
+      ],
+      "additionalProperties": false
+    },
+    "OBEventSubject1": {
+      "description": "The resource-update event.",
+      "type": "object",
+      "properties": {
+        "subject_type": {
+          "description": "Subject type for the updated resource. ",
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 128
+        },
+        "http://openbanking.org.uk/rid": {
+          "description": "Resource Id for the updated resource.",
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 128
+        },
+        "http://openbanking.org.uk/rty": {
+          "description": "Resource Type for the updated resource.",
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 128
+        },
+        "http://openbanking.org.uk/rlk": {
+          "items": {
+            "$ref": "#/definitions/OBEventLink1"
+          },
+          "type": "array",
+          "description": "Resource links to other available versions of the resource.",
+          "minItems": 1
+        }
+      },
+      "required": [
+        "subject_type",
+        "http://openbanking.org.uk/rid",
+        "http://openbanking.org.uk/rty",
+        "http://openbanking.org.uk/rlk"
+      ],
+      "additionalProperties": false
+    }
+  }
+}
+```

--- a/secure-api-gateway-ob-uk-rs-resource-store/secure-api-gateway-ob-uk-rs-resource-store-api/src/main/java/com/forgerock/sapi/gateway/rs/resource/store/api/admin/exceptions/DataApiExceptionHandler.java
+++ b/secure-api-gateway-ob-uk-rs-resource-store/secure-api-gateway-ob-uk-rs-resource-store-api/src/main/java/com/forgerock/sapi/gateway/rs/resource/store/api/admin/exceptions/DataApiExceptionHandler.java
@@ -15,6 +15,7 @@
  */
 package com.forgerock.sapi.gateway.rs.resource.store.api.admin.exceptions;
 
+import com.forgerock.sapi.gateway.ob.uk.common.error.OBErrorException;
 import com.forgerock.sapi.gateway.rs.resource.store.api.ResourceStoreApiModuleConfiguration;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -36,6 +37,21 @@ public class DataApiExceptionHandler extends ResponseEntityExceptionHandler {
     protected ResponseEntity<Object> handleDataApiException(DataApiException ex, WebRequest request) {
         HttpStatus httpStatus = ex.getErrorType().getHttpStatus();
         log.debug("Error in admin data user API, reason {}", ex.getMessage());
+        return ResponseEntity.status(httpStatus).body(
+                new OBErrorResponse1()
+                        .code(httpStatus.name())
+                        .id(request.getHeader("x-fapi-interaction-id"))
+                        .message(httpStatus.getReasonPhrase())
+                        .errors(
+                                Collections.singletonList(new OBError1().message(ex.getMessage()))
+                        )
+        );
+    }
+
+    @ExceptionHandler(value = {OBErrorException.class})
+    protected ResponseEntity<Object> handleOBErrorException(OBErrorException ex, WebRequest request) {
+        HttpStatus httpStatus = ex.getObriErrorType().getHttpStatus();
+        log.debug("Error in admin data API, reason {}", ex.getMessage());
         return ResponseEntity.status(httpStatus).body(
                 new OBErrorResponse1()
                         .code(httpStatus.name())

--- a/secure-api-gateway-ob-uk-rs-resource-store/secure-api-gateway-ob-uk-rs-resource-store-api/src/test/java/com/forgerock/sapi/gateway/rs/resource/store/api/admin/events/DataEventsApiControllerTest.java
+++ b/secure-api-gateway-ob-uk-rs-resource-store/secure-api-gateway-ob-uk-rs-resource-store-api/src/test/java/com/forgerock/sapi/gateway/rs/resource/store/api/admin/events/DataEventsApiControllerTest.java
@@ -1,0 +1,287 @@
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.rs.resource.store.api.admin.events;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
+import static org.springframework.http.HttpMethod.DELETE;
+import static org.springframework.http.HttpMethod.GET;
+import static org.springframework.http.HttpMethod.PUT;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.web.client.RestTemplate;
+
+import com.forgerock.sapi.gateway.rs.resource.store.datamodel.events.FREventMessages;
+import com.forgerock.sapi.gateway.rs.resource.store.datamodel.events.FREventMessage;
+import com.forgerock.sapi.gateway.rs.resource.store.repo.mongo.events.FREventMessageRepository;
+
+/**
+ * Test for {@link DataEventsApiController}
+ */
+@SpringBootTest(webEnvironment = RANDOM_PORT)
+@ActiveProfiles("test")
+public class DataEventsApiControllerTest {
+
+    private static final String BASE_URL = "http://localhost:";
+    private static final String DATA_URI = "/admin/data/events";
+
+    private final String TPP_ID = UUID.randomUUID().toString();
+
+    @LocalServerPort
+    private int port;
+
+    @Autowired
+    private FREventMessageRepository frEventMessageRepository;
+
+    @Autowired
+    private RestTemplate restTemplate;
+
+    @BeforeEach
+    public void setUp() {
+        frEventMessageRepository.deleteAll();
+    }
+
+    @Test
+    public void shouldCreateNewEventMessages() {
+        // Given
+        final FREventMessages frEventMessages = aValidFREventMessages();
+        // When
+        ResponseEntity<FREventMessages> response = restTemplate.postForEntity(dataUrl(), frEventMessages, FREventMessages.class);
+
+        // Then
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+        assertThat(Objects.requireNonNull(response.getBody()).getTppId()).isNotNull().isEqualTo(frEventMessages.getTppId());
+        assertThat(Objects.requireNonNull(response.getBody()).getEvents()).isEqualTo(frEventMessages.getEvents());
+    }
+
+    @Test
+    public void shouldUpdateMultipleEventMessages() {
+        // Given
+        final String set = "set-jwt-00000011222";
+
+        FREventMessages frEventMessages = aValidFREventMessages(TPP_ID);
+        ResponseEntity<FREventMessages> response = restTemplate.postForEntity(dataUrl(), frEventMessages, FREventMessages.class);
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+        assertThat(Objects.requireNonNull(response.getBody()).getTppId()).isNotNull().isEqualTo(frEventMessages.getTppId());
+        assertThat(Objects.requireNonNull(response.getBody()).getEvents()).isEqualTo(frEventMessages.getEvents());
+
+        FREventMessages frEventMessagesUpdate = aValidFREventMessages(TPP_ID, frEventMessages.getEvents());
+        frEventMessagesUpdate.getEvents().forEach(eventMessage -> eventMessage.setSet(set));
+
+        // When
+        ResponseEntity<FREventMessages> responseUpdate = restTemplate.exchange(dataUrl(), PUT, new HttpEntity<>(frEventMessagesUpdate), FREventMessages.class);
+        // Then
+        assertThat(responseUpdate.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(Objects.requireNonNull(responseUpdate.getBody()).getTppId()).isNotNull().isEqualTo(frEventMessages.getTppId()).isEqualTo(frEventMessagesUpdate.getTppId());
+        assertThat(Objects.requireNonNull(responseUpdate.getBody()).getEvents()).isEqualTo(frEventMessagesUpdate.getEvents());
+
+        // When
+        ResponseEntity<FREventMessages> responseExport = restTemplate.getForEntity(dataUrl(frEventMessages.getTppId()), FREventMessages.class);
+        // Then
+        assertThat(responseExport.getStatusCode()).isEqualTo(HttpStatus.OK);
+        // An apiClient with a collection of SETs
+        assertThat(Objects.requireNonNull(responseExport.getBody()).getTppId()).isNotNull().isEqualTo(frEventMessages.getTppId()).isEqualTo(frEventMessages.getTppId());
+        assertThat(Objects.requireNonNull(responseExport.getBody()).getEvents()).containsExactlyInAnyOrderElementsOf(frEventMessages.getEvents());
+
+    }
+
+    @Test
+    public void shouldExportEventMessages() {
+        // Given
+        // Creation of event messages for an api client (tpp id)
+        FREventMessages frEventMessages = aValidFREventMessages(UUID.randomUUID().toString());
+        ResponseEntity<FREventMessages> response = restTemplate.postForEntity(dataUrl(), frEventMessages, FREventMessages.class);
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+        assertThat(Objects.requireNonNull(response.getBody()).getTppId()).isNotNull().isEqualTo(frEventMessages.getTppId());
+        assertThat(Objects.requireNonNull(response.getBody()).getEvents()).isEqualTo(frEventMessages.getEvents());
+        // creation of event message for another api client (tpp id)
+        FREventMessages frEventMessages2 = aValidFREventMessages(UUID.randomUUID().toString());
+        ResponseEntity<FREventMessages> response2 = restTemplate.postForEntity(dataUrl(), frEventMessages2, FREventMessages.class);
+        assertThat(response2.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+        assertThat(Objects.requireNonNull(response2.getBody()).getTppId()).isNotNull().isEqualTo(frEventMessages2.getTppId());
+        assertThat(Objects.requireNonNull(response2.getBody()).getEvents()).isEqualTo(frEventMessages2.getEvents());
+
+        // When
+        ResponseEntity<Collection<FREventMessages>> responseExport = restTemplate.exchange(dataUrl() + "/all", GET, null, new ParameterizedTypeReference<>() {
+        });
+        // Then
+        assertThat(responseExport.getStatusCode()).isEqualTo(HttpStatus.OK);
+        Collection<FREventMessages> dataEvents = Objects.requireNonNull(responseExport.getBody());
+        assertThat(dataEvents).containsExactly(frEventMessages, frEventMessages2);
+    }
+
+    @Test
+    public void shouldExportEventMessagesByApiClient() {
+        // Given
+        FREventMessages frEventMessages = aValidFREventMessages(TPP_ID);
+        ResponseEntity<FREventMessages> response = restTemplate.postForEntity(dataUrl(), frEventMessages, FREventMessages.class);
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+        assertThat(Objects.requireNonNull(response.getBody()).getTppId()).isNotNull().isEqualTo(frEventMessages.getTppId());
+        assertThat(Objects.requireNonNull(response.getBody()).getEvents()).isEqualTo(frEventMessages.getEvents());
+
+        FREventMessages frEventMessages2 = aValidFREventMessages(TPP_ID);
+        ResponseEntity<FREventMessages> response2 = restTemplate.postForEntity(dataUrl(), frEventMessages2, FREventMessages.class);
+        assertThat(response2.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+        assertThat(Objects.requireNonNull(response2.getBody()).getTppId()).isNotNull().isEqualTo(frEventMessages2.getTppId());
+        assertThat(Objects.requireNonNull(response2.getBody()).getEvents()).isEqualTo(frEventMessages2.getEvents());
+
+        // When
+        ResponseEntity<FREventMessages> responseExport = restTemplate.getForEntity(dataUrl(frEventMessages2.getTppId()), FREventMessages.class);
+        // Then
+        assertThat(responseExport.getStatusCode()).isEqualTo(HttpStatus.OK);
+        // An apiClient with a collection of SETs
+        assertThat(Objects.requireNonNull(responseExport.getBody()).getTppId()).isNotNull().isEqualTo(frEventMessages2.getTppId()).isEqualTo(frEventMessages.getTppId());
+        assertThat(Objects.requireNonNull(responseExport.getBody()).getEvents()).containsAll(frEventMessages.getEvents()).containsAll(frEventMessages2.getEvents());
+    }
+
+    @Test
+    public void shouldDeleteAllEventMessagesByApiClient() {
+        // Given
+        final FREventMessages frEventMessages = aValidFREventMessages();
+        final ResponseEntity<FREventMessages> response = restTemplate.postForEntity(dataUrl(), frEventMessages, FREventMessages.class);
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+        assertThat(Objects.requireNonNull(response.getBody()).getTppId()).isNotNull().isEqualTo(frEventMessages.getTppId());
+        assertThat(Objects.requireNonNull(response.getBody()).getEvents()).isEqualTo(frEventMessages.getEvents());
+
+        final ResponseEntity<Void> responseDelete = restTemplate.exchange(dataUrl(frEventMessages.getTppId()), DELETE, null, Void.class);
+        // Then
+        assertThat(responseDelete.getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
+        assertThat(responseDelete.getBody()).isNull();
+
+        // When
+        final ResponseEntity<FREventMessages> responseExport = restTemplate.getForEntity(dataUrl(frEventMessages.getTppId()), FREventMessages.class);
+        // Then
+        assertThat(responseExport.getStatusCode()).isEqualTo(HttpStatus.OK);
+        // An apiClient with a collection of SETs
+        assertThat(Objects.requireNonNull(responseExport.getBody()).getTppId()).isNotNull().isEqualTo(frEventMessages.getTppId()).isEqualTo(frEventMessages.getTppId());
+        assertThat(Objects.requireNonNull(responseExport.getBody()).getEvents()).isEmpty();
+    }
+
+    @Test
+    public void shouldDeleteEventMessageByApiClientAndJti() {
+        // Given
+        final String jtiToDelete = UUID.randomUUID().toString();
+        FREventMessages frEventMessages = aValidFREventMessages(TPP_ID);
+        ResponseEntity<FREventMessages> response = restTemplate.postForEntity(dataUrl(), frEventMessages, FREventMessages.class);
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+        assertThat(Objects.requireNonNull(response.getBody()).getTppId()).isNotNull().isEqualTo(frEventMessages.getTppId());
+        assertThat(Objects.requireNonNull(response.getBody()).getEvents()).isEqualTo(frEventMessages.getEvents());
+        // adding new event message for the same apiClient ID
+        FREventMessages frEventMessages2 = aValidFREventMessages(
+                TPP_ID,
+                List.of(
+                        FREventMessage.builder()
+                                .jti(jtiToDelete)
+                                .set("TEST-JWT-TO-DELETE-eyJ0eXAiOiJKV1QiLCJodHRwOi8vb3BlbmJhbmtpbmcub3J")
+                                .build())
+        );
+        frEventMessages2.setTppId(frEventMessages.getTppId());
+        ResponseEntity<FREventMessages> response2 = restTemplate.postForEntity(dataUrl(), frEventMessages2, FREventMessages.class);
+        assertThat(response2.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+        assertThat(Objects.requireNonNull(response2.getBody()).getTppId()).isNotNull().isEqualTo(frEventMessages.getTppId());
+        assertThat(Objects.requireNonNull(response2.getBody()).getEvents()).isEqualTo(frEventMessages2.getEvents());
+
+        // When
+        ResponseEntity<FREventMessages> responseExport = restTemplate.getForEntity(dataUrl(frEventMessages2.getTppId()), FREventMessages.class);
+        // Then
+        assertThat(responseExport.getStatusCode()).isEqualTo(HttpStatus.OK);
+        // An apiClient with a collection of SETs
+        assertThat(Objects.requireNonNull(responseExport.getBody()).getTppId()).isNotNull().isEqualTo(frEventMessages2.getTppId()).isEqualTo(frEventMessages.getTppId());
+        List<FREventMessage> allEventMessages = new ArrayList<>();
+        allEventMessages.addAll(frEventMessages.getEvents());
+        allEventMessages.addAll(frEventMessages2.getEvents());
+        assertThat(Objects.requireNonNull(responseExport.getBody()).getEvents().size()).isEqualTo(allEventMessages.size());
+        assertThat(Objects.requireNonNull(responseExport.getBody()).getEvents()).containsExactlyInAnyOrderElementsOf(allEventMessages);
+
+        // When
+        ResponseEntity<Void> responseDelete = restTemplate.exchange(
+                dataUrl(frEventMessages.getTppId(), jtiToDelete),
+                DELETE,
+                null,
+                Void.class
+        );
+        // Then
+        assertThat(responseDelete.getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
+        assertThat(responseDelete.getBody()).isNull();
+
+        // When
+        ResponseEntity<FREventMessages> responseExportAfterDelete = restTemplate.getForEntity(dataUrl(frEventMessages.getTppId()), FREventMessages.class);
+        // Then
+        assertThat(responseExportAfterDelete.getStatusCode()).isEqualTo(HttpStatus.OK);
+        // An apiClient with a collection of SETs
+        assertThat(Objects.requireNonNull(responseExportAfterDelete.getBody()).getTppId()).isNotNull().isEqualTo(frEventMessages.getTppId()).isEqualTo(frEventMessages.getTppId());
+        assertThat(Objects.requireNonNull(responseExportAfterDelete.getBody()).getEvents()).containsOnlyOnceElementsOf(frEventMessages.getEvents());
+    }
+
+    private FREventMessages aValidFREventMessages() {
+        return aValidFREventMessages(UUID.randomUUID().toString(), aValidEventMessageList());
+    }
+
+    private FREventMessages aValidFREventMessages(String apiClientId) {
+        return aValidFREventMessages(apiClientId, aValidEventMessageList());
+    }
+
+    private FREventMessages aValidFREventMessages(String apiClientId, List<FREventMessage> eventMessages) {
+        return FREventMessages.builder()
+                .tppId(apiClientId)
+                .events(eventMessages)
+                .build();
+    }
+
+    private List<FREventMessage> aValidEventMessageList() {
+        return List.of(
+                FREventMessage.builder()
+                        .jti(UUID.randomUUID().toString())
+                        .set("TEST-JWT-01-eyJ0eXAiOiJKV1QiLCJodHRwOi8vb3BlbmJhbmtpbmcub3J")
+                        .build(),
+                FREventMessage.builder()
+                        .jti(UUID.randomUUID().toString())
+                        .set("TEST-JWT-02-eyJ0eXAiOiJKV1QiLCJodHRwOi8vb3BlbmJhbmtpbmcub3J")
+                        .build(),
+                FREventMessage.builder()
+                        .jti(UUID.randomUUID().toString())
+                        .set("TEST-JWT-03-eyJ0eXAiOiJKV1QiLCJodHRwOi8vb3BlbmJhbmtpbmcub3J")
+                        .build()
+        );
+    }
+
+    private String dataUrl(String tppId) {
+        return dataUrl() + "?tppId=" + tppId;
+    }
+
+    private String dataUrl(String tppId, String jti) {
+        return dataUrl(tppId) + "&jti=" + jti;
+    }
+
+    private String dataUrl() {
+        return BASE_URL + port + DATA_URI;
+    }
+}

--- a/secure-api-gateway-ob-uk-rs-resource-store/secure-api-gateway-ob-uk-rs-resource-store-api/src/test/java/com/forgerock/sapi/gateway/rs/resource/store/api/admin/events/DataEventsApiControllerTest.java
+++ b/secure-api-gateway-ob-uk-rs-resource-store/secure-api-gateway-ob-uk-rs-resource-store-api/src/test/java/com/forgerock/sapi/gateway/rs/resource/store/api/admin/events/DataEventsApiControllerTest.java
@@ -16,13 +16,12 @@
 package com.forgerock.sapi.gateway.rs.resource.store.api.admin.events;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowableOfType;
 import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
 import static org.springframework.http.HttpMethod.DELETE;
-import static org.springframework.http.HttpMethod.GET;
 import static org.springframework.http.HttpMethod.PUT;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
@@ -30,17 +29,19 @@ import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.web.server.LocalServerPort;
-import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestTemplate;
 
-import com.forgerock.sapi.gateway.rs.resource.store.datamodel.events.FREventMessages;
 import com.forgerock.sapi.gateway.rs.resource.store.datamodel.events.FREventMessage;
+import com.forgerock.sapi.gateway.rs.resource.store.datamodel.events.FREventMessages;
 import com.forgerock.sapi.gateway.rs.resource.store.repo.mongo.events.FREventMessageRepository;
 
 /**
@@ -48,12 +49,13 @@ import com.forgerock.sapi.gateway.rs.resource.store.repo.mongo.events.FREventMes
  */
 @SpringBootTest(webEnvironment = RANDOM_PORT)
 @ActiveProfiles("test")
+@TestPropertySource(properties = {"rs.data.upload.limit.events=10"})
 public class DataEventsApiControllerTest {
 
     private static final String BASE_URL = "http://localhost:";
     private static final String DATA_URI = "/admin/data/events";
 
-    private final String TPP_ID = UUID.randomUUID().toString();
+    private final String API_CLIENT_ID = UUID.randomUUID().toString();
 
     @LocalServerPort
     private int port;
@@ -69,8 +71,13 @@ public class DataEventsApiControllerTest {
         frEventMessageRepository.deleteAll();
     }
 
+    public final Integer eventsLimit;
+    public DataEventsApiControllerTest(@Value("${rs.data.upload.limit.events}") Integer eventsLimit) {
+        this.eventsLimit = eventsLimit;
+    }
+
     @Test
-    public void shouldCreateNewEventMessages() {
+    public void shouldCreateEventMessages() {
         // Given
         final FREventMessages frEventMessages = aValidFREventMessages();
         // When
@@ -78,8 +85,105 @@ public class DataEventsApiControllerTest {
 
         // Then
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
-        assertThat(Objects.requireNonNull(response.getBody()).getTppId()).isNotNull().isEqualTo(frEventMessages.getTppId());
+        assertThat(Objects.requireNonNull(response.getBody()).getApiClientId()).isNotNull().isEqualTo(frEventMessages.getApiClientId());
         assertThat(Objects.requireNonNull(response.getBody()).getEvents()).isEqualTo(frEventMessages.getEvents());
+    }
+
+    @Test
+    public void shouldExceedLimitAllowed() {
+        // Given
+        List<FREventMessage> frEventMessageList = new ArrayList<>();
+        frEventMessageList.addAll(aValidEventMessageList());
+        frEventMessageList.addAll(aValidEventMessageList());
+        frEventMessageList.addAll(aValidEventMessageList());
+        frEventMessageList.addAll(aValidEventMessageList());
+        frEventMessageList.addAll(aValidEventMessageList());
+        frEventMessageList.addAll(aValidEventMessageList());
+        final FREventMessages frEventMessages = aValidFREventMessages(API_CLIENT_ID, frEventMessageList);
+        // When
+        HttpClientErrorException exception = catchThrowableOfType(() ->
+                        restTemplate.postForEntity(dataUrl(), frEventMessages, FREventMessages.class),
+                HttpClientErrorException.class
+        );
+        // Then
+        assertThat(exception.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        assertThat(exception.getMessage()).contains(
+                String.format("The number of events provided in the payload (%d) exceeded maximum limit of %s", frEventMessageList.size(), eventsLimit)
+        );
+    }
+
+    @Test
+    public void shouldExceedLimitStoredAllowed() {
+        // Given
+        List<FREventMessage> frEventMessageList = new ArrayList<>();
+        frEventMessageList.addAll(aValidEventMessageList());
+        frEventMessageList.addAll(aValidEventMessageList());
+        frEventMessageList.addAll(aValidEventMessageList());
+        frEventMessageList.addAll(aValidEventMessageList());
+        frEventMessageList.addAll(aValidEventMessageList());
+        final FREventMessages frEventMessages = aValidFREventMessages(API_CLIENT_ID, frEventMessageList);
+        restTemplate.postForEntity(dataUrl(), frEventMessages, FREventMessages.class);
+        final FREventMessages moreFrEventMessages = aValidFREventMessages(API_CLIENT_ID);
+        // When
+        HttpClientErrorException exception = catchThrowableOfType(() ->
+                        restTemplate.postForEntity(dataUrl(), moreFrEventMessages, FREventMessages.class),
+                HttpClientErrorException.class
+        );
+        // Then
+        assertThat(exception.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        assertThat(exception.getMessage()).contains(
+                String.format("Cannot add events as it the stored events in the system has reached the maximum limit of %s, current events in the system %d", eventsLimit, frEventMessageList.size())
+        );
+    }
+
+    @Test
+    public void shouldExceedTotalEventsAllowed() {
+        // Given
+        List<FREventMessage> frEventMessageList = new ArrayList<>();
+        frEventMessageList.addAll(aValidEventMessageList());
+        frEventMessageList.addAll(aValidEventMessageList());
+        frEventMessageList.addAll(aValidEventMessageList());
+        final FREventMessages frEventMessages = aValidFREventMessages(API_CLIENT_ID, frEventMessageList);
+        restTemplate.postForEntity(dataUrl(), frEventMessages, FREventMessages.class);
+        final FREventMessages moreFrEventMessages = aValidFREventMessages(API_CLIENT_ID, frEventMessageList);
+        // When
+        HttpClientErrorException exception = catchThrowableOfType(() ->
+                        restTemplate.postForEntity(dataUrl(), moreFrEventMessages, FREventMessages.class),
+                HttpClientErrorException.class
+        );
+        // Then
+        assertThat(exception.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        assertThat(exception.getMessage()).contains(
+                String.format("Cannot add events as it will exceeded maximum limit of %s, current events in the system %d", eventsLimit, frEventMessageList.size())
+        );
+    }
+
+    @Test
+    public void shouldRaisedAndErrorWhenApiClientIdIsNull() {
+        // Given
+        final FREventMessages frEventMessages = aValidFREventMessages(null);
+        // When
+        HttpClientErrorException exception = catchThrowableOfType(() ->
+                        restTemplate.postForEntity(dataUrl(), frEventMessages, FREventMessages.class),
+                HttpClientErrorException.class
+        );
+        // Then
+        assertThat(exception.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        assertThat(exception.getMessage()).contains("The apiClientId cannot be null or empty");
+    }
+
+    @Test
+    public void shouldRaisedAndErrorWhenApiClientIdIsEmpty() {
+        // Given
+        final FREventMessages frEventMessages = aValidFREventMessages("");
+        // When
+        HttpClientErrorException exception = catchThrowableOfType(() ->
+                        restTemplate.postForEntity(dataUrl(), frEventMessages, FREventMessages.class),
+                HttpClientErrorException.class
+        );
+        // Then
+        assertThat(exception.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        assertThat(exception.getMessage()).contains("The apiClientId cannot be null or empty");
     }
 
     @Test
@@ -87,78 +191,52 @@ public class DataEventsApiControllerTest {
         // Given
         final String set = "set-jwt-00000011222";
 
-        FREventMessages frEventMessages = aValidFREventMessages(TPP_ID);
+        FREventMessages frEventMessages = aValidFREventMessages(API_CLIENT_ID);
         ResponseEntity<FREventMessages> response = restTemplate.postForEntity(dataUrl(), frEventMessages, FREventMessages.class);
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
-        assertThat(Objects.requireNonNull(response.getBody()).getTppId()).isNotNull().isEqualTo(frEventMessages.getTppId());
+        assertThat(Objects.requireNonNull(response.getBody()).getApiClientId()).isNotNull().isEqualTo(frEventMessages.getApiClientId());
         assertThat(Objects.requireNonNull(response.getBody()).getEvents()).isEqualTo(frEventMessages.getEvents());
 
-        FREventMessages frEventMessagesUpdate = aValidFREventMessages(TPP_ID, frEventMessages.getEvents());
+        FREventMessages frEventMessagesUpdate = aValidFREventMessages(API_CLIENT_ID, frEventMessages.getEvents());
         frEventMessagesUpdate.getEvents().forEach(eventMessage -> eventMessage.setSet(set));
 
         // When
         ResponseEntity<FREventMessages> responseUpdate = restTemplate.exchange(dataUrl(), PUT, new HttpEntity<>(frEventMessagesUpdate), FREventMessages.class);
         // Then
         assertThat(responseUpdate.getStatusCode()).isEqualTo(HttpStatus.OK);
-        assertThat(Objects.requireNonNull(responseUpdate.getBody()).getTppId()).isNotNull().isEqualTo(frEventMessages.getTppId()).isEqualTo(frEventMessagesUpdate.getTppId());
+        assertThat(Objects.requireNonNull(responseUpdate.getBody()).getApiClientId()).isNotNull().isEqualTo(frEventMessages.getApiClientId()).isEqualTo(frEventMessagesUpdate.getApiClientId());
         assertThat(Objects.requireNonNull(responseUpdate.getBody()).getEvents()).isEqualTo(frEventMessagesUpdate.getEvents());
 
         // When
-        ResponseEntity<FREventMessages> responseExport = restTemplate.getForEntity(dataUrl(frEventMessages.getTppId()), FREventMessages.class);
+        ResponseEntity<FREventMessages> responseExport = restTemplate.getForEntity(dataUrl(frEventMessages.getApiClientId()), FREventMessages.class);
         // Then
         assertThat(responseExport.getStatusCode()).isEqualTo(HttpStatus.OK);
         // An apiClient with a collection of SETs
-        assertThat(Objects.requireNonNull(responseExport.getBody()).getTppId()).isNotNull().isEqualTo(frEventMessages.getTppId()).isEqualTo(frEventMessages.getTppId());
+        assertThat(Objects.requireNonNull(responseExport.getBody()).getApiClientId()).isNotNull().isEqualTo(frEventMessages.getApiClientId()).isEqualTo(frEventMessages.getApiClientId());
         assertThat(Objects.requireNonNull(responseExport.getBody()).getEvents()).containsExactlyInAnyOrderElementsOf(frEventMessages.getEvents());
-
-    }
-
-    @Test
-    public void shouldExportEventMessages() {
-        // Given
-        // Creation of event messages for an api client (tpp id)
-        FREventMessages frEventMessages = aValidFREventMessages(UUID.randomUUID().toString());
-        ResponseEntity<FREventMessages> response = restTemplate.postForEntity(dataUrl(), frEventMessages, FREventMessages.class);
-        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
-        assertThat(Objects.requireNonNull(response.getBody()).getTppId()).isNotNull().isEqualTo(frEventMessages.getTppId());
-        assertThat(Objects.requireNonNull(response.getBody()).getEvents()).isEqualTo(frEventMessages.getEvents());
-        // creation of event message for another api client (tpp id)
-        FREventMessages frEventMessages2 = aValidFREventMessages(UUID.randomUUID().toString());
-        ResponseEntity<FREventMessages> response2 = restTemplate.postForEntity(dataUrl(), frEventMessages2, FREventMessages.class);
-        assertThat(response2.getStatusCode()).isEqualTo(HttpStatus.CREATED);
-        assertThat(Objects.requireNonNull(response2.getBody()).getTppId()).isNotNull().isEqualTo(frEventMessages2.getTppId());
-        assertThat(Objects.requireNonNull(response2.getBody()).getEvents()).isEqualTo(frEventMessages2.getEvents());
-
-        // When
-        ResponseEntity<Collection<FREventMessages>> responseExport = restTemplate.exchange(dataUrl() + "/all", GET, null, new ParameterizedTypeReference<>() {
-        });
-        // Then
-        assertThat(responseExport.getStatusCode()).isEqualTo(HttpStatus.OK);
-        Collection<FREventMessages> dataEvents = Objects.requireNonNull(responseExport.getBody());
-        assertThat(dataEvents).containsExactly(frEventMessages, frEventMessages2);
     }
 
     @Test
     public void shouldExportEventMessagesByApiClient() {
         // Given
-        FREventMessages frEventMessages = aValidFREventMessages(TPP_ID);
+        FREventMessages frEventMessages = aValidFREventMessages(API_CLIENT_ID);
         ResponseEntity<FREventMessages> response = restTemplate.postForEntity(dataUrl(), frEventMessages, FREventMessages.class);
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
-        assertThat(Objects.requireNonNull(response.getBody()).getTppId()).isNotNull().isEqualTo(frEventMessages.getTppId());
+        assertThat(Objects.requireNonNull(response.getBody()).getApiClientId()).isNotNull().isEqualTo(frEventMessages.getApiClientId());
         assertThat(Objects.requireNonNull(response.getBody()).getEvents()).isEqualTo(frEventMessages.getEvents());
 
-        FREventMessages frEventMessages2 = aValidFREventMessages(TPP_ID);
+        FREventMessages frEventMessages2 = aValidFREventMessages(API_CLIENT_ID);
         ResponseEntity<FREventMessages> response2 = restTemplate.postForEntity(dataUrl(), frEventMessages2, FREventMessages.class);
         assertThat(response2.getStatusCode()).isEqualTo(HttpStatus.CREATED);
-        assertThat(Objects.requireNonNull(response2.getBody()).getTppId()).isNotNull().isEqualTo(frEventMessages2.getTppId());
+        assertThat(Objects.requireNonNull(response2.getBody()).getApiClientId()).isNotNull().isEqualTo(frEventMessages2.getApiClientId());
         assertThat(Objects.requireNonNull(response2.getBody()).getEvents()).isEqualTo(frEventMessages2.getEvents());
 
         // When
-        ResponseEntity<FREventMessages> responseExport = restTemplate.getForEntity(dataUrl(frEventMessages2.getTppId()), FREventMessages.class);
+        ResponseEntity<FREventMessages> responseExport = restTemplate.getForEntity(dataUrl(frEventMessages2.getApiClientId()), FREventMessages.class);
         // Then
         assertThat(responseExport.getStatusCode()).isEqualTo(HttpStatus.OK);
         // An apiClient with a collection of SETs
-        assertThat(Objects.requireNonNull(responseExport.getBody()).getTppId()).isNotNull().isEqualTo(frEventMessages2.getTppId()).isEqualTo(frEventMessages.getTppId());
+        assertThat(Objects.requireNonNull(responseExport.getBody()).getApiClientId()).isNotNull().isEqualTo(frEventMessages2.getApiClientId()).isEqualTo(frEventMessages.getApiClientId());
         assertThat(Objects.requireNonNull(responseExport.getBody()).getEvents()).containsAll(frEventMessages.getEvents()).containsAll(frEventMessages2.getEvents());
     }
 
@@ -168,20 +246,20 @@ public class DataEventsApiControllerTest {
         final FREventMessages frEventMessages = aValidFREventMessages();
         final ResponseEntity<FREventMessages> response = restTemplate.postForEntity(dataUrl(), frEventMessages, FREventMessages.class);
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
-        assertThat(Objects.requireNonNull(response.getBody()).getTppId()).isNotNull().isEqualTo(frEventMessages.getTppId());
+        assertThat(Objects.requireNonNull(response.getBody()).getApiClientId()).isNotNull().isEqualTo(frEventMessages.getApiClientId());
         assertThat(Objects.requireNonNull(response.getBody()).getEvents()).isEqualTo(frEventMessages.getEvents());
 
-        final ResponseEntity<Void> responseDelete = restTemplate.exchange(dataUrl(frEventMessages.getTppId()), DELETE, null, Void.class);
+        final ResponseEntity<Void> responseDelete = restTemplate.exchange(dataUrl(frEventMessages.getApiClientId()), DELETE, null, Void.class);
         // Then
         assertThat(responseDelete.getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
         assertThat(responseDelete.getBody()).isNull();
 
         // When
-        final ResponseEntity<FREventMessages> responseExport = restTemplate.getForEntity(dataUrl(frEventMessages.getTppId()), FREventMessages.class);
+        final ResponseEntity<FREventMessages> responseExport = restTemplate.getForEntity(dataUrl(frEventMessages.getApiClientId()), FREventMessages.class);
         // Then
         assertThat(responseExport.getStatusCode()).isEqualTo(HttpStatus.OK);
         // An apiClient with a collection of SETs
-        assertThat(Objects.requireNonNull(responseExport.getBody()).getTppId()).isNotNull().isEqualTo(frEventMessages.getTppId()).isEqualTo(frEventMessages.getTppId());
+        assertThat(Objects.requireNonNull(responseExport.getBody()).getApiClientId()).isNotNull().isEqualTo(frEventMessages.getApiClientId()).isEqualTo(frEventMessages.getApiClientId());
         assertThat(Objects.requireNonNull(responseExport.getBody()).getEvents()).isEmpty();
     }
 
@@ -189,32 +267,32 @@ public class DataEventsApiControllerTest {
     public void shouldDeleteEventMessageByApiClientAndJti() {
         // Given
         final String jtiToDelete = UUID.randomUUID().toString();
-        FREventMessages frEventMessages = aValidFREventMessages(TPP_ID);
+        FREventMessages frEventMessages = aValidFREventMessages(API_CLIENT_ID);
         ResponseEntity<FREventMessages> response = restTemplate.postForEntity(dataUrl(), frEventMessages, FREventMessages.class);
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
-        assertThat(Objects.requireNonNull(response.getBody()).getTppId()).isNotNull().isEqualTo(frEventMessages.getTppId());
+        assertThat(Objects.requireNonNull(response.getBody()).getApiClientId()).isNotNull().isEqualTo(frEventMessages.getApiClientId());
         assertThat(Objects.requireNonNull(response.getBody()).getEvents()).isEqualTo(frEventMessages.getEvents());
         // adding new event message for the same apiClient ID
         FREventMessages frEventMessages2 = aValidFREventMessages(
-                TPP_ID,
+                API_CLIENT_ID,
                 List.of(
                         FREventMessage.builder()
                                 .jti(jtiToDelete)
                                 .set("TEST-JWT-TO-DELETE-eyJ0eXAiOiJKV1QiLCJodHRwOi8vb3BlbmJhbmtpbmcub3J")
                                 .build())
         );
-        frEventMessages2.setTppId(frEventMessages.getTppId());
+        frEventMessages2.setApiClientId(frEventMessages.getApiClientId());
         ResponseEntity<FREventMessages> response2 = restTemplate.postForEntity(dataUrl(), frEventMessages2, FREventMessages.class);
         assertThat(response2.getStatusCode()).isEqualTo(HttpStatus.CREATED);
-        assertThat(Objects.requireNonNull(response2.getBody()).getTppId()).isNotNull().isEqualTo(frEventMessages.getTppId());
+        assertThat(Objects.requireNonNull(response2.getBody()).getApiClientId()).isNotNull().isEqualTo(frEventMessages.getApiClientId());
         assertThat(Objects.requireNonNull(response2.getBody()).getEvents()).isEqualTo(frEventMessages2.getEvents());
 
         // When
-        ResponseEntity<FREventMessages> responseExport = restTemplate.getForEntity(dataUrl(frEventMessages2.getTppId()), FREventMessages.class);
+        ResponseEntity<FREventMessages> responseExport = restTemplate.getForEntity(dataUrl(frEventMessages2.getApiClientId()), FREventMessages.class);
         // Then
         assertThat(responseExport.getStatusCode()).isEqualTo(HttpStatus.OK);
         // An apiClient with a collection of SETs
-        assertThat(Objects.requireNonNull(responseExport.getBody()).getTppId()).isNotNull().isEqualTo(frEventMessages2.getTppId()).isEqualTo(frEventMessages.getTppId());
+        assertThat(Objects.requireNonNull(responseExport.getBody()).getApiClientId()).isNotNull().isEqualTo(frEventMessages2.getApiClientId()).isEqualTo(frEventMessages.getApiClientId());
         List<FREventMessage> allEventMessages = new ArrayList<>();
         allEventMessages.addAll(frEventMessages.getEvents());
         allEventMessages.addAll(frEventMessages2.getEvents());
@@ -223,7 +301,7 @@ public class DataEventsApiControllerTest {
 
         // When
         ResponseEntity<Void> responseDelete = restTemplate.exchange(
-                dataUrl(frEventMessages.getTppId(), jtiToDelete),
+                dataUrl(frEventMessages.getApiClientId(), jtiToDelete),
                 DELETE,
                 null,
                 Void.class
@@ -233,11 +311,11 @@ public class DataEventsApiControllerTest {
         assertThat(responseDelete.getBody()).isNull();
 
         // When
-        ResponseEntity<FREventMessages> responseExportAfterDelete = restTemplate.getForEntity(dataUrl(frEventMessages.getTppId()), FREventMessages.class);
+        ResponseEntity<FREventMessages> responseExportAfterDelete = restTemplate.getForEntity(dataUrl(frEventMessages.getApiClientId()), FREventMessages.class);
         // Then
         assertThat(responseExportAfterDelete.getStatusCode()).isEqualTo(HttpStatus.OK);
         // An apiClient with a collection of SETs
-        assertThat(Objects.requireNonNull(responseExportAfterDelete.getBody()).getTppId()).isNotNull().isEqualTo(frEventMessages.getTppId()).isEqualTo(frEventMessages.getTppId());
+        assertThat(Objects.requireNonNull(responseExportAfterDelete.getBody()).getApiClientId()).isNotNull().isEqualTo(frEventMessages.getApiClientId()).isEqualTo(frEventMessages.getApiClientId());
         assertThat(Objects.requireNonNull(responseExportAfterDelete.getBody()).getEvents()).containsOnlyOnceElementsOf(frEventMessages.getEvents());
     }
 
@@ -251,7 +329,7 @@ public class DataEventsApiControllerTest {
 
     private FREventMessages aValidFREventMessages(String apiClientId, List<FREventMessage> eventMessages) {
         return FREventMessages.builder()
-                .tppId(apiClientId)
+                .apiClientId(apiClientId)
                 .events(eventMessages)
                 .build();
     }
@@ -265,20 +343,16 @@ public class DataEventsApiControllerTest {
                 FREventMessage.builder()
                         .jti(UUID.randomUUID().toString())
                         .set("TEST-JWT-02-eyJ0eXAiOiJKV1QiLCJodHRwOi8vb3BlbmJhbmtpbmcub3J")
-                        .build(),
-                FREventMessage.builder()
-                        .jti(UUID.randomUUID().toString())
-                        .set("TEST-JWT-03-eyJ0eXAiOiJKV1QiLCJodHRwOi8vb3BlbmJhbmtpbmcub3J")
                         .build()
         );
     }
 
-    private String dataUrl(String tppId) {
-        return dataUrl() + "?tppId=" + tppId;
+    private String dataUrl(String apiClientId) {
+        return dataUrl() + "?apiClientId=" + apiClientId;
     }
 
-    private String dataUrl(String tppId, String jti) {
-        return dataUrl(tppId) + "&jti=" + jti;
+    private String dataUrl(String apiClientId, String jti) {
+        return dataUrl(apiClientId) + "&jti=" + jti;
     }
 
     private String dataUrl() {

--- a/secure-api-gateway-ob-uk-rs-resource-store/secure-api-gateway-ob-uk-rs-resource-store-api/src/test/resources/application-test.yml
+++ b/secure-api-gateway-ob-uk-rs-resource-store/secure-api-gateway-ob-uk-rs-resource-store-api/src/test/resources/application-test.yml
@@ -24,6 +24,7 @@ rs:
       limit:
         accounts: 100
         documents: 1000
+        events: 10
   obie:
     validation:
       # OBIE validation module to load, the "default" module is provided as standard with the simulator

--- a/secure-api-gateway-ob-uk-rs-resource-store/secure-api-gateway-ob-uk-rs-resource-store-datamodel/src/main/java/com/forgerock/sapi/gateway/rs/resource/store/datamodel/events/FREventMessage.java
+++ b/secure-api-gateway-ob-uk-rs-resource-store/secure-api-gateway-ob-uk-rs-resource-store-datamodel/src/main/java/com/forgerock/sapi/gateway/rs/resource/store/datamodel/events/FREventMessage.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.rs.resource.store.datamodel.events;
+
+import com.forgerock.sapi.gateway.ob.uk.common.datamodel.event.FREventPollingError;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class FREventMessage {
+    private String jti = null;
+    private String set = null;
+    private FREventPollingError errors;
+
+}

--- a/secure-api-gateway-ob-uk-rs-resource-store/secure-api-gateway-ob-uk-rs-resource-store-datamodel/src/main/java/com/forgerock/sapi/gateway/rs/resource/store/datamodel/events/FREventMessages.java
+++ b/secure-api-gateway-ob-uk-rs-resource-store/secure-api-gateway-ob-uk-rs-resource-store-datamodel/src/main/java/com/forgerock/sapi/gateway/rs/resource/store/datamodel/events/FREventMessages.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.rs.resource.store.datamodel.events;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class FREventMessages {
+    private String tppId;
+    private List<FREventMessage> events;
+
+    public FREventMessages events(List<FREventMessage> events) {
+        this.events = events;
+        return this;
+    }
+
+    public FREventMessages eventItem(FREventMessage event) {
+        if(Objects.isNull(events)) {
+            events = new ArrayList<>();
+        }
+        this.events.add(event);
+        return this;
+    }
+}

--- a/secure-api-gateway-ob-uk-rs-resource-store/secure-api-gateway-ob-uk-rs-resource-store-datamodel/src/main/java/com/forgerock/sapi/gateway/rs/resource/store/datamodel/events/FREventMessages.java
+++ b/secure-api-gateway-ob-uk-rs-resource-store/secure-api-gateway-ob-uk-rs-resource-store-datamodel/src/main/java/com/forgerock/sapi/gateway/rs/resource/store/datamodel/events/FREventMessages.java
@@ -29,7 +29,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @Builder
 public class FREventMessages {
-    private String tppId;
+    private String apiClientId;
     private List<FREventMessage> events;
 
     public FREventMessages events(List<FREventMessage> events) {

--- a/secure-api-gateway-ob-uk-rs-resource-store/secure-api-gateway-ob-uk-rs-resource-store-repo/src/main/java/com/forgerock/sapi/gateway/rs/resource/store/repo/entity/event/FREventMessageEntity.java
+++ b/secure-api-gateway-ob-uk-rs-resource-store/secure-api-gateway-ob-uk-rs-resource-store-repo/src/main/java/com/forgerock/sapi/gateway/rs/resource/store/repo/entity/event/FREventMessageEntity.java
@@ -39,7 +39,7 @@ import org.springframework.data.mongodb.core.mapping.Document;
 @AllArgsConstructor
 @Builder
 @Document
-public class FREventNotification implements Persistable<String> {
+public class FREventMessageEntity implements Persistable<String> {
 
     @Id
     @Indexed
@@ -48,10 +48,10 @@ public class FREventNotification implements Persistable<String> {
     @Indexed
     private String jti;
 
-    private String signedJwt;
+    private String set;
 
     @Indexed
-    private String tppId;
+    private String apiClientId;
 
     @CreatedDate
     private DateTime created;

--- a/secure-api-gateway-ob-uk-rs-resource-store/secure-api-gateway-ob-uk-rs-resource-store-repo/src/main/java/com/forgerock/sapi/gateway/rs/resource/store/repo/mongo/events/FREventMessageRepository.java
+++ b/secure-api-gateway-ob-uk-rs-resource-store/secure-api-gateway-ob-uk-rs-resource-store-repo/src/main/java/com/forgerock/sapi/gateway/rs/resource/store/repo/mongo/events/FREventMessageRepository.java
@@ -15,7 +15,7 @@
  */
 package com.forgerock.sapi.gateway.rs.resource.store.repo.mongo.events;
 
-import com.forgerock.sapi.gateway.rs.resource.store.repo.entity.event.FREventNotification;
+import com.forgerock.sapi.gateway.rs.resource.store.repo.entity.event.FREventMessageEntity;
 import org.springframework.data.mongodb.repository.MongoRepository;
 import org.springframework.data.repository.query.Param;
 
@@ -23,18 +23,18 @@ import java.util.Collection;
 import java.util.Optional;
 
 /**
- * Persistence for pending events generated within the sandbox so that we can track acknowledgement, error status and event history.
+ * Persistence for event messages generated within the sandbox so that we can track acknowledgement, error status and event history.
  * <p>
  * Events sent to a callback URL will not be stored here. If TPP does not have a callback URL then all events will be stored here until they are polled AND acknowledged.
- * Event polled but not acknowledged will remain here. Events with TPP reported errors against them will remain here for ever (for audit/investigation)
+ * Event polled but not acknowledged will remain here. Events with TPP reported errors against them will remain here forever (for audit/investigation)
  */
-public interface FRPendingEventsRepository extends MongoRepository<FREventNotification, String> {
+public interface FREventMessageRepository extends MongoRepository<FREventMessageEntity, String> {
 
-    Collection<FREventNotification> findByTppId(@Param("tppId") String tppId);
+    Collection<FREventMessageEntity> findByApiClientId(@Param("apiClientId") String apiClientId);
 
-    Optional<FREventNotification> findByTppIdAndJti(@Param("tppId") String tppId, @Param("jti") String jti);
+    Optional<FREventMessageEntity> findByApiClientIdAndJti(@Param("apiClientId") String apiClientId, @Param("jti") String jti);
 
-    void deleteByTppIdAndJti(@Param("tppId") String tppId, @Param("jti") String jti);
+    void deleteByApiClientIdAndJti(@Param("apiClientId") String apiClientId, @Param("jti") String jti);
 
-    void deleteByTppId(@Param("tppId") String tppId);
+    void deleteByApiClientId(@Param("apiClientId") String apiClientId);
 }

--- a/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/service/event/EventPollingService.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/service/event/EventPollingService.java
@@ -47,26 +47,26 @@ public class EventPollingService {
         this.frEventMessageRepository = frEventMessageRepository;
     }
 
-    public void acknowledgeEvents(FREventPolling frEventPolling, String tppId) {
-        Preconditions.checkNotNull(tppId);
+    public void acknowledgeEvents(FREventPolling frEventPolling, String apiClientId) {
+        Preconditions.checkNotNull(apiClientId);
         Preconditions.checkNotNull(frEventPolling);
 
         if (frEventPolling.getAck() != null && !frEventPolling.getAck().isEmpty()) {
-            log.debug("TPP '{}' is acknowledging (and therefore deleting) the following event notifications: {}", tppId, frEventPolling.getAck());
+            log.debug("TPP '{}' is acknowledging (and therefore deleting) the following event notifications: {}", apiClientId, frEventPolling.getAck());
             frEventPolling.getAck()
                     .forEach(
-                            jti -> frEventMessageRepository.deleteByApiClientIdAndJti(tppId, jti)
+                            jti -> frEventMessageRepository.deleteByApiClientIdAndJti(apiClientId, jti)
                     );
         }
     }
 
-    public void recordTppEventErrors(FREventPolling frEventPolling, String tppId) {
-        Preconditions.checkNotNull(tppId);
+    public void recordTppEventErrors(FREventPolling frEventPolling, String apiClientId) {
+        Preconditions.checkNotNull(apiClientId);
         Preconditions.checkNotNull(frEventPolling);
         if (frEventPolling.getSetErrs() != null && !frEventPolling.getSetErrs().isEmpty()) {
             log.debug("Persisting {} event notification errors for keys: {}", frEventPolling.getSetErrs().size(), frEventPolling.getSetErrs().keySet());
             frEventPolling.getSetErrs()
-                    .forEach((key, value) -> frEventMessageRepository.findByApiClientIdAndJti(tppId, key)
+                    .forEach((key, value) -> frEventMessageRepository.findByApiClientIdAndJti(apiClientId, key)
                             .ifPresent(event -> {
                                 event.setErrors(value);
                                 frEventMessageRepository.save(event);
@@ -75,18 +75,18 @@ public class EventPollingService {
 
     }
 
-    public Map<String, String> fetchNewEvents(FREventPolling frEventPolling, String tppId) throws OBErrorResponseException {
-        Preconditions.checkNotNull(tppId);
+    public Map<String, String> fetchNewEvents(FREventPolling frEventPolling, String apiClientId) throws OBErrorResponseException {
+        Preconditions.checkNotNull(apiClientId);
         Preconditions.checkNotNull(frEventPolling);
         if (frEventPolling.getMaxEvents() != null && frEventPolling.getMaxEvents() <= 0) {
             // Zero notifications can be requested by TPP when they just want to send acknowledgements and/or errors to sandbox
-            log.debug("Polling request for TPP: '{}' requested no event notifications so none will be returned", tppId);
+            log.debug("Polling request for TPP: '{}' requested no event notifications so none will be returned", apiClientId);
             return Collections.emptyMap();
         }
 
         // Long polling is currently optional in OB specs and as it requires more work to implement it will be left out for now.
         if (frEventPolling.getReturnImmediately() != null && !frEventPolling.isReturnImmediately()) {
-            log.warn("TPP: {} requested long polling on the event notification API but it is not supported", tppId);
+            log.warn("TPP: {} requested long polling on the event notification API but it is not supported", apiClientId);
             throw new OBErrorResponseException(
                     HttpStatus.NOT_IMPLEMENTED,
                     OBRIErrorResponseCategory.REQUEST_INVALID,
@@ -94,21 +94,21 @@ public class EventPollingService {
         }
 
         // Load all event notifications for TPP
-        log.debug("Loading all notifications for TPP: {}", tppId);
-        return frEventMessageRepository.findByApiClientId(tppId).stream()
+        log.debug("Loading all notifications for TPP: {}", apiClientId);
+        return frEventMessageRepository.findByApiClientId(apiClientId).stream()
                 .filter(event -> !event.hasErrors())
                 .collect(Collectors.toMap(FREventMessageEntity::getJti, FREventMessageEntity::getSet));
     }
 
-    public Map<String, String> truncateEvents(Integer maxEvents, Map<String, String> eventNotifications, String tppId) {
-        Preconditions.checkNotNull(tppId);
+    public Map<String, String> truncateEvents(Integer maxEvents, Map<String, String> eventNotifications, String apiClientId) {
+        Preconditions.checkNotNull(apiClientId);
         log.debug("Request to truncate {} event notification to be max of {}", eventNotifications.size(), maxEvents);
         if (eventNotifications.isEmpty()) {
             return eventNotifications; // Nothing to do
         }
 
         if (maxEvents == null || maxEvents > MAX_EVENTS) {
-            log.debug("TPP {} requested a number of event notifications ({}) on polling that exceeds that allowed maximum on the sandbox ({}). Only {} will be returned.", tppId, maxEvents, MAX_EVENTS, MAX_EVENTS);
+            log.debug("TPP {} requested a number of event notifications ({}) on polling that exceeds that allowed maximum on the sandbox ({}). Only {} will be returned.", apiClientId, maxEvents, MAX_EVENTS, MAX_EVENTS);
             maxEvents = MAX_EVENTS;
         }
 

--- a/secure-api-gateway-ob-uk-rs-server/src/main/resources/application.yml
+++ b/secure-api-gateway-ob-uk-rs-server/src/main/resources/application.yml
@@ -53,12 +53,15 @@ cloud:
 
 # RS config
 rs:
-  # Data creation limits (see com.forgerock.securebanking.openbanking.uk.rs.api.admin.data.DataCreator)
+  # Data creation limits
+  # see com.forgerock.securebanking.openbanking.uk.rs.api.admin.data.DataCreator
+  # see com.forgerock.sapi.gateway.rs.resource.store.api.admin.events.DataEventsApiController
   data:
     upload:
       limit:
         accounts: 100
         documents: 1000
+        events: 10
   obie:
     validation:
       # OBIE validation module to load, the "default" module is provided as standard with the simulator

--- a/secure-api-gateway-ob-uk-rs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/event/v3_1_2/aggregatedpolling/AggregatedPollingApiControllerTest.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/event/v3_1_2/aggregatedpolling/AggregatedPollingApiControllerTest.java
@@ -65,11 +65,11 @@ public class AggregatedPollingApiControllerTest {
     @Test
     public void shouldPollEvents() {
         // Given
-        String tppId = UUID.randomUUID().toString();
-        FREventMessageEntity frEventMessageEntity = aValidFREventNotificationEntityBuilder(tppId).build();
+        String apiClientId = UUID.randomUUID().toString();
+        FREventMessageEntity frEventMessageEntity = aValidFREventNotificationEntityBuilder(apiClientId).build();
         pendingEventsRepository.save(frEventMessageEntity);
         OBEventPolling1 obEventPolling = aValidOBEventPolling1();
-        HttpHeaders headers = HttpHeadersTestDataFactory.requiredEventHttpHeaders(eventsUrl(), tppId);
+        HttpHeaders headers = HttpHeadersTestDataFactory.requiredEventHttpHeaders(eventsUrl(), apiClientId);
         HttpEntity<OBEventPolling1> request = new HttpEntity<>(obEventPolling, headers);
 
         // When
@@ -84,13 +84,13 @@ public class AggregatedPollingApiControllerTest {
     @Test
     public void shouldAcknowledgeEvents() {
         // Given
-        String tppId = UUID.randomUUID().toString();
-        FREventMessageEntity frEventMessageEntity = aValidFREventNotificationEntityBuilder(tppId).build();
+        String apiClientId = UUID.randomUUID().toString();
+        FREventMessageEntity frEventMessageEntity = aValidFREventNotificationEntityBuilder(apiClientId).build();
         pendingEventsRepository.save(frEventMessageEntity);
         OBEventPolling1 obEventPolling = aValidOBEventPolling1();
         // set the ACK for acknowledgement
         obEventPolling.setAck(List.of(frEventMessageEntity.getJti()));
-        HttpHeaders headers = HttpHeadersTestDataFactory.requiredEventHttpHeaders(eventsUrl(), tppId);
+        HttpHeaders headers = HttpHeadersTestDataFactory.requiredEventHttpHeaders(eventsUrl(), apiClientId);
         HttpEntity<OBEventPolling1> request = new HttpEntity<>(obEventPolling, headers);
 
         // When
@@ -106,12 +106,12 @@ public class AggregatedPollingApiControllerTest {
         return BASE_URL + port + EVENTS_URI;
     }
 
-    private FREventMessageEntity.FREventMessageEntityBuilder aValidFREventNotificationEntityBuilder(String tppId) {
+    private FREventMessageEntity.FREventMessageEntityBuilder aValidFREventNotificationEntityBuilder(String apiClientId) {
         return FREventMessageEntity.builder()
                 .id(UUID.randomUUID().toString())
                 .jti(UUID.randomUUID().toString())
                 .set("eyJraWQiOiJkOGFiMzI4N2QxZTI4MDc0NDFjMWM4Yjc0MGNjYWQ3MTBiMjM2MDI4IiwiYWxnIjoiUFMyNTYifQ.eyJhdWQiOiI3dW14NW5UUjMzODExUXlRZmkiLCJzdWIiOiJodHRwczpcL1wvZXhhbXBsZWJhbmsuY29tXC9hcGlcL29wZW4tYmFua2luZ1wvdjMuMS4yXC9waXNwXC9kb21lc3RpYy1wYXltZW50c1wvcG10LTcyOTAtMDAzIiwiaXNzIjoiaHR0cHM6XC9cL2FzLmFzcHNwLnNhbmRib3gubGxveWRzYmFua2luZy5jb21cL29hdXRoMiIsInR4biI6ImRmYzUxNjI4LTM0NzktNGI4MS1hZDYwLTIxMGI0M2QwMjMwNiIsInRvZSI6MTUxNjIzOTAyMiwiaWF0IjoxNjE2NTk2NTg1LCJqdGkiOiJkYzY0OTkzMy0zMDc3LTRhZGItOGFjNy0xYmRjODA1Y2M2MTEiLCJldmVudHMiOnsidXJuOnVrOm9yZzpvcGVuYmFua2luZzpldmVudHM6cmVzb3VyY2UtdXBkYXRlIjp7InN1YmplY3QiOnsiaHR0cDpcL1wvb3BlbmJhbmtpbmcub3JnLnVrXC9yaWQiOiJwbXQtNzI5MC0wMDMiLCJzdWJqZWN0X3R5cGUiOiJodHRwOlwvXC9vcGVuYmFua2luZy5vcmcudWtcL3JpZF9odHRwOlwvXC9vcGVuYmFua2luZy5vcmcudWtcL3J0eSIsImh0dHA6XC9cL29wZW5iYW5raW5nLm9yZy51a1wvcmxrIjpbeyJsaW5rIjoiaHR0cHM6XC9cL2V4YW1wbGViYW5rLmNvbVwvYXBpXC9vcGVuLWJhbmtpbmdcL3YzLjEuMlwvcGlzcFwvZG9tZXN0aWMtcGF5bWVudHNcL3BtdC03MjkwLTAwMyIsInZlcnNpb24iOiIzLjEuMiJ9XSwiaHR0cDpcL1wvb3BlbmJhbmtpbmcub3JnLnVrXC9ydHkiOiJkb21lc3RpYy1wYXltZW50In19fX0.kgaGq6mN3Gso7er_bKXLQF0cTc4LtHKaVRErtTOhIYzLds2af8NKPhCHcqs74epEfYb_IZc8onKJEUpjiCKDKCipLyzHUD2DFxPd3BCTVAlP1eXDTDuWSa5ZwcrINEwNfeBLbyqOp1oTS5VUJ_ld9d7ovERr271DipZ4OXTC5AR04T2BzK4GlU4ekjqOaYulVD3GLWNZuFfoVXeyPPr9t-q1SPZLGmR_e3kRETxn_v32JzIQx8iN8ACOkOvMEXYA_mKhbSiwj4i_9_O9lOYBJo2BQClfC5vcxrnNSmg5tu0V-nYw-4q4IajwhNKBIbO7yZhS6y7QWXPgeUbZEv3luA")
-                .apiClientId(tppId);
+                .apiClientId(apiClientId);
     }
 
     private OBEventPolling1 aValidOBEventPolling1() {

--- a/secure-api-gateway-ob-uk-rs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/server/service/event/EventPollingServiceTest.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/server/service/event/EventPollingServiceTest.java
@@ -42,7 +42,7 @@ import static org.mockito.Mockito.*;
  */
 @ExtendWith(MockitoExtension.class)
 public class EventPollingServiceTest {
-    private static final String TPP_ID = "abc123";
+    private static final String API_CLIENT_ID = "abc123";
 
     @Mock
     private FREventMessageRepository mockRepo;
@@ -57,11 +57,11 @@ public class EventPollingServiceTest {
                 .build();
 
         // When
-        eventPollingService.acknowledgeEvents(pollingRequest, TPP_ID);
+        eventPollingService.acknowledgeEvents(pollingRequest, API_CLIENT_ID);
 
         // Then
-        verify(mockRepo).deleteByApiClientIdAndJti(eq(TPP_ID), eq("11111"));
-        verify(mockRepo).deleteByApiClientIdAndJti(eq(TPP_ID), eq("11111"));
+        verify(mockRepo).deleteByApiClientIdAndJti(eq(API_CLIENT_ID), eq("11111"));
+        verify(mockRepo).deleteByApiClientIdAndJti(eq(API_CLIENT_ID), eq("11111"));
     }
 
     @Test
@@ -72,7 +72,7 @@ public class EventPollingServiceTest {
                 .build();
 
         // When
-        eventPollingService.acknowledgeEvents(pollingRequest, TPP_ID);
+        eventPollingService.acknowledgeEvents(pollingRequest, API_CLIENT_ID);
 
         // Then
         verifyNoMoreInteractions(mockRepo);
@@ -86,7 +86,7 @@ public class EventPollingServiceTest {
                 .build();
 
         // When
-        eventPollingService.acknowledgeEvents(pollingRequest, TPP_ID);
+        eventPollingService.acknowledgeEvents(pollingRequest, API_CLIENT_ID);
 
         // Then
         verifyNoMoreInteractions(mockRepo);
@@ -106,7 +106,7 @@ public class EventPollingServiceTest {
         when(mockRepo.findByApiClientIdAndJti(any(), any())).thenReturn(Optional.of(existingNotification));
 
         // When
-        eventPollingService.recordTppEventErrors(pollingRequest, TPP_ID);
+        eventPollingService.recordTppEventErrors(pollingRequest, API_CLIENT_ID);
 
         // Then
         verify(mockRepo, times(1)).save(any());
@@ -123,7 +123,7 @@ public class EventPollingServiceTest {
         when(mockRepo.findByApiClientIdAndJti(any(), any())).thenReturn(Optional.empty());
 
         // When
-        eventPollingService.recordTppEventErrors(pollingRequest, TPP_ID);
+        eventPollingService.recordTppEventErrors(pollingRequest, API_CLIENT_ID);
 
         // Then
         verify(mockRepo, times(0)).save(any());
@@ -137,7 +137,7 @@ public class EventPollingServiceTest {
                 .build();
 
         // When
-        eventPollingService.recordTppEventErrors(pollingRequest, TPP_ID);
+        eventPollingService.recordTppEventErrors(pollingRequest, API_CLIENT_ID);
 
         // Then
         verifyNoMoreInteractions(mockRepo);
@@ -156,14 +156,14 @@ public class EventPollingServiceTest {
                 .jti("22222")
                 .set("test222")
                 .build();
-        when(mockRepo.findByApiClientId(eq(TPP_ID))).thenReturn(ImmutableList.of(existingNotification1, existingNotification2));
+        when(mockRepo.findByApiClientId(eq(API_CLIENT_ID))).thenReturn(ImmutableList.of(existingNotification1, existingNotification2));
 
         // When
         FREventPolling pollingRequest = FREventPolling.builder()
                 .maxEvents(100)
                 .returnImmediately(true)
                 .build();
-        Map<String, String> eventNotifications = eventPollingService.fetchNewEvents(pollingRequest, TPP_ID);
+        Map<String, String> eventNotifications = eventPollingService.fetchNewEvents(pollingRequest, API_CLIENT_ID);
 
         // Then
         assertThat(eventNotifications.size()).isEqualTo(2);
@@ -185,14 +185,14 @@ public class EventPollingServiceTest {
                 .set("test222")
                 .errors(FREventPollingError.builder().error("err1").description("error").build())
                 .build();
-        when(mockRepo.findByApiClientId(eq(TPP_ID))).thenReturn(ImmutableList.of(existingNotificationWithoutError, existingNotificationWithError));
+        when(mockRepo.findByApiClientId(eq(API_CLIENT_ID))).thenReturn(ImmutableList.of(existingNotificationWithoutError, existingNotificationWithError));
 
         // When
         FREventPolling pollingRequest = FREventPolling.builder()
                 .maxEvents(null) // Do not restrict
                 .returnImmediately(true)
                 .build();
-        Map<String, String> eventNotifications = eventPollingService.fetchNewEvents(pollingRequest, TPP_ID);
+        Map<String, String> eventNotifications = eventPollingService.fetchNewEvents(pollingRequest, API_CLIENT_ID);
 
         // Then
         assertThat(eventNotifications.size()).isEqualTo(1);
@@ -206,7 +206,7 @@ public class EventPollingServiceTest {
                 .maxEvents(0)
                 .returnImmediately(true)
                 .build();
-        Map<String, String> eventNotifications = eventPollingService.fetchNewEvents(pollingRequest, TPP_ID);
+        Map<String, String> eventNotifications = eventPollingService.fetchNewEvents(pollingRequest, API_CLIENT_ID);
 
         // Then
         assertThat(eventNotifications.size()).isEqualTo(0);
@@ -224,7 +224,7 @@ public class EventPollingServiceTest {
 
         assertThatThrownBy(() ->
                 // When
-                eventPollingService.fetchNewEvents(pollingRequest, TPP_ID))
+                eventPollingService.fetchNewEvents(pollingRequest, API_CLIENT_ID))
                 // Then
                 .isInstanceOf(OBErrorResponseException.class);
     }
@@ -236,7 +236,7 @@ public class EventPollingServiceTest {
         ImmutableMap<String, String> allEventsMap = ImmutableMap.of("11111", "jwt1", "22222", "jwt2", "33333", "jwt3");
 
         // When
-        Map<String, String> truncatedEvents = eventPollingService.truncateEvents(maxEventsParam, allEventsMap, TPP_ID);
+        Map<String, String> truncatedEvents = eventPollingService.truncateEvents(maxEventsParam, allEventsMap, API_CLIENT_ID);
 
         // Then
         assertThat(truncatedEvents.size()).isEqualTo(2);
@@ -245,7 +245,7 @@ public class EventPollingServiceTest {
     @Test
     public void truncateEvents_noEvents_doNothing() {
         // When
-        Map<String, String> truncatedEvents = eventPollingService.truncateEvents(2, Collections.emptyMap(), TPP_ID);
+        Map<String, String> truncatedEvents = eventPollingService.truncateEvents(2, Collections.emptyMap(), API_CLIENT_ID);
 
         // Then
         assertThat(truncatedEvents.size()).isEqualTo(0);


### PR DESCRIPTION
- Added admin data events API from the TPP can import, export, update and delete event messages
- Upgrade commons version to 2.0.2-SNAPSHOT

Issue: https://github.com/SecureApiGateway/SecureApiGateway/issues/998