### PR TITLE
863: Logging x-fapi-interaction-id header via logging context (MDC)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
     </parent>
 
     <properties>
-        <uk.bom.version>2.1.0</uk.bom.version>
+        <uk.bom.version>2.1.1-SNAPSHOT</uk.bom.version>
         <consent.api.version>2.1.0</consent.api.version>
     </properties>
 

--- a/secure-api-gateway-ob-uk-rs-server/pom.xml
+++ b/secure-api-gateway-ob-uk-rs-server/pom.xml
@@ -44,6 +44,7 @@
         <gcrRepo>sbat-gcr-develop</gcrRepo>
         <!-- property to run individually the module with no license issues -->
         <legal.path.header>../legal/LICENSE-HEADER.txt</legal.path.header>
+        <logback.contrib.version>0.1.5</logback.contrib.version>
     </properties>
 
     <dependencies>
@@ -151,6 +152,16 @@
         <dependency>
             <groupId>io.micrometer</groupId>
             <artifactId>micrometer-registry-prometheus</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback.contrib</groupId>
+            <artifactId>logback-json-classic</artifactId>
+            <version>${logback.contrib.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback.contrib</groupId>
+            <artifactId>logback-jackson</artifactId>
+            <version>${logback.contrib.version}</version>
         </dependency>
         <!-- ForgeRock Test dependencies -->
         <dependency>

--- a/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/configuration/WebMvcConfig.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/configuration/WebMvcConfig.java
@@ -16,6 +16,8 @@
 package com.forgerock.sapi.gateway.ob.uk.rs.server.configuration;
 
 import com.forgerock.sapi.gateway.ob.uk.rs.server.web.DisabledEndpointInterceptor;
+import com.forgerock.sapi.gateway.uk.common.shared.spring.web.filter.FapiInteractionIdFilter;
+
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.filter.ForwardedHeaderFilter;
@@ -34,6 +36,15 @@ public class WebMvcConfig implements WebMvcConfigurer {
     @Bean
     ForwardedHeaderFilter forwardedHeaderFilter() {
         return new ForwardedHeaderFilter();
+    }
+
+    /**
+     * Installs the {@link FapiInteractionIdFilter}, this filter adds the x-fapi-interaction-id header value to the
+     * logging context.
+     */
+    @Bean
+    FapiInteractionIdFilter fapInteractionIdFilter() {
+        return new FapiInteractionIdFilter();
     }
 
     @Override

--- a/secure-api-gateway-ob-uk-rs-server/src/main/resources/logback.xml
+++ b/secure-api-gateway-ob-uk-rs-server/src/main/resources/logback.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder class="ch.qos.logback.core.encoder.LayoutWrappingEncoder">
+            <layout class="ch.qos.logback.contrib.json.classic.JsonLayout">
+                <jsonFormatter class="ch.qos.logback.contrib.jackson.JacksonJsonFormatter">
+                </jsonFormatter>
+                <timestampFormat>yyyy-MM-dd'T'HH:mm:ss.SSS'Z'</timestampFormat>
+                <timestampFormatTimezoneId>UTC</timestampFormatTimezoneId>
+                <appendLineSeparator>true</appendLineSeparator>
+            </layout>
+        </encoder>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="STDOUT"/>
+    </root>
+</configuration>
+

--- a/secure-api-gateway-ob-uk-rs-server/src/test/resources/logback-test.xml
+++ b/secure-api-gateway-ob-uk-rs-server/src/test/resources/logback-test.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder class="ch.qos.logback.core.encoder.LayoutWrappingEncoder">
+            <layout class="ch.qos.logback.contrib.json.classic.JsonLayout">
+                <jsonFormatter class="ch.qos.logback.contrib.jackson.JacksonJsonFormatter">
+                </jsonFormatter>
+                <timestampFormat>yyyy-MM-dd'T'HH:mm:ss.SSS'Z'</timestampFormat>
+                <timestampFormatTimezoneId>UTC</timestampFormatTimezoneId>
+                <appendLineSeparator>true</appendLineSeparator>
+            </layout>
+        </encoder>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="STDOUT"/>
+    </root>
+</configuration>
+


### PR DESCRIPTION
Installing FapInteractionIdFilter which stores the x-fapi-interaction-id header value in the logging context (MDC).

Updating logging configuration to use a JSON log format, which automatically adds the MDC data to the log message. Logging will now be consistent with IG.

Adding logback dependencies to support JSON logging.

Example log (pretty printed):
```
{
    "timestamp": "2023-10-31T16:06:14.312Z",
    "level": "INFO",
    "thread": "http-nio-auto-1-exec-4",
    "mdc": {
        "x-fapi-interaction-id": "acadff39-eca0-4d08-b33b-e549e73daf8a"
    },
    "logger": "com.forgerock.sapi.gateway.ob.uk.rs.server.idempotency.IdempotentRepositoryAdapter",
    "message": "Created new Payment Submission: 992677bc-e8e3-490b-8883-d3e7f7fbf811",
    "context": "default"
}
```

https://github.com/SecureApiGateway/SecureApiGateway/issues/863