### PR TITLE
1431: Fix priority of permissions for account access

### DIFF
--- a/secure-api-gateway-ob-uk-rs-resource-store/secure-api-gateway-ob-uk-rs-resource-store-repo/src/main/java/com/forgerock/sapi/gateway/rs/resource/store/repo/mongo/accounts/accounts/FRAccountRepositoryImpl.java
+++ b/secure-api-gateway-ob-uk-rs-resource-store/secure-api-gateway-ob-uk-rs-resource-store-repo/src/main/java/com/forgerock/sapi/gateway/rs/resource/store/repo/mongo/accounts/accounts/FRAccountRepositoryImpl.java
@@ -108,24 +108,18 @@ public class FRAccountRepositoryImpl implements FRAccountRepositoryCustom {
     }
 
     private void filterAccount(FRAccount account, List<FRExternalPermissionsCode> permissions) {
-        for (FRExternalPermissionsCode permission : permissions) {
-            switch (permission) {
-
-                case READACCOUNTSBASIC:
-                    account.getAccount().setAccounts(null);
-                    account.getAccount().setServicer(null);
-                    break;
-                case READACCOUNTSDETAIL:
-                    if (!CollectionUtils.isEmpty(account.getAccount().getAccounts())) {
-                        for (FRAccountIdentifier subAccount : account.getAccount().getAccounts()) {
-                            if (!permissions.contains(FRExternalPermissionsCode.READPAN)
-                                    && OBExternalAccountIdentification4Code.PAN.toString().equals(subAccount.getSchemeName())) {
-                                subAccount.setIdentification("xxx");
-                            }
-                        }
+        if(permissions.contains(FRExternalPermissionsCode.READACCOUNTSDETAIL)){
+            if (!CollectionUtils.isEmpty(account.getAccount().getAccounts())) {
+                for (FRAccountIdentifier subAccount : account.getAccount().getAccounts()) {
+                    if (!permissions.contains(FRExternalPermissionsCode.READPAN)
+                            && OBExternalAccountIdentification4Code.PAN.toString().equals(subAccount.getSchemeName())) {
+                        subAccount.setIdentification("xxx");
                     }
-                    break;
+                }
             }
+        } else if (permissions.contains(FRExternalPermissionsCode.READACCOUNTSBASIC)){
+            account.getAccount().setAccounts(null);
+            account.getAccount().setServicer(null);
         }
     }
 

--- a/secure-api-gateway-ob-uk-rs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/account/v3_1_10/accounts/AccountsApiControllerTest.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/account/v3_1_10/accounts/AccountsApiControllerTest.java
@@ -91,8 +91,10 @@ public class AccountsApiControllerTest {
         // When
         final String apiClientId = "client-123";
         final String consentId = "consent-343553";
-
-        mockAuthorisedConsentResponse(accountId, apiClientId, consentId);
+        // This makes this test ensure that the DETAIL permission overrides the BASIC permissions. See issue
+        // https://github.com/SecureApiGateway/SecureApiGateway/issues/1431
+        List<FRExternalPermissionsCode> permissions = List.of(FRExternalPermissionsCode.READACCOUNTSDETAIL, FRExternalPermissionsCode.READACCOUNTSBASIC);
+        mockAuthorisedConsentResponse(accountId, apiClientId, consentId, permissions);
 
         ResponseEntity<OBReadAccount6> response = restTemplate.exchange(
                 url,
@@ -132,7 +134,8 @@ public class AccountsApiControllerTest {
         final String apiClientId = "client-123";
         final String consentId = "consent-343553";
 
-        mockAuthorisedConsentResponse(accountId, apiClientId, consentId);
+        List<FRExternalPermissionsCode> permissions = List.of(FRExternalPermissionsCode.READACCOUNTSDETAIL);
+        mockAuthorisedConsentResponse(accountId, apiClientId, consentId, permissions);
 
         // When
         ResponseEntity<OBReadAccount6> response = restTemplate.exchange(
@@ -157,13 +160,13 @@ public class AccountsApiControllerTest {
         assertThat(response.getBody().getLinks().getSelf().toString()).isEqualTo(url);
     }
 
-    private void mockAuthorisedConsentResponse(String accountId, String apiClientId, String consentId) {
+    private void mockAuthorisedConsentResponse(String accountId, String apiClientId, String consentId, List<FRExternalPermissionsCode> permissions) {
         final AccountAccessConsent consent = new AccountAccessConsent();
         consent.setId(consentId);
         consent.setApiClientId(apiClientId);
         consent.setStatus("Authorised");
         consent.setAuthorisedAccountIds(List.of(accountId));
-        consent.setRequestObj(FRReadConsent.builder().data(FRReadConsentData.builder().permissions(List.of(FRExternalPermissionsCode.READACCOUNTSDETAIL)).build()).build());
+        consent.setRequestObj(FRReadConsent.builder().data(FRReadConsentData.builder().permissions(permissions).build()).build());
         given(accountAccessConsentStoreClient.getConsent(eq(consentId), eq(apiClientId))).willReturn(consent);
     }
 


### PR DESCRIPTION
When both basic and detail account permissions were added the basic account detail was returned instead of the detailed account data Issue: https://github.com/ForgeCloud/secure-api-gateway-relenv-deployer/pull/42