### PR TITLE
998: Defaulting property rs.data.upload.limit.events in annotation

### DIFF
--- a/secure-api-gateway-ob-uk-rs-resource-store/secure-api-gateway-ob-uk-rs-resource-store-api/src/main/java/com/forgerock/sapi/gateway/rs/resource/store/api/admin/events/DataEventsApiController.java
+++ b/secure-api-gateway-ob-uk-rs-resource-store/secure-api-gateway-ob-uk-rs-resource-store-api/src/main/java/com/forgerock/sapi/gateway/rs/resource/store/api/admin/events/DataEventsApiController.java
@@ -42,12 +42,12 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class DataEventsApiController implements DataEventsApi {
     private final FREventMessageRepository frEventMessageRepository;
-    private final Integer eventsLimit;
+    private final int eventsLimit;
 
     @Autowired
     public DataEventsApiController(
             FREventMessageRepository frEventMessageRepository,
-            @Value("${rs.data.upload.limit.events}") Integer eventsLimit
+            @Value("${rs.data.upload.limit.events:10}") int eventsLimit
     ) {
         this.frEventMessageRepository = frEventMessageRepository;
         this.eventsLimit = eventsLimit;


### PR DESCRIPTION
Defaulting rs.data.upload.limit.events property in the annotation to 10. This makes upgrading easier for extensions projects which have their own spring configuration file.

https://github.com/SecureApiGateway/SecureApiGateway/issues/998