### PR TITLE
1133: Adding validation framework support for VRP Funds Confirmation Requests

### DIFF
--- a/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/configuration/validation/DefaultOBValidationModule.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/configuration/validation/DefaultOBValidationModule.java
@@ -52,6 +52,8 @@ import com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.payment.OBWriteIntern
 import com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.payment.OBWriteInternationalStandingOrder4Validator;
 import com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.payment.OBWriteInternationalStandingOrder4Validator.OBWriteInternationalStandingOrder4ValidationContext;
 import com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.payment.consent.OBDomesticVRPConsentRequestValidator;
+import com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.payment.consent.OBVRPFundsConfirmationRequestValidator;
+import com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.payment.consent.OBVRPFundsConfirmationRequestValidator.VRPFundsConfirmationValidationContext;
 import com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.payment.consent.OBWriteDomesticConsent4Validator;
 import com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.payment.consent.OBWriteDomesticScheduledConsent4Validator;
 import com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.payment.consent.OBWriteDomesticStandingOrderConsent5Validator;
@@ -127,6 +129,11 @@ public class DefaultOBValidationModule {
     @Bean
     public OBValidationService<OBDomesticVRPConsentRequest> domesticVRPConsentValidator(BaseOBValidator<OBRisk1> riskValidator) {
         return new OBValidationService<>(new OBDomesticVRPConsentRequestValidator(riskValidator));
+    }
+
+    @Bean
+    public OBValidationService<VRPFundsConfirmationValidationContext> domesticVRPFundsConfirmationValidator() {
+        return new OBValidationService<>(new OBVRPFundsConfirmationRequestValidator());
     }
 
     @Bean

--- a/secure-api-gateway-ob-uk-rs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/v3_1_10/vrp/DomesticVrpConsentsApiControllerTest.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/v3_1_10/vrp/DomesticVrpConsentsApiControllerTest.java
@@ -353,11 +353,15 @@ public class DomesticVrpConsentsApiControllerTest {
     @Test
     public void shouldRaiseBadRequestConsentIdMismatch() {
         // Given
+        final DomesticVRPConsent consent = buildAwaitingAuthorisationConsent(createValidateConsentRequest());
         final String consentId = UUID.randomUUID().toString();
+
+        given(consentStoreClient.getConsent(eq(consentId), eq(TEST_API_CLIENT_ID))).willReturn(consent);
+
         final BigDecimal instructedAmount = new BigDecimal("50.00").setScale(2);
         final OBVRPFundsConfirmationRequest obvrpFundsConfirmationRequest = new OBVRPFundsConfirmationRequest()
                 .data(new OBVRPFundsConfirmationRequestData()
-                        .consentId(consentId)
+                        .consentId("id does not match request")
                         .reference("reference")
                         .instructedAmount(new OBActiveOrHistoricCurrencyAndAmount()
                                 .amount(instructedAmount.toPlainString())
@@ -371,7 +375,7 @@ public class DomesticVrpConsentsApiControllerTest {
 
         // When
         ResponseEntity<OBErrorResponse1> response = restTemplate.postForEntity(
-                getFundsConfirmationUrl(UUID.randomUUID().toString()),
+                getFundsConfirmationUrl(consentId),
                 request,
                 OBErrorResponse1.class
         );

--- a/secure-api-gateway-ob-uk-rs-validation/secure-api-gateway-ob-uk-rs-validation-obie/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/validation/obie/payment/consent/OBVRPFundsConfirmationRequestValidator.java
+++ b/secure-api-gateway-ob-uk-rs-validation/secure-api-gateway-ob-uk-rs-validation-obie/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/validation/obie/payment/consent/OBVRPFundsConfirmationRequestValidator.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.payment.consent;
+
+import com.forgerock.sapi.gateway.ob.uk.common.error.OBRIErrorType;
+import com.forgerock.sapi.gateway.ob.uk.rs.validation.ValidationResult;
+import com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.BaseOBValidator;
+import com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.payment.consent.OBVRPFundsConfirmationRequestValidator.VRPFundsConfirmationValidationContext;
+
+import uk.org.openbanking.datamodel.error.OBError1;
+import uk.org.openbanking.datamodel.vrp.OBDomesticVRPConsentResponseData.StatusEnum;
+import uk.org.openbanking.datamodel.vrp.OBVRPFundsConfirmationRequest;
+import uk.org.openbanking.datamodel.vrp.OBVRPFundsConfirmationRequestData;
+
+/**
+ * Validator of OBVRPFundsConfirmationRequest objects.
+ *
+ * Validates the following:
+ * - consentId from the access_token matches the consentId inside the OBVRPFundsConfirmationRequest
+ * - consentStatus is Authorised
+ */
+public class OBVRPFundsConfirmationRequestValidator extends BaseOBValidator<VRPFundsConfirmationValidationContext> {
+
+    public static class VRPFundsConfirmationValidationContext {
+        /**
+         * This is the consentId obtained from the access_token
+         */
+        private final String consentId;
+        private final String consentStatus;
+        private final OBVRPFundsConfirmationRequest vrpFundsConfirmationRequest;
+
+        public VRPFundsConfirmationValidationContext(String consentId, String consentStatus,
+                                                     OBVRPFundsConfirmationRequest vrpFundsConfirmationRequest) {
+            this.consentId = consentId;
+            this.consentStatus = consentStatus;
+            this.vrpFundsConfirmationRequest = vrpFundsConfirmationRequest;
+        }
+
+        public String getConsentId() {
+            return consentId;
+        }
+
+        public String getConsentStatus() {
+            return consentStatus;
+        }
+
+        public OBVRPFundsConfirmationRequest getVrpFundsConfirmationRequest() {
+            return vrpFundsConfirmationRequest;
+        }
+    }
+
+    @Override
+    protected void validate(VRPFundsConfirmationValidationContext fundsConfValidationCtxt, ValidationResult<OBError1> validationResult) {
+        final OBVRPFundsConfirmationRequestData fundsConfirmationRequestData = fundsConfValidationCtxt.getVrpFundsConfirmationRequest().getData();
+        if (!fundsConfirmationRequestData.getConsentId().equals(fundsConfValidationCtxt.consentId)) {
+            validationResult.addError(OBRIErrorType.REQUEST_OBJECT_INVALID.toOBError1("The consentId provided in the body doesn't match with the consent id provided as parameter"));
+        }
+
+        final String consentStatus = fundsConfValidationCtxt.getConsentStatus();
+        if (!StatusEnum.AUTHORISED.toString().equals(consentStatus)) {
+            validationResult.addError(OBRIErrorType.CONSENT_STATUS_NOT_AUTHORISED.toOBError1(consentStatus));
+        }
+    }
+}

--- a/secure-api-gateway-ob-uk-rs-validation/secure-api-gateway-ob-uk-rs-validation-obie/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/validation/obie/payment/consent/OBVRPFundsConfirmationRequestValidatorTest.java
+++ b/secure-api-gateway-ob-uk-rs-validation/secure-api-gateway-ob-uk-rs-validation-obie/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/validation/obie/payment/consent/OBVRPFundsConfirmationRequestValidatorTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.payment.consent;
+
+import static com.forgerock.sapi.gateway.ob.uk.rs.validation.ValidationResultTest.validateErrorResult;
+import static com.forgerock.sapi.gateway.ob.uk.rs.validation.ValidationResultTest.validateSuccessResult;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import com.forgerock.sapi.gateway.ob.uk.common.error.OBRIErrorType;
+import com.forgerock.sapi.gateway.ob.uk.rs.validation.ValidationResult;
+import com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.payment.consent.OBVRPFundsConfirmationRequestValidator.VRPFundsConfirmationValidationContext;
+
+import uk.org.openbanking.datamodel.common.OBActiveOrHistoricCurrencyAndAmount;
+import uk.org.openbanking.datamodel.error.OBError1;
+import uk.org.openbanking.datamodel.vrp.OBDomesticVRPConsentResponseData.StatusEnum;
+import uk.org.openbanking.datamodel.vrp.OBVRPFundsConfirmationRequest;
+import uk.org.openbanking.datamodel.vrp.OBVRPFundsConfirmationRequestData;
+
+class OBVRPFundsConfirmationRequestValidatorTest {
+
+    private final OBVRPFundsConfirmationRequestValidator validator = new OBVRPFundsConfirmationRequestValidator();
+
+    private OBVRPFundsConfirmationRequest createValidFundsConfirmationRequest(String consentId, BigDecimal amount) {
+        return new OBVRPFundsConfirmationRequest()
+                .data(new OBVRPFundsConfirmationRequestData()
+                            .consentId(consentId)
+                            .reference("reference")
+                            .instructedAmount(new OBActiveOrHistoricCurrencyAndAmount()
+                                                    .amount(amount.toPlainString())
+                                                    .currency("GBP")));
+    }
+
+
+    @Test
+    void testValidConsentPasses() {
+        final String consentId = "1234";
+        final OBVRPFundsConfirmationRequest fundsConfRequest = createValidFundsConfirmationRequest(consentId, new BigDecimal("99.21"));
+        validateSuccessResult(validator.validate(new VRPFundsConfirmationValidationContext(consentId, "Authorised", fundsConfRequest)));
+    }
+
+    @Test
+    void failsWhenConsentIdMismatch() {
+        final OBVRPFundsConfirmationRequest fundsConfRequest = createValidFundsConfirmationRequest("9999", new BigDecimal("99.21"));
+        final ValidationResult<OBError1> validationResult = validator.validate(new VRPFundsConfirmationValidationContext("1111", "Authorised", fundsConfRequest));
+        validateErrorResult(validationResult, List.of(OBRIErrorType.REQUEST_OBJECT_INVALID.toOBError1("The consentId provided in the body doesn't match with the consent id provided as parameter")));
+    }
+
+    @Test
+    void failsWhenConsentNotAuthorised() {
+        final String consentId = "1234";
+        final OBVRPFundsConfirmationRequest fundsConfRequest = createValidFundsConfirmationRequest(consentId, new BigDecimal("99.21"));
+        final String[] invalidStatuses = new String[] {
+                StatusEnum.AWAITINGAUTHORISATION.toString(), StatusEnum.REJECTED.toString()
+        };
+
+        for (final String invalidStatus : invalidStatuses) {
+            final ValidationResult<OBError1> validationResult = validator.validate(new VRPFundsConfirmationValidationContext(consentId, invalidStatus, fundsConfRequest));
+            validateErrorResult(validationResult, List.of(OBRIErrorType.CONSENT_STATUS_NOT_AUTHORISED.toOBError1(invalidStatus)));
+        }
+    }
+
+}


### PR DESCRIPTION
- Added OBVRPFundsConfirmationRequestValidator which validates the consentId in the funds confirmation request matches the access_token and that the consent is Authorised
- Updated DomesticVrpConsentsApiController to use the new validator when processing funds confirmation requests

https://github.com/SecureApiGateway/SecureApiGateway/issues/1133