### PR TITLE
1315: Remove unwanted config from dev-core

### DIFF
--- a/_infra/helm/securebanking-openbanking-uk-rs/readme.md
+++ b/_infra/helm/securebanking-openbanking-uk-rs/readme.md
@@ -118,12 +118,12 @@ spec:
           - name: CONSENT_REPO_URI
             valueFrom:
               configMapKeyRef:
-                name: deployment-config
+                name: core-deployment-config
                 key: CONSENT_REPO_URI
           - name: RS_DISCOVERY_FINANCIAL_ID
             valueFrom:
               configMapKeyRef:
-                name: deployment-config
+                name: core-deployment-config
                 key: OB_ASPSP_ORG_ID
           - name: SPRING_PROFILES_ACTIVE
             value: "docker"
@@ -148,8 +148,8 @@ These are the environment variables declared in the `deployment.yaml`;
 |-----|---------|-------------|--------|
 | SPRING_DATA_MONGODB_HOST | mongodb | Full name of the mongodb deployment | deployment.mongodb.host |
 | SERVER_PORT | 8080 | What port does the container use |deployment.containerPort |
-| CONSENT_REPO_URI | http://ig:80 | URI of IG | deployment-config |
-| RS_DISCOVERY_FINANCIAL_ID | 0015800001041REAAY | OB Organisation ID | deployment-config |
+| CONSENT_REPO_URI | http://ig:80 | URI of IG | core-deployment-config |
+| RS_DISCOVERY_FINANCIAL_ID | 0015800001041REAAY | OB Organisation ID | core-deployment-config |
 | SPRING_PROFILES_ACTIVE | docker |What spring provile to use | Hardcoded |
 | JAVA_OPTS | -XX:+UseG1GC -XX:+UseContainerSupport -XX:MaxRAMPercentage=50 -agentlib:jdwp=transport=dt_socket,address=*:9090,server=y,suspend=n | Additional Java config | deployment.java.opts |
 

--- a/_infra/helm/securebanking-openbanking-uk-rs/templates/deployment.yaml
+++ b/_infra/helm/securebanking-openbanking-uk-rs/templates/deployment.yaml
@@ -59,17 +59,17 @@ spec:
           - name: SPRING_DATA_MONGODB_DATABASE
             valueFrom:
               secretKeyRef:
-                name: core-secrets
+                name: ob-secrets
                 key: MONGODB_TEST_FACILITY_USERNAME
           - name: SPRING_DATA_MONGODB_USERNAME
             valueFrom:
               secretKeyRef:
-                name: core-secrets
+                name: ob-secrets
                 key: MONGODB_TEST_FACILITY_USERNAME
           - name: SPRING_DATA_MONGODB_PASSWORD
             valueFrom:
               secretKeyRef:
-                name: core-secrets
+                name: ob-secrets
                 key: MONGODB_TEST_FACILITY_PASSWORD
           - name: SERVER_PORT
             value: {{ .Values.deployment.containerPort | quote }}

--- a/_infra/helm/securebanking-openbanking-uk-rs/templates/deployment.yaml
+++ b/_infra/helm/securebanking-openbanking-uk-rs/templates/deployment.yaml
@@ -81,12 +81,12 @@ spec:
           - name: RCS_CONSENT_STORE_API_BASEURI
             valueFrom:
               configMapKeyRef:
-                name: core-deployment-config
+                name: ob-deployment-config
                 key: RCS_CONSENT_STORE_URI
           - name: RS_DISCOVERY_FINANCIAL_ID
             valueFrom:
               configMapKeyRef:
-                name: core-deployment-config
+                name: ob-deployment-config
                 key: OB_ASPSP_ORG_ID
           - name: SPRING_PROFILES_ACTIVE
             value: "docker"

--- a/_infra/helm/securebanking-openbanking-uk-rs/templates/deployment.yaml
+++ b/_infra/helm/securebanking-openbanking-uk-rs/templates/deployment.yaml
@@ -59,34 +59,34 @@ spec:
           - name: SPRING_DATA_MONGODB_DATABASE
             valueFrom:
               secretKeyRef:
-                name: openig-secrets-env
+                name: core-secrets
                 key: MONGODB_TEST_FACILITY_USERNAME
           - name: SPRING_DATA_MONGODB_USERNAME
             valueFrom:
               secretKeyRef:
-                name: openig-secrets-env
+                name: core-secrets
                 key: MONGODB_TEST_FACILITY_USERNAME
           - name: SPRING_DATA_MONGODB_PASSWORD
             valueFrom:
               secretKeyRef:
-                name: openig-secrets-env
+                name: core-secrets
                 key: MONGODB_TEST_FACILITY_PASSWORD
           - name: SERVER_PORT
             value: {{ .Values.deployment.containerPort | quote }}
           - name: CLOUD_CLIENT_BASE_URI
             valueFrom:
               configMapKeyRef:
-                name: deployment-config
+                name: core-deployment-config
                 key: GATEWAY_DATA_REPO_URI
           - name: RCS_CONSENT_STORE_API_BASEURI
             valueFrom:
               configMapKeyRef:
-                name: deployment-config
+                name: core-deployment-config
                 key: RCS_CONSENT_STORE_URI
           - name: RS_DISCOVERY_FINANCIAL_ID
             valueFrom:
               configMapKeyRef:
-                name: deployment-config
+                name: core-deployment-config
                 key: OB_ASPSP_ORG_ID
           - name: SPRING_PROFILES_ACTIVE
             value: "docker"


### PR DESCRIPTION
Rename deployment-config to be core-deployment-config & ob-deployment-config
Change openig-secrets-env to core-secrets & ob-secrets

Issue: https://github.com/SecureApiGateway/SecureApiGateway/issues/1315