### PR TITLE
1235: Configure server.max-http-request-header-size

### DIFF
--- a/secure-api-gateway-ob-uk-rs-server/src/main/resources/application.yml
+++ b/secure-api-gateway-ob-uk-rs-server/src/main/resources/application.yml
@@ -26,7 +26,7 @@
 #        baseUri:
 
 server:
-  max-http-header-size: 16KB
+  max-http-request-header-size: 16KB
 
 spring:
   data:


### PR DESCRIPTION
server.max-http-header-size has been deprecated and has been replaced with server.max-http-request-header-size, updating our application config to use the new property

https://github.com/SecureApiGateway/SecureApiGateway/issues/1235