### PR TITLE
987: Migration to Artifact Registry

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -41,21 +41,23 @@ jobs:
           server-username: FR_ARTIFACTORY_USER # env variable for username in deploy
           server-password: FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD # env variable for token in deploy
 
-      - uses: google-github-actions/auth@v0
+      - name: Auth to GCP  
+        uses: google-github-actions/auth@v2
         with:
-          credentials_json: ${{ secrets.GCR_CREDENTIALS_JSON }}
+          credentials_json: ${{ secrets.DEV_GAR_KEY }}
 
       - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v0
+        uses: google-github-actions/setup-gcloud@v1.1.1
 
-      - run: |
-          gcloud auth configure-docker
+      - name: Auth Docker
+        run: |
+          gcloud auth configure-docker europe-west4-docker.pkg.dev
 
       - name: Build Code + Test + Create Docker Image
         run: |
           make docker tag=${{ env.GIT_SHA_SHORT }}
-          docker tag eu.gcr.io/${{ secrets.GCR_DEV_REPO }}/securebanking/${{ env.SERVICE_NAME }}:${{ env.GIT_SHA_SHORT }} eu.gcr.io/${{ secrets.GCR_DEV_REPO }}/securebanking/${{ env.SERVICE_NAME }}:latest
-          docker push --all-tags eu.gcr.io/${{ secrets.GCR_DEV_REPO }}/securebanking/${{ env.SERVICE_NAME }}
+          docker tag ${{ vars.GAR_DEV_REPO }}/securebanking/${{ env.SERVICE_NAME }}:${{ env.GIT_SHA_SHORT }} ${{ vars.GAR_DEV_REPO }}/securebanking/${{ env.SERVICE_NAME }}:latest
+          docker push ${{ vars.GAR_DEV_REPO }}/securebanking/${{ env.SERVICE_NAME }} --all-tags
 
       - name: Deploy artifact package
         run: mvn -B deploy -DskipTests -DskipITs -DdockerCompose.skip -Ddockerfile.skip
@@ -63,7 +65,15 @@ jobs:
           FR_ARTIFACTORY_USER: ${{ secrets.FR_ARTIFACTORY_USER }}
           FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD: ${{ secrets.FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD }}
       
-      - name: 'run functional tests'
+      - uses: codecov/codecov-action@v1
+        with:
+          token: ${{ secrets.CODECOV_ACCESS_TOKEN }}
+  test:
+    runs-on: ubuntu-latest
+    name: Check master integrity
+    needs: build
+    steps:      
+      - name: 'Update Environment'
         uses: codefresh-io/codefresh-pipeline-runner@master
         with:
           args: '-v ARGO_VALUES_PREFIX=testFacilityBank -v SERVICE_NAME=test-facility-bank'
@@ -72,7 +82,3 @@ jobs:
           CF_API_KEY: ${{ secrets.CF_API_KEY }}
           TRIGGER_NAME: github-actions-trigger-rs
         id: run-pipeline
-
-      - uses: codecov/codecov-action@v1
-        with:
-          token: ${{ secrets.CODECOV_ACCESS_TOKEN }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -14,10 +14,25 @@ env:
   PR_NUMBER: pr-${{ github.event.number }}
 
 jobs:
-  build:
+  check:
     runs-on: ubuntu-latest
     name: Check PR integrity
     steps:
+      - uses: actions/checkout@v3
+
+      - name: template helm
+        run: |
+          helm template $HELM_DIRECTORY/$SERVICE_NAME
+
+      - name: Check Copyright
+        run: mvn license:check
+  
+  build:
+    runs-on: ubuntu-latest
+    name: Build Image
+    needs: check
+    steps:
+
       - uses: actions/checkout@v3
 
       - name: Get version
@@ -44,22 +59,17 @@ jobs:
           server-username: FR_ARTIFACTORY_USER # env variable for username in deploy
           server-password: FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD # env variable for token in deploy
 
-      - uses: google-github-actions/auth@v0
+      - name: Auth to GCP  
+        uses: google-github-actions/auth@v2
         with:
-          credentials_json: ${{ secrets.GCR_CREDENTIALS_JSON }}
+          credentials_json: ${{ secrets.DEV_GAR_KEY }}
 
       - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v0
-
-      - name: template helm
+        uses: google-github-actions/setup-gcloud@v1.1.1
+      
+      - name: Auth Docker
         run: |
-          helm template $HELM_DIRECTORY/$SERVICE_NAME
-
-      - name: Check Copyright
-        run: mvn license:check
-
-      - run: |
-          gcloud auth configure-docker
+          gcloud auth configure-docker europe-west4-docker.pkg.dev
       
       - name: Build Code + Test + Create Docker Image
         run: |
@@ -69,6 +79,11 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_ACCESS_TOKEN }}
       
+  test:
+    runs-on: ubuntu-latest
+    name: Test Changes
+    needs: build
+    steps:
       - name: Create lowercase Github Username
         id: toLowerCase
         run: echo "GITHUB_USER=$(echo ${{github.actor}} | tr '[:upper:]' '[:lower:]')" >> ${GITHUB_ENV}
