### PR TITLE
1296: Fix UserClientService query by username URI

### DIFF
--- a/secure-api-gateway-ob-uk-rs-cloud-client/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/cloud/client/services/UserClientService.java
+++ b/secure-api-gateway-ob-uk-rs-cloud-client/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/cloud/client/services/UserClientService.java
@@ -63,7 +63,7 @@ public class UserClientService {
         this.restTemplate = restTemplate;
         this.queryByUsernameUriTemplate = UriComponentsBuilder.fromHttpUrl(cloudClientConfiguration.getBaseUri())
                                                               .path("/repo/users")
-                                                              .queryParam("_queryFilter","username+eq+\"{username}\"}")
+                                                              .queryParam("_queryFilter","userName+eq+\"{username}\"")
                                                               .build();
     }
 

--- a/secure-api-gateway-ob-uk-rs-cloud-client/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/cloud/client/services/UserClientServiceTest.java
+++ b/secure-api-gateway-ob-uk-rs-cloud-client/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/cloud/client/services/UserClientServiceTest.java
@@ -69,7 +69,7 @@ public class UserClientServiceTest {
                 .accountStatus(ACCOUNT_ACTIVE_STATUS)
                 .build();
         // When
-        mockServer.expect(once(), requestTo("http://ig:80/repo/users?_queryFilter=username+eq+%22psu4test%22%7D"))
+        mockServer.expect(once(), requestTo("http://ig:80/repo/users?_queryFilter=userName+eq+%22psu4test%22"))
                 .andRespond(withStatus(HttpStatus.OK)
                         .contentType(MediaType.APPLICATION_JSON)
                         .body(objectMapper.writeValueAsString(user)));
@@ -91,7 +91,7 @@ public class UserClientServiceTest {
                 .accountStatus("inactive")
                 .build();
         // when
-        mockServer.expect(once(), requestTo("http://ig:80/repo/users?_queryFilter=username+eq+%22psu4test%22%7D"))
+        mockServer.expect(once(), requestTo("http://ig:80/repo/users?_queryFilter=userName+eq+%22psu4test%22"))
                 .andRespond(withStatus(HttpStatus.OK)
                         .contentType(MediaType.APPLICATION_JSON)
                         .body(objectMapper.writeValueAsString(user)));
@@ -111,7 +111,7 @@ public class UserClientServiceTest {
     @Test
     public void ShouldRaiseNotFoundUserDataFromPlatform() {
         // When
-        mockServer.expect(once(), requestTo("http://ig:80/repo/users?_queryFilter=username+eq+%22psu4test%22%7D"))
+        mockServer.expect(once(), requestTo("http://ig:80/repo/users?_queryFilter=userName+eq+%22psu4test%22"))
                   .andRespond(withStatus(HttpStatus.NOT_FOUND));
 
         ExceptionClient exception = catchThrowableOfType(() ->


### PR DESCRIPTION
- Removing trailing '}'
- Fixing parameter name to userName

https://github.com/SecureApiGateway/SecureApiGateway/issues/1296