### PR TITLE
1220: Removing version from logback-classic dependency in rs-validation-obie module

### DIFF
--- a/secure-api-gateway-ob-uk-rs-validation/secure-api-gateway-ob-uk-rs-validation-obie/pom.xml
+++ b/secure-api-gateway-ob-uk-rs-validation/secure-api-gateway-ob-uk-rs-validation-obie/pom.xml
@@ -69,7 +69,6 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>1.2.3</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
The logback-classic dependency is included (with test scope) in order to get logging when running tests for rs-validation-obie module. This is needed because this module has no dependency on Spring, all other modules get logging configured via Spring dependencies.

Removing the explicit version number from the pom to fix and issue raised by the enforcer plugin wrt DependencyConvergence

https://github.com/SecureApiGateway/SecureApiGateway/issues/1220