### PR TITLE
1364: Using latest versions of SAPI-G dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,12 +46,12 @@
     <parent>
         <groupId>com.forgerock.sapi.gateway</groupId>
         <artifactId>secure-api-gateway-parent</artifactId>
-        <version>2.3.0</version>
+        <version>2.3.2-SNAPSHOT</version>
     </parent>
 
     <properties>
-        <uk.bom.version>2.3.0</uk.bom.version>
-        <consent.api.version>2.3.0</consent.api.version>
+        <uk.bom.version>2.3.1-SNAPSHOT</uk.bom.version>
+        <consent.api.version>2.3.1-SNAPSHOT</consent.api.version>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
- Updating parent version to 2.3.2-SNAPSHOT
- Updating common to 2.3.1-SNAPSHOT
- Updating consent API to 2.3.1-SNAPSHOT

https://github.com/SecureApiGateway/SecureApiGateway/issues/1364