### PR TITLE
1430: Fix party not found when updating user data

### DIFF
--- a/secure-api-gateway-ob-uk-rs-resource-store/secure-api-gateway-ob-uk-rs-resource-store-api/src/main/java/com/forgerock/sapi/gateway/rs/resource/store/api/admin/DataApiController.java
+++ b/secure-api-gateway-ob-uk-rs-resource-store/secure-api-gateway-ob-uk-rs-resource-store-api/src/main/java/com/forgerock/sapi/gateway/rs/resource/store/api/admin/DataApiController.java
@@ -171,6 +171,10 @@ public class DataApiController implements DataApi {
             User user = userClientService.getUserByName(userData.getUserName());
             // user exist, carry on to update the user data
             String userId = user.getId();
+
+            // This method is currently keyed off the userName field in the user data.
+            // Overwrite any supplied userId with the value retrieved from the platform for the username so that it is consistent
+            userData.setUserId(userId);
             log.debug("user found with id: {}", userId);
             // update customer information
             log.debug("Customer information enabled: {}", isCustomerInfoEnabled);

--- a/secure-api-gateway-ob-uk-rs-resource-store/secure-api-gateway-ob-uk-rs-resource-store-api/src/main/java/com/forgerock/sapi/gateway/rs/resource/store/api/admin/DataUpdater.java
+++ b/secure-api-gateway-ob-uk-rs-resource-store/secure-api-gateway-ob-uk-rs-resource-store-api/src/main/java/com/forgerock/sapi/gateway/rs/resource/store/api/admin/DataUpdater.java
@@ -104,7 +104,7 @@ public class DataUpdater {
             return;
         }
         FRPartyData frPartyDiff = toFRPartyData(userData.getParty());
-        FRParty frParty = partyRepository.findByUserId(userData.getUserName());
+        FRParty frParty = partyRepository.findByUserId(userData.getUserId());
         if (!frParty.getId().equals(frPartyDiff.getPartyId())) {
             throw new ResponseStatusException(HttpStatus.UNAUTHORIZED,
                     String.format("the party ID '%s' doesn't match '%s' for user '%s'",


### PR DESCRIPTION
The DataUpdater has been fixed to query for the FRParty object using the userId.

DataApiController has been updated to ensure that the userId field is always set. The update method is currently keyed off the username field, any value in the userId field will be overwritten to the value retrieved from the platform for the username.

https://github.com/SecureApiGateway/SecureApiGateway/issues/1430