### PR TITLE
1260: Investigate PR runs for GitHub user

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,7 +71,7 @@ jobs:
   release_draft_and_pr:
     name: Call publish draft and PR
     needs: [ release_prepare, release_java, release_docker, release_helm ]
-    uses: SecureApiGateway/secure-api-gateway-parent/.github/workflows/elease-publish.yml@master
+    uses: SecureApiGateway/secure-api-gateway-parent/.github/workflows/release-publish.yml@master
     with:
       release_version_number: ${{ inputs.release_version_number }}
       release_branch_ref: ${{ needs.release_prepare.outputs.release_branch_ref }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,3 +76,5 @@ jobs:
       release_version_number: ${{ inputs.release_version_number }}
       release_tag_ref: ${{ needs.release_prepare.outputs.release_tag_ref }}
       release_notes: ${{ inputs.notes }}
+    secrets:
+      release_github_token: ${{ secrets.RELEASE_PAT }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,12 +68,11 @@ jobs:
       FR_ARTIFACTORY_USER_ACCESS_TOKEN: ${{ secrets.FR_ARTIFACTORY_USER_ACCESS_TOKEN }}
       FR_HELM_REPO: ${{ secrets.FR_HELM_REPO }}
 
-  release_draft_and_pr:
-    name: Call publish draft and PR
+  release_publish:
+    name: Call publish
     needs: [ release_prepare, release_java, release_docker, release_helm ]
     uses: SecureApiGateway/secure-api-gateway-parent/.github/workflows/release-publish.yml@master
     with:
       release_version_number: ${{ inputs.release_version_number }}
-      release_branch_ref: ${{ needs.release_prepare.outputs.release_branch_ref }}
       release_tag_ref: ${{ needs.release_prepare.outputs.release_tag_ref }}
       release_notes: ${{ inputs.notes }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,7 +71,7 @@ jobs:
   release_draft_and_pr:
     name: Call publish draft and PR
     needs: [ release_prepare, release_java, release_docker, release_helm ]
-    uses: SecureApiGateway/secure-api-gateway-parent/.github/workflows/release-publish-draft-and-pr.yml@master
+    uses: SecureApiGateway/secure-api-gateway-parent/.github/workflows/elease-publish.yml@master
     with:
       release_version_number: ${{ inputs.release_version_number }}
       release_branch_ref: ${{ needs.release_prepare.outputs.release_branch_ref }}


### PR DESCRIPTION
Remove the need for the fropenbanking github user to create a PR to push changes

This will allow pushes direct to master which will avoid user having to wait for PR workflows and manual merges

Relies on: https://github.com/SecureApiGateway/secure-api-gateway-parent/pull/111

Issue: https://github.com/SecureApiGateway/SecureApiGateway/issues/1260