### PR TITLE
1267: Removing mockito-inline and gson dependencies

### DIFF
--- a/secure-api-gateway-ob-uk-rs-cloud-client/pom.xml
+++ b/secure-api-gateway-ob-uk-rs-cloud-client/pom.xml
@@ -42,8 +42,6 @@
     <properties>
         <!-- property to run individually the module with no license issues -->
         <legal.path.header>../legal/LICENSE-HEADER.txt</legal.path.header>
-	<mockito-inline.version>5.2.0</mockito-inline.version>
-        <gson.version>2.10.1</gson.version>
     </properties>
 
     <dependencies>
@@ -82,11 +80,6 @@
             <groupId>org.apache.httpcomponents.client5</groupId>
             <artifactId>httpclient5</artifactId>
         </dependency>
-        <dependency>
-            <groupId>com.google.code.gson</groupId>
-            <artifactId>gson</artifactId>
-	    <version>${gson.version}</version>
-        </dependency>
         <!-- External Test dependencies -->
         <dependency>
             <groupId>org.junit.jupiter</groupId>
@@ -96,12 +89,6 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-inline</artifactId>
-	    <version>${mockito-inline.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
These dependencies are no longer being used.

https://github.com/SecureApiGateway/SecureApiGateway/issues/1267