### PR TITLE
1140: Adding ContentType validation to File Payment File Upload Requests

### DIFF
--- a/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/v3_1_10/file/FilePaymentConsentsApiController.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/v3_1_10/file/FilePaymentConsentsApiController.java
@@ -136,6 +136,12 @@ public class FilePaymentConsentsApiController implements FilePaymentConsentsApi 
         final FilePaymentConsent consent = consentStoreApiClient.getConsent(consentId, apiClientId);
 
         final String fileType = consent.getRequestObj().getData().getInitiation().getFileType();
+        final PaymentFileType paymentFileType = paymentFileProcessorService.findPaymentFileType(fileType);
+        final String contentType = request.getContentType();
+        if (!paymentFileType.getContentType().toString().equals(contentType)) {
+            throw new OBErrorException(OBRIErrorType.REQUEST_MEDIA_TYPE_NOT_SUPPORTED, contentType, paymentFileType.getContentType());
+        }
+
         final PaymentFile paymentFile = paymentFileProcessorService.processFile(fileType, fileParam);
 
         fileContentValidator.validate(new FilePaymentFileContentValidationContext(HashUtils.computeSHA256FullHash(fileParam),


### PR DESCRIPTION
Validating that the HTTP ContentType header value for the File Payment File Upload request matches the value expected for the FileType that is specified in the Consent.

If the ContentType does not match then a HTTP 415 Unsupported Media Type response is returned.

https://github.com/SecureApiGateway/SecureApiGateway/issues/1140