### PR TITLE
1123: Changing BasePaymentFileProcessor.processFileImpl to throw OBErrorException

### DIFF
--- a/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/common/payment/file/processor/OBIEPain001FileProcessor.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/common/payment/file/processor/OBIEPain001FileProcessor.java
@@ -29,7 +29,8 @@ import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 
 import com.forgerock.sapi.gateway.ob.uk.common.datamodel.payment.FRFilePayment;
-import com.forgerock.sapi.gateway.ob.uk.common.error.FileParseException;
+import com.forgerock.sapi.gateway.ob.uk.common.error.OBErrorException;
+import com.forgerock.sapi.gateway.ob.uk.common.error.OBRIErrorType;
 import com.forgerock.sapi.gateway.ob.uk.rs.server.common.payment.file.DefaultPaymentFileType;
 import com.forgerock.sapi.gateway.ob.uk.rs.server.common.payment.file.PaymentFile;
 import com.forgerock.sapi.gateway.ob.uk.rs.server.common.payment.file.jaxb.pain001.CreditTransferTransaction26;
@@ -48,7 +49,7 @@ public class OBIEPain001FileProcessor extends BasePaymentFileProcessor {
     }
 
     @Override
-    protected PaymentFile processFileImpl(String fileContent) throws FileParseException {
+    protected PaymentFile processFileImpl(String fileContent) throws OBErrorException {
         try {
             logger.debug("Attempt to unmarshal XML '{}'", fileContent);
             Document document = JAXB.unmarshal(new StringReader(fileContent), Document.class);
@@ -66,7 +67,7 @@ public class OBIEPain001FileProcessor extends BasePaymentFileProcessor {
             return createPaymentFile(payments, controlSum);
         } catch (Exception e) {
             logger.warn("JAXB exception while attempting to unmarshal: {}", fileContent, e);
-            throw new FileParseException("Invalid XML", e);
+            throw new OBErrorException(OBRIErrorType.REQUEST_FILE_INVALID, e.getMessage());
         }
     }
     

--- a/secure-api-gateway-ob-uk-rs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/server/common/payment/file/BasePaymentFileProcessorTest.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/server/common/payment/file/BasePaymentFileProcessorTest.java
@@ -22,8 +22,11 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
 
 import com.forgerock.sapi.gateway.ob.uk.common.error.OBErrorException;
+import com.forgerock.sapi.gateway.ob.uk.common.error.OBRIErrorType;
 import com.forgerock.sapi.gateway.ob.uk.rs.server.common.payment.file.processor.PaymentFileProcessor;
 import com.forgerock.sapi.gateway.ob.uk.rs.server.util.payment.file.TestPaymentFileResources;
 import com.forgerock.sapi.gateway.ob.uk.rs.server.util.payment.file.TestPaymentFileResources.TestPaymentFile;
@@ -54,6 +57,17 @@ public abstract class BasePaymentFileProcessorTest {
         assertThat(paymentFileResult.getControlSum()).isEqualByComparingTo(testPaymentFile.getControlSum());
         assertThat(paymentFileResult.getNumberOfTransactions()).isEqualTo(testPaymentFile.getNumTransactions());
         assertThat(paymentFileResult.getFileType()).isEqualTo(testPaymentFile.getFileType());
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    void shouldThrowOBErrorForEmptyFile(String fileContent) {
+        final Throwable throwable = catchThrowable(() -> paymentFileProcessor.processFile(fileContent));
+        assertThat(throwable).isInstanceOf(OBErrorException.class);
+
+        final OBErrorException obErrorException = (OBErrorException) throwable;
+        assertThat(obErrorException.getOBError().getErrorCode()).isEqualTo(OBRIErrorType.REQUEST_FILE_EMPTY.getCode().toString());
+        assertThat(obErrorException.getOBError().getMessage()).startsWith(OBRIErrorType.REQUEST_FILE_EMPTY.getMessage());
     }
 
     @Test


### PR DESCRIPTION
The FileParseException does not allow implementations enough flexibility in choosing specific error codes to return to the user. Changing processFileImpl method to throw OBErrorException so that subclasses are able to specify the errorCode.

https://github.com/SecureApiGateway/SecureApiGateway/issues/1123