### PR TITLE
1236: Adding coverage for GlobalExceptionHandler

### DIFF
--- a/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/exceptions/GlobalExceptionHandler.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/exceptions/GlobalExceptionHandler.java
@@ -40,6 +40,7 @@ import org.springframework.web.HttpMediaTypeNotSupportedException;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.MissingPathVariableException;
+import org.springframework.web.bind.MissingRequestHeaderException;
 import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.ServletRequestBindingException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
@@ -105,28 +106,12 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
                                                                           HttpHeaders headers,
                                                                           HttpStatus status,
                                                                           WebRequest request) {
-        if (ex.getMessage().startsWith("Missing request header")) {
+        if (ex instanceof MissingRequestHeaderException) {
             return handleOBErrorResponse(
                     new OBErrorResponseException(
                             HttpStatus.BAD_REQUEST,
                             OBRIErrorResponseCategory.REQUEST_INVALID,
                             OBRIErrorType.REQUEST_MISSING_HEADER.toOBError1(ex.getMessage())
-                    ),
-                    request);
-        } else if (ex.getMessage().startsWith("Missing cookie")) {
-            return handleOBErrorResponse(
-                    new OBErrorResponseException(
-                            HttpStatus.BAD_REQUEST,
-                            OBRIErrorResponseCategory.REQUEST_INVALID,
-                            OBRIErrorType.REQUEST_MISSING_COOKIE.toOBError1(ex.getMessage())
-                    ),
-                    request);
-        } else if (ex.getMessage().startsWith("Missing argument")) {
-            return handleOBErrorResponse(
-                    new OBErrorResponseException(
-                            HttpStatus.BAD_REQUEST,
-                            OBRIErrorResponseCategory.REQUEST_INVALID,
-                            OBRIErrorType.REQUEST_MISSING_ARGUMENT.toOBError1(ex.getMessage())
                     ),
                     request);
         }

--- a/secure-api-gateway-ob-uk-rs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/server/exceptions/GlobalExceptionHandlerTest.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/server/exceptions/GlobalExceptionHandlerTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.ob.uk.rs.server.exceptions;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.ActiveProfiles;
+
+import com.forgerock.sapi.gateway.ob.uk.common.error.OBRIErrorResponseCategory;
+
+import uk.org.openbanking.datamodel.error.OBError1;
+import uk.org.openbanking.datamodel.error.OBErrorResponse1;
+import uk.org.openbanking.datamodel.error.OBStandardErrorCodes1;
+
+/**
+ * Tests for the GlobalExceptionHandler, uses the {@link com.forgerock.sapi.gateway.ob.uk.rs.obie.api.account.v3_1_10.accounts.AccountAccessConsentsApi}
+ * as the endpoint to test the cross-cutting error handling done by the GlobalExceptionHandler.
+ */
+@SpringBootTest(webEnvironment = RANDOM_PORT)
+@ActiveProfiles("test")
+
+class GlobalExceptionHandlerTest {
+
+    @LocalServerPort
+    private int port;
+
+    @Autowired
+    private TestRestTemplate restTemplate;
+
+    private String accountAccessConsentApiUri() {
+        return "http://localhost:" + port + "/open-banking/v3.1.10/aisp/account-access-consents";
+    }
+
+    private String getAccountAccessConsentApiUri(String consentId) {
+        return accountAccessConsentApiUri() + "/" + consentId;
+    }
+
+    @Test
+    void testErrorDueToMissingHeader() {
+        final HttpEntity<Object> requestWithNoHeaders = new HttpEntity<>(null);
+        final ResponseEntity<OBErrorResponse1> errorResponse = restTemplate.exchange(getAccountAccessConsentApiUri("12234"),
+                HttpMethod.GET, requestWithNoHeaders, OBErrorResponse1.class);
+
+        assertThat(errorResponse.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+
+        final OBErrorResponse1 errorResponseBody = errorResponse.getBody();
+        assertThat(errorResponseBody.getCode()).isEqualTo(OBRIErrorResponseCategory.REQUEST_INVALID.getId());
+        assertThat(errorResponseBody.getErrors()).hasSize(1);
+        final OBError1 firstError = errorResponseBody.getErrors().get(0);
+        assertThat(firstError.getErrorCode()).isEqualTo(OBStandardErrorCodes1.UK_OBIE_HEADER_MISSING.toString());
+        assertThat(firstError.getMessage()).isEqualTo("Missing request header 'Authorization' for method parameter of type String");
+    }
+}

--- a/secure-api-gateway-ob-uk-rs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/server/exceptions/GlobalExceptionHandlerTest.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/server/exceptions/GlobalExceptionHandlerTest.java
@@ -45,7 +45,6 @@ import uk.org.openbanking.datamodel.error.OBStandardErrorCodes1;
  */
 @SpringBootTest(webEnvironment = RANDOM_PORT)
 @ActiveProfiles("test")
-
 class GlobalExceptionHandlerTest {
 
     public static final HttpHeaders REQUIRED_ACCOUNT_CONSENT_API_HEADERS = requiredAccountConsentApiHeaders("client-123");


### PR DESCRIPTION
Adding test for handling of missing request headers, HTTP method not supported and request media type not supported.

Cleaned up GlobalException handler to remove testing exception string error messages and instead made us of instanceof. Implemented this for MissingRequestHeaderException, removed error conditions which are not reachable.

https://github.com/SecureApiGateway/SecureApiGateway/issues/1236