### PR TITLE
1207: Add StatusUpdateTime to VRP Consent response

### DIFF
--- a/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/v3_1_9/vrp/DomesticVrpsApiController.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/v3_1_9/vrp/DomesticVrpsApiController.java
@@ -248,6 +248,7 @@ public class DomesticVrpsApiController implements DomesticVrpsApi {
                                 .domesticVRPId(paymentSubmission.getId())
                                 .status(toOBDomesticVRPResponseDataStatusEnum(paymentSubmission.getStatus()))
                                 .creationDateTime(paymentSubmission.getCreated())
+                                .statusUpdateDateTime(paymentSubmission.getUpdated())
                                 .debtorAccount(obDomesticVRPRequest.getData().getInitiation().getDebtorAccount())
                                 .initiation(obDomesticVRPRequest.getData().getInitiation())
                                 .instruction(obDomesticVRPRequest.getData().getInstruction())


### PR DESCRIPTION
The response to the PUT VRP Payment Consent request does not contain the mandatory StatusUpdateTime field.

Issue: https://github.com/SecureApiGateway/SecureApiGateway/issues/1207