@@ -76,7 +91,7 @@ jobs:
       - name: Output GITHUB_USER env
         run: echo "GITHUB_USER set to ${{ env.GITHUB_USER }}"
 
-      - name: 'run functional tests'
+      - name: 'Update Environment'
         uses: codefresh-io/codefresh-pipeline-runner@master
         with:
           args: '-v TAG=${{ env.PR_NUMBER }} -v ARGO_VALUES_PREFIX=testFacilityBank -v SERVICE_NAME=test-facility-bank -v ENVIRONMENT=${{ env.GITHUB_USER }} -v BRANCH=${{ github.head_ref }}'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,7 +53,7 @@ jobs:
       SERVICE_NAME: securebanking-openbanking-uk-rs
     secrets:
       GCR_credentials_json: ${{ secrets.DEV_GAR_KEY }}
-      GCR_RELEASE_REPO: ${{ secrets.GCR_RELEASE_REPO }}
+      GCR_RELEASE_REPO: ${{ vars.GAR_RELEASE_REPO }}
 
   release_helm:
     name: Call publish helm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,7 +52,7 @@ jobs:
       release_tag_ref: ${{ needs.release_prepare.outputs.release_tag_ref }}
       SERVICE_NAME: securebanking-openbanking-uk-rs
     secrets:
-      GCR_CREDENTIALS_JSON: ${{ secrets.GCR_CREDENTIALS_JSON }}
+      GCR_credentials_json: ${{ secrets.DEV_GAR_KEY }}
       GCR_RELEASE_REPO: ${{ secrets.GCR_RELEASE_REPO }}
 
   release_helm:

--- a/secure-api-gateway-ob-uk-rs-server/docker/docker-compose-git.yml
+++ b/secure-api-gateway-ob-uk-rs-server/docker/docker-compose-git.yml
@@ -3,7 +3,7 @@ services:
 
   securebanking-config-server:
     container_name: securebanking-config-server
-    image: eu.gcr.io/sbat-gcr-develop/securebanking/securebanking-spring-config-server
+    image: europe-west4-docker.pkg.dev/sbat-gcr-develop/sapig-docker-artifact/securebanking/securebanking-spring-config-server
     environment:
       - SSH_KEY=${GIT_SSH_KEY}
       - SPRING_CLOUD_CONFIG_SERVER_GIT_URI=git@github.com:SecureApiGateway/secure-api-gateway-ob-uk-spring-config.git
@@ -13,7 +13,7 @@ services:
 
   rs-simulator:
     container_name: rs-simulator
-    image: eu.gcr.io/sbat-gcr-develop/securebanking/securebanking-openbanking-uk-rs
+    image: europe-west4-docker.pkg.dev/sbat-gcr-develop/sapig-docker-artifact/securebanking/securebanking-openbanking-uk-rs
     ports:
       - 8080:8080
       - 9096:9096

--- a/secure-api-gateway-ob-uk-rs-server/docker/docker-compose.yml
+++ b/secure-api-gateway-ob-uk-rs-server/docker/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   securebanking-config-server:
     container_name: securebanking-config-server
     hostname: securebanking-config-server
-    image: eu.gcr.io/sbat-gcr-develop/securebanking/securebanking-spring-config-server
+    image: europe-west4-docker.pkg.dev/sbat-gcr-develop/sapig-docker-artifact/securebanking/securebanking-spring-config-server
     environment:
       - SPRING_PROFILES_ACTIVE=native
       - CONFIG_SERVER_SEARCH_LOCATIONS=file:///home/config
@@ -15,7 +15,7 @@ services:
 
   rs-simulator:
     container_name: rs-simulator
-    image: eu.gcr.io/sbat-gcr-develop/securebanking/securebanking-openbanking-uk-rs
+    image: europe-west4-docker.pkg.dev/sbat-gcr-develop/sapig-docker-artifact/securebanking/securebanking-openbanking-uk-rs
     ports:
       - 8080:8080
       - 9096:9096

--- a/secure-api-gateway-ob-uk-rs-server/pom.xml
+++ b/secure-api-gateway-ob-uk-rs-server/pom.xml
@@ -248,7 +248,7 @@
                 <configuration>
                     <dockerfile>docker/Dockerfile</dockerfile>
                     <skipPush>false</skipPush>
-                    <repository>eu.gcr.io/${gcrRepo}/securebanking/securebanking-openbanking-uk-rs</repository>
+                    <repository>europe-west4-docker.pkg.dev/${gcrRepo}/sapig-docker-artifact/securebanking/securebanking-openbanking-uk-rs</repository>
                     <buildArgs>
                         <JAR_FILE>target/${project.build.finalName}-exec.jar</JAR_FILE>
                     </buildArgs>


### PR DESCRIPTION
- Change any pipelines to push to the new Artifact Registry
- Change any pipelines / packages that pull images to use the new Artifact Registry
- Change Auth to GCP pipeline command to use V2 as V0 is deprecated

Issue:
- https://github.com/SecureApiGateway/SecureApiGateway/issues/987
- https://github.com/SecureApiGateway/SecureApiGateway/issues/1202