### PR TITLE
863: Setting x-fapi-interaction-id when calling ID Cloud API

### DIFF
--- a/secure-api-gateway-ob-uk-rs-cloud-client/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/cloud/client/services/UserClientService.java
+++ b/secure-api-gateway-ob-uk-rs-cloud-client/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/cloud/client/services/UserClientService.java
@@ -21,7 +21,13 @@ import com.forgerock.sapi.gateway.ob.uk.rs.cloud.client.exceptions.ErrorType;
 import com.forgerock.sapi.gateway.ob.uk.rs.cloud.client.exceptions.ExceptionClient;
 import com.forgerock.sapi.gateway.ob.uk.rs.cloud.client.model.User;
 import com.forgerock.sapi.gateway.ob.uk.rs.cloud.client.utils.url.UrlContext;
+import com.forgerock.sapi.gateway.uk.common.shared.api.meta.obie.OBHeaders;
+import com.forgerock.sapi.gateway.uk.common.shared.fapi.FapiInteractionIdContext;
+
 import lombok.extern.slf4j.Slf4j;
+
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -30,6 +36,7 @@ import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestTemplate;
 
 import java.util.Objects;
+import java.util.UUID;
 
 import static java.util.Objects.requireNonNull;
 import static org.springframework.http.HttpMethod.GET;
@@ -78,7 +85,7 @@ public class UserClientService {
             ResponseEntity<User> responseEntity = restTemplate.exchange(
                     userFilterURL,
                     GET,
-                    null,
+                    createRequestEntity(),
                     User.class);
 
             return (responseEntity.getStatusCode() != HttpStatus.OK) ?
@@ -108,5 +115,12 @@ public class UserClientService {
                     exception
             );
         }
+    }
+
+    protected HttpEntity<?> createRequestEntity() {
+        final HttpHeaders httpHeaders = new HttpHeaders();
+        httpHeaders.add(OBHeaders.X_FAPI_INTERACTION_ID, FapiInteractionIdContext.getFapiInteractionId()
+                                                                                 .orElseGet(() -> UUID.randomUUID().toString()));
+        return new HttpEntity<>(httpHeaders);
     }
 }

--- a/secure-api-gateway-ob-uk-rs-cloud-client/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/cloud/client/services/UserClientServiceTest.java
+++ b/secure-api-gateway-ob-uk-rs-cloud-client/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/cloud/client/services/UserClientServiceTest.java
@@ -20,15 +20,19 @@ import com.forgerock.sapi.gateway.ob.uk.rs.cloud.client.exceptions.ErrorType;
 import com.forgerock.sapi.gateway.ob.uk.rs.cloud.client.exceptions.ExceptionClient;
 import com.forgerock.sapi.gateway.ob.uk.rs.cloud.client.model.User;
 import com.forgerock.sapi.gateway.ob.uk.rs.cloud.client.utils.url.UrlContext;
+import com.forgerock.sapi.gateway.uk.common.shared.api.meta.obie.OBHeaders;
+
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpEntity;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.web.client.RestTemplate;
@@ -84,10 +88,11 @@ public class UserClientServiceTest {
                 .accountStatus(ACCOUNT_ACTIVE_STATUS)
                 .build();
         // When
+        final ArgumentCaptor<HttpEntity> entityArgumentCaptor = ArgumentCaptor.forClass(HttpEntity.class);
         when(restTemplate.exchange(
                 anyString(),
                 eq(GET),
-                isNull(),
+                entityArgumentCaptor.capture(),
                 eq(User.class))
         ).thenReturn(ResponseEntity.ok(user));
 
@@ -97,6 +102,7 @@ public class UserClientServiceTest {
         assertThat(userResponse.getAccountStatus()).isEqualTo(ACCOUNT_ACTIVE_STATUS);
         assertThat(userResponse.getUserName()).isEqualTo(user.getUserName());
         assertThat(userResponse.getId()).isEqualTo(user.getId());
+        assertThat(entityArgumentCaptor.getValue().getHeaders().get(OBHeaders.X_FAPI_INTERACTION_ID)).isNotNull();
     }
 
     @Test
@@ -111,7 +117,7 @@ public class UserClientServiceTest {
         when(restTemplate.exchange(
                 anyString(),
                 eq(GET),
-                isNull(),
+                any(HttpEntity.class),
                 eq(User.class))
         ).thenReturn(ResponseEntity.ok(user));
 
@@ -133,7 +139,7 @@ public class UserClientServiceTest {
         when(restTemplate.exchange(
                 anyString(),
                 eq(GET),
-                isNull(),
+                any(HttpEntity.class),
                 eq(User.class))
         ).thenReturn(ResponseEntity.notFound().build());
 


### PR DESCRIPTION
Adding x-fapi-interaction-id to HTTP call made to ID Cloud API from UserClientService

https://github.com/SecureApiGateway/SecureApiGateway/issues/863