### PR TITLE
1430: Fix User Account Data export bug

### DIFF
--- a/secure-api-gateway-ob-uk-rs-resource-store/secure-api-gateway-ob-uk-rs-resource-store-api/src/main/java/com/forgerock/sapi/gateway/rs/resource/store/api/admin/DataExporter.java
+++ b/secure-api-gateway-ob-uk-rs-resource-store/secure-api-gateway-ob-uk-rs-resource-store-api/src/main/java/com/forgerock/sapi/gateway/rs/resource/store/api/admin/DataExporter.java
@@ -1,0 +1,216 @@
+/*
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.rs.resource.store.api.admin;
+
+import static com.forgerock.sapi.gateway.ob.uk.common.datamodel.converter.account.FRAccountBeneficiaryConverter.toOBBeneficiary5;
+import static com.forgerock.sapi.gateway.ob.uk.common.datamodel.converter.account.FRCashBalanceConverter.toOBReadBalance1DataBalance;
+import static com.forgerock.sapi.gateway.ob.uk.common.datamodel.converter.account.FRDirectDebitConverter.toOBReadDirectDebit2DataDirectDebit;
+import static com.forgerock.sapi.gateway.ob.uk.common.datamodel.converter.account.FRFinancialAccountConverter.toOBAccount6;
+import static com.forgerock.sapi.gateway.ob.uk.common.datamodel.converter.account.FROfferConverter.toOBReadOffer1DataOffer;
+import static com.forgerock.sapi.gateway.ob.uk.common.datamodel.converter.account.FRPartyConverter.toOBParty2;
+import static com.forgerock.sapi.gateway.ob.uk.common.datamodel.converter.account.FRStatementConverter.toOBStatement2;
+import static com.forgerock.sapi.gateway.ob.uk.common.datamodel.converter.account.FRTransactionConverter.toOBTransaction6;
+import static com.forgerock.sapi.gateway.ob.uk.common.datamodel.converter.payment.FRScheduledPaymentConverter.toOBScheduledPayment3;
+import static com.forgerock.sapi.gateway.ob.uk.common.datamodel.converter.payment.FRStandingOrderConverter.toOBStandingOrder6;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+import com.forgerock.sapi.gateway.rs.resource.store.datamodel.account.FRAccountData;
+import com.forgerock.sapi.gateway.rs.resource.store.repo.entity.account.FRAccount;
+import com.forgerock.sapi.gateway.rs.resource.store.repo.entity.account.FRParty;
+import com.forgerock.sapi.gateway.rs.resource.store.repo.entity.account.FRProduct;
+import com.forgerock.sapi.gateway.rs.resource.store.repo.mongo.accounts.balances.FRBalanceRepository;
+import com.forgerock.sapi.gateway.rs.resource.store.repo.mongo.accounts.beneficiaries.FRBeneficiaryRepository;
+import com.forgerock.sapi.gateway.rs.resource.store.repo.mongo.accounts.directdebits.FRDirectDebitRepository;
+import com.forgerock.sapi.gateway.rs.resource.store.repo.mongo.accounts.offers.FROfferRepository;
+import com.forgerock.sapi.gateway.rs.resource.store.repo.mongo.accounts.party.FRPartyRepository;
+import com.forgerock.sapi.gateway.rs.resource.store.repo.mongo.accounts.products.FRProductRepository;
+import com.forgerock.sapi.gateway.rs.resource.store.repo.mongo.accounts.scheduledpayments.FRScheduledPaymentRepository;
+import com.forgerock.sapi.gateway.rs.resource.store.repo.mongo.accounts.standingorders.FRStandingOrderRepository;
+import com.forgerock.sapi.gateway.rs.resource.store.repo.mongo.accounts.statements.FRStatementRepository;
+import com.forgerock.sapi.gateway.rs.resource.store.repo.mongo.accounts.transactions.FRTransactionRepository;
+
+import uk.org.openbanking.datamodel.account.OBBeneficiary5;
+import uk.org.openbanking.datamodel.account.OBParty2;
+import uk.org.openbanking.datamodel.account.OBReadBalance1DataBalanceInner;
+import uk.org.openbanking.datamodel.account.OBReadDirectDebit2DataDirectDebitInner;
+import uk.org.openbanking.datamodel.account.OBReadOffer1DataOfferInner;
+import uk.org.openbanking.datamodel.account.OBReadProduct2DataProductInner;
+import uk.org.openbanking.datamodel.account.OBScheduledPayment3;
+import uk.org.openbanking.datamodel.account.OBStandingOrder6;
+import uk.org.openbanking.datamodel.account.OBStatement2;
+import uk.org.openbanking.datamodel.account.OBTransaction6;
+
+@Service
+public class DataExporter {
+
+    private final FRBalanceRepository balanceRepository;
+    private final FRBeneficiaryRepository beneficiaryRepository;
+    private final FRDirectDebitRepository directDebitRepository;
+    private final FRProductRepository productRepository;
+    private final FRStandingOrderRepository standingOrderRepository;
+    private final FRTransactionRepository transactionRepository;
+    private final FRStatementRepository statementRepository;
+    private final FRScheduledPaymentRepository scheduledPaymentRepository;
+    private final FRPartyRepository partyRepository;
+    private final FROfferRepository offerRepository;
+
+    private final int dataPageSize;
+
+    @Autowired
+    public DataExporter(FRBalanceRepository balanceRepository,
+                        FRBeneficiaryRepository beneficiaryRepository,
+                        FRDirectDebitRepository directDebitRepository,
+                        FRProductRepository productRepository,
+                        FRStandingOrderRepository standingOrderRepository,
+                        FRTransactionRepository transactionRepository,
+                        FRStatementRepository statementRepository,
+                        FRScheduledPaymentRepository scheduledPaymentRepository,
+                        FRPartyRepository partyRepository,
+                        FROfferRepository offerRepository,
+                        @Value("${rs.data.export.page.size:500}") int dataPageSize
+    ) {
+        this.balanceRepository = balanceRepository;
+        this.beneficiaryRepository = beneficiaryRepository;
+        this.directDebitRepository = directDebitRepository;
+        this.productRepository = productRepository;
+        this.standingOrderRepository = standingOrderRepository;
+        this.transactionRepository = transactionRepository;
+        this.statementRepository = statementRepository;
+        this.scheduledPaymentRepository = scheduledPaymentRepository;
+        this.partyRepository = partyRepository;
+        this.offerRepository = offerRepository;
+        this.dataPageSize = dataPageSize;
+    }
+
+    FRAccountData exportAccountData(FRAccount account) {
+        final FRAccountData accountData = new FRAccountData();
+        accountData.setAccount(toOBAccount6(account.getAccount()));
+
+        final String accountId = account.getId();
+        accountData.setTransactions(getTransactions(accountId));
+        accountData.setProduct(getProduct(accountId));
+        accountData.setBalances(getBalances(accountId));
+        accountData.setBeneficiaries(getBeneficiaries(accountId));
+        accountData.setDirectDebits(getDirectDebits(accountId));
+        accountData.setStandingOrders(getStandingOrders(accountId));
+        accountData.setStatements(getStatements(accountId));
+        accountData.setScheduledPayments(getScheduledPayments(accountId));
+        accountData.setOffers(getOffers(accountId));
+        accountData.setParty(getParty(accountId));
+
+        return accountData;
+    }
+
+    private OBParty2 getParty(String accountId) {
+        final FRParty party = partyRepository.findByAccountId(accountId);
+        if (party != null) {
+            return toOBParty2(party.getParty());
+        }
+        return null;
+    }
+
+    private List<OBReadOffer1DataOfferInner> getOffers(String accountId) {
+        return executePagingFindQuery(accountId, offerRepository::findByAccountId,
+                frOffer -> toOBReadOffer1DataOffer(frOffer.getOffer()));
+    }
+
+    private List<OBScheduledPayment3> getScheduledPayments(String accountId) {
+        return executePagingFindQuery(accountId, scheduledPaymentRepository::findByAccountId,
+                frScheduledPayment -> toOBScheduledPayment3(frScheduledPayment.getScheduledPayment()));
+    }
+
+    private List<OBStatement2> getStatements(String accountId) {
+        return executePagingFindQuery(accountId, statementRepository::findByAccountId,
+                frStatement -> toOBStatement2(frStatement.getStatement()));
+    }
+
+    private List<OBStandingOrder6> getStandingOrders(String accountId) {
+        return executePagingFindQuery(accountId, standingOrderRepository::findByAccountId,
+                frStandingOrder -> toOBStandingOrder6(frStandingOrder.getStandingOrder()));
+    }
+
+    private List<OBReadDirectDebit2DataDirectDebitInner> getDirectDebits(String accountId) {
+        return executePagingFindQuery(accountId, directDebitRepository::findByAccountId,
+                frDirectDebit -> toOBReadDirectDebit2DataDirectDebit(frDirectDebit.getDirectDebit()));
+    }
+
+    private List<OBBeneficiary5> getBeneficiaries(String accountId) {
+        return executePagingFindQuery(accountId, beneficiaryRepository::findByAccountId,
+                frBeneficiary -> toOBBeneficiary5(frBeneficiary.getBeneficiary()));
+    }
+
+    private List<OBReadBalance1DataBalanceInner> getBalances(String accountId) {
+        return executePagingFindQuery(accountId, balanceRepository::findByAccountId,
+                frBalance -> toOBReadBalance1DataBalance(frBalance.getBalance()));
+    }
+
+    private OBReadProduct2DataProductInner getProduct(String accountId) {
+        final Page<FRProduct> product = productRepository.findByAccountId(accountId, PageRequest.ofSize(1));
+        if (product.hasContent()) {
+            return product.getContent().get(0).getProduct();
+        }
+        return null;
+    }
+
+    private List<OBTransaction6> getTransactions(String accountId) {
+        return executePagingFindQuery(accountId, transactionRepository::findByAccountId,
+                frTransaction -> toOBTransaction6(frTransaction.getTransaction()));
+    }
+
+    /**
+     * Helper function for executing a query that returns data in pages.
+     *
+     * @param accountId                 the id of the account that we are ret
+     * @param findByAccountIdPagerQuery Function which takes an accountId and a Pageable and returns a Page of data
+     * @param obDataModelConverter      Function which takes an FR data model object and converts it into an OB data model object
+     * @param <F>                       FR data model type (database representation)
+     * @param <O>                       OB data model type (OB API representation)
+     * @return List of OB data model objects retrieved by executing the query for the given accountId, returns an empty list if
+     * the query finds no results
+     */
+    private <F, O> List<O> executePagingFindQuery(String accountId,
+                                                  BiFunction<String, Pageable, Page<F>> findByAccountIdPagerQuery,
+                                                  Function<F, O> obDataModelConverter) {
+        int pageNumber = 0;
+        Page<F> pageOfFrItems;
+        List<O> obItems = null;
+        do {
+            pageOfFrItems = findByAccountIdPagerQuery.apply(accountId, PageRequest.of(pageNumber, dataPageSize));
+            if (obItems == null) {
+                obItems = new ArrayList<>((int) pageOfFrItems.getTotalElements());
+            }
+            for (F frItem : pageOfFrItems.getContent()) {
+                obItems.add(obDataModelConverter.apply(frItem));
+            }
+            pageNumber++;
+        }
+        while (pageOfFrItems.hasNext());
+
+        return obItems;
+    }
+
+}

--- a/secure-api-gateway-ob-uk-rs-resource-store/secure-api-gateway-ob-uk-rs-resource-store-api/src/test/java/com/forgerock/sapi/gateway/rs/resource/store/api/admin/DataExporterTest.java
+++ b/secure-api-gateway-ob-uk-rs-resource-store/secure-api-gateway-ob-uk-rs-resource-store-api/src/test/java/com/forgerock/sapi/gateway/rs/resource/store/api/admin/DataExporterTest.java
@@ -1,0 +1,421 @@
+/*
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.rs.resource.store.api.admin;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.client.AutoConfigureWebClient;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import com.forgerock.sapi.gateway.ob.uk.common.datamodel.account.FRFinancialAccount;
+import com.forgerock.sapi.gateway.ob.uk.common.datamodel.account.FRTransactionData;
+import com.forgerock.sapi.gateway.ob.uk.common.datamodel.converter.account.FRAccountBeneficiaryConverter;
+import com.forgerock.sapi.gateway.ob.uk.common.datamodel.converter.account.FRCashBalanceConverter;
+import com.forgerock.sapi.gateway.ob.uk.common.datamodel.converter.account.FRDirectDebitConverter;
+import com.forgerock.sapi.gateway.ob.uk.common.datamodel.converter.account.FROfferConverter;
+import com.forgerock.sapi.gateway.ob.uk.common.datamodel.converter.account.FRPartyConverter;
+import com.forgerock.sapi.gateway.ob.uk.common.datamodel.converter.account.FRStatementConverter;
+import com.forgerock.sapi.gateway.ob.uk.common.datamodel.converter.account.FRTransactionConverter;
+import com.forgerock.sapi.gateway.ob.uk.common.datamodel.converter.payment.FRScheduledPaymentConverter;
+import com.forgerock.sapi.gateway.ob.uk.common.datamodel.converter.payment.FRStandingOrderConverter;
+import com.forgerock.sapi.gateway.rs.resource.store.datamodel.account.FRAccountData;
+import com.forgerock.sapi.gateway.rs.resource.store.repo.entity.account.FRAccount;
+import com.forgerock.sapi.gateway.rs.resource.store.repo.entity.account.FRBalance;
+import com.forgerock.sapi.gateway.rs.resource.store.repo.entity.account.FRBeneficiary;
+import com.forgerock.sapi.gateway.rs.resource.store.repo.entity.account.FRDirectDebit;
+import com.forgerock.sapi.gateway.rs.resource.store.repo.entity.account.FROffer;
+import com.forgerock.sapi.gateway.rs.resource.store.repo.entity.account.FRParty;
+import com.forgerock.sapi.gateway.rs.resource.store.repo.entity.account.FRProduct;
+import com.forgerock.sapi.gateway.rs.resource.store.repo.entity.account.FRScheduledPayment;
+import com.forgerock.sapi.gateway.rs.resource.store.repo.entity.account.FRStandingOrder;
+import com.forgerock.sapi.gateway.rs.resource.store.repo.entity.account.FRStatement;
+import com.forgerock.sapi.gateway.rs.resource.store.repo.entity.account.FRTransaction;
+import com.forgerock.sapi.gateway.rs.resource.store.repo.mongo.accounts.balances.FRBalanceRepository;
+import com.forgerock.sapi.gateway.rs.resource.store.repo.mongo.accounts.beneficiaries.FRBeneficiaryRepository;
+import com.forgerock.sapi.gateway.rs.resource.store.repo.mongo.accounts.directdebits.FRDirectDebitRepository;
+import com.forgerock.sapi.gateway.rs.resource.store.repo.mongo.accounts.offers.FROfferRepository;
+import com.forgerock.sapi.gateway.rs.resource.store.repo.mongo.accounts.party.FRPartyRepository;
+import com.forgerock.sapi.gateway.rs.resource.store.repo.mongo.accounts.products.FRProductRepository;
+import com.forgerock.sapi.gateway.rs.resource.store.repo.mongo.accounts.scheduledpayments.FRScheduledPaymentRepository;
+import com.forgerock.sapi.gateway.rs.resource.store.repo.mongo.accounts.standingorders.FRStandingOrderRepository;
+import com.forgerock.sapi.gateway.rs.resource.store.repo.mongo.accounts.statements.FRStatementRepository;
+import com.forgerock.sapi.gateway.rs.resource.store.repo.mongo.accounts.transactions.FRTransactionRepository;
+
+import uk.org.openbanking.datamodel.account.OBBalanceType1Code;
+import uk.org.openbanking.datamodel.account.OBBeneficiary5;
+import uk.org.openbanking.datamodel.account.OBBeneficiaryType1Code;
+import uk.org.openbanking.datamodel.account.OBCashAccount51;
+import uk.org.openbanking.datamodel.account.OBCreditDebitCode2;
+import uk.org.openbanking.datamodel.account.OBExternalPartyType1Code;
+import uk.org.openbanking.datamodel.account.OBExternalStatementType1Code;
+import uk.org.openbanking.datamodel.account.OBParty2;
+import uk.org.openbanking.datamodel.account.OBReadBalance1;
+import uk.org.openbanking.datamodel.account.OBReadBalance1Data;
+import uk.org.openbanking.datamodel.account.OBReadBalance1DataBalanceInner;
+import uk.org.openbanking.datamodel.account.OBReadBalance1DataBalanceInnerAmount;
+import uk.org.openbanking.datamodel.account.OBReadDirectDebit2DataDirectDebitInner;
+import uk.org.openbanking.datamodel.account.OBReadOffer1;
+import uk.org.openbanking.datamodel.account.OBReadOffer1Data;
+import uk.org.openbanking.datamodel.account.OBReadOffer1DataOfferInner;
+import uk.org.openbanking.datamodel.account.OBReadOffer1DataOfferInnerOfferType;
+import uk.org.openbanking.datamodel.account.OBReadProduct2DataProductInner;
+import uk.org.openbanking.datamodel.account.OBReadProduct2DataProductInnerProductType;
+import uk.org.openbanking.datamodel.account.OBScheduledPayment3;
+import uk.org.openbanking.datamodel.account.OBStandingOrder6;
+import uk.org.openbanking.datamodel.account.OBStatement2;
+import uk.org.openbanking.datamodel.account.OBTransaction6;
+import uk.org.openbanking.datamodel.account.OBTransactionCashBalance;
+import uk.org.openbanking.datamodel.account.OBTransactionCashBalanceAmount;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@AutoConfigureWebClient(registerRestTemplate = true)
+class DataExporterTest {
+
+    @Autowired
+    private DataExporter dataExporter;
+    @Autowired
+    private FRTransactionRepository transactionRepository;
+    @Autowired
+    private FRProductRepository productRepository;
+    @Autowired
+    private FROfferRepository offerRepository;
+    @Autowired
+    private FRPartyRepository partyRepository;
+    @Autowired
+    private FRScheduledPaymentRepository scheduledPaymentRepository;
+    @Autowired
+    private FRBeneficiaryRepository beneficiaryRepository;
+    @Autowired
+    private FRDirectDebitRepository directDebitRepository;
+    @Autowired
+    private FRStatementRepository statementRepository;
+    @Autowired
+    private FRStandingOrderRepository standingOrderRepository;
+    @Autowired
+    private FRBalanceRepository balanceRepository;
+
+    private String accountId;
+
+    @BeforeEach
+    public void beforeEach() {
+        // Fresh accountId (and test data) for each test
+        accountId = UUID.randomUUID().toString();
+    }
+
+    @Test
+    public void testExportingAccountWithNoData() {
+        final FRAccountData accountData = exportAccountData();
+
+        assertThat(accountData.getBalances()).isEmpty();
+        assertThat(accountData.getTransactions()).isEmpty();
+        assertThat(accountData.getParty()).isNull();
+        assertThat(accountData.getStandingOrders()).isEmpty();
+        assertThat(accountData.getBeneficiaries()).isEmpty();
+        assertThat(accountData.getProduct()).isNull();
+        assertThat(accountData.getStandingOrders()).isEmpty();
+        assertThat(accountData.getDirectDebits()).isEmpty();
+        assertThat(accountData.getOffers()).isEmpty();
+        assertThat(accountData.getScheduledPayments()).isEmpty();
+        assertThat(accountData.getStatements()).isEmpty();
+    }
+
+    private FRAccount createAccount() {
+        return FRAccount.builder().id(accountId).account(FRFinancialAccount.builder().accountId(accountId).build()).build();
+    }
+
+    private FRAccountData exportAccountData() {
+        final FRAccount account = createAccount();
+        final FRAccountData accountData = dataExporter.exportAccountData(account);
+
+        assertThat(accountData.getAccount().getAccountId()).isEqualTo(accountId);
+        return accountData;
+    }
+
+    @Test
+    public void testExportingAccountWithTransactionData() {
+        final int numTransactions = 1234;
+        final List<OBTransaction6> transactions = generateTransactions(numTransactions);
+
+        final FRAccountData accountData = exportAccountData();
+        assertThat(accountData.getTransactions()).hasSize(numTransactions);
+        assertThat(accountData.getTransactions()).isEqualTo(transactions);
+    }
+
+    private List<OBTransaction6> generateTransactions(int numTransactions) {
+        final List<OBTransaction6> transactions = new ArrayList<>(numTransactions);
+        for (int i = 0; i < numTransactions; i++) {
+            transactions.add(new OBTransaction6().accountId(accountId)
+                                                 .balance(new OBTransactionCashBalance(OBCreditDebitCode2.CREDIT,
+                                                         OBBalanceType1Code.CLOSINGCLEARED,
+                                                         new OBTransactionCashBalanceAmount(i + ".00", "GBP")))
+                                                 .transactionReference("Test Payment: " + i));
+        }
+        transactionRepository.saveAll(transactions.stream().map(obTransaction -> {
+            final FRTransactionData frTransactionData = FRTransactionConverter.toFRTransactionData(obTransaction);
+            return FRTransaction.builder().transaction(frTransactionData).accountId(accountId).build();
+        }).toList());
+
+        return transactions;
+    }
+
+    @Test
+    public void testExportingAccountWithProductData() {
+        final OBReadProduct2DataProductInner product = generateProductData();
+
+        final FRAccountData accountData = exportAccountData();
+        assertThat(accountData.getProduct()).isEqualTo(product);
+    }
+
+    private OBReadProduct2DataProductInner generateProductData() {
+        final OBReadProduct2DataProductInner product = new OBReadProduct2DataProductInner().accountId(accountId)
+                                                                                           .productId(UUID.randomUUID().toString())
+                                                                                           .productType(OBReadProduct2DataProductInnerProductType.PERSONALCURRENTACCOUNT)
+                                                                                           .productName("321 Product");
+
+        productRepository.save(FRProduct.builder().accountId(accountId).product(product).build());
+        return product;
+    }
+
+    @Test
+    public void testExportingAccountWithOffers() {
+        final List<OBReadOffer1> offers = generateOffers(7);
+
+        final FRAccountData accountData = exportAccountData();
+        validateOffers(accountData, offers);
+    }
+
+    private static void validateOffers(FRAccountData accountData, List<OBReadOffer1> offers) {
+        assertThat(accountData.getOffers()).isEqualTo(offers.stream().flatMap(offer -> offer.getData().getOffer().stream()).toList());
+    }
+
+    private List<OBReadOffer1> generateOffers(int numOffers) {
+        final List<OBReadOffer1> offers = new ArrayList<>(numOffers);
+        for (int i = 0; i < numOffers; i++) {
+            offers.add(new OBReadOffer1(new OBReadOffer1Data().offer(List.of(new OBReadOffer1DataOfferInner().accountId(accountId).offerType(OBReadOffer1DataOfferInnerOfferType.BALANCETRANSFER).description("Offer #" + i)))));
+        }
+        offerRepository.saveAll(offers.stream().map(offer -> {
+            final FROffer frOffer = new FROffer();
+            frOffer.setAccountId(accountId);
+            frOffer.setOffer(FROfferConverter.toFROfferData(offer.getData().getOffer().get(0)));
+            return frOffer;
+        }).toList());
+        return offers;
+    }
+
+    @Test
+    public void testExportingAccountWithPartyData() {
+        final OBParty2 party = generatePartyData();
+
+        final FRAccountData accountData = exportAccountData();
+        assertThat(accountData.getParty()).isEqualTo(party);
+    }
+
+    private OBParty2 generatePartyData() {
+        final OBParty2 party = new OBParty2().partyType(OBExternalPartyType1Code.SOLE).accountRole("acc-role");
+        partyRepository.save(FRParty.builder().accountId(accountId).party(FRPartyConverter.toFRPartyData(party)).build());
+        return party;
+    }
+
+    @Test
+    public void testExportingAccountWithScheduledPaymentsData() {
+        final int numPayments = 99;
+        final List<OBScheduledPayment3> scheduledPayments = generateScheduledPayments(numPayments);
+
+        final FRAccountData accountData = exportAccountData();
+
+        assertThat(accountData.getScheduledPayments()).isEqualTo(scheduledPayments);
+    }
+
+    private List<OBScheduledPayment3> generateScheduledPayments(int numPayments) {
+        final List<OBScheduledPayment3> payments = new ArrayList<>(numPayments);
+        for (int i = 0; i < numPayments; i++) {
+            payments.add(new OBScheduledPayment3().accountId(accountId)
+                                                  .reference("Scheduled Payment #" + i)
+                                                  .creditorAccount(new OBCashAccount51().schemeName("ABC")
+                                                                                        .name("Test Acc")
+                                                                                        .identification("acc" + i)));
+        }
+        scheduledPaymentRepository.saveAll(
+                payments.stream().map(obScheduledPayment ->
+                                FRScheduledPayment.builder().accountId(accountId)
+                                        .scheduledPayment(
+                                                FRScheduledPaymentConverter.toFRScheduledPaymentData(obScheduledPayment))
+                                        .build())
+                        .toList());
+        return payments;
+    }
+
+    @Test
+    public void testExportingAccountWithBeneficiaryData() {
+        int numBeneficiaries = 2;
+        final List<OBBeneficiary5> beneficiaries = generateBeneficiaries(numBeneficiaries);
+
+        final FRAccountData accountData = exportAccountData();
+
+        assertThat(accountData.getBeneficiaries()).isEqualTo(beneficiaries);
+    }
+
+    private List<OBBeneficiary5> generateBeneficiaries(int numBeneficiaries) {
+        final List<OBBeneficiary5> beneficiaries = new ArrayList<>(numBeneficiaries);
+        for (int i = 0; i < numBeneficiaries; i++) {
+            beneficiaries.add(new OBBeneficiary5().accountId(accountId)
+                                                  .reference("Beneficiary #" + i)
+                                                  .beneficiaryType(OBBeneficiaryType1Code.ORDINARY));
+        }
+        beneficiaryRepository.saveAll(beneficiaries.stream().map(obBeneficiary ->
+                        FRBeneficiary.builder().accountId(accountId)
+                                .beneficiary(FRAccountBeneficiaryConverter.toFRAccountBeneficiary(obBeneficiary))
+                                .build())
+                        .toList());
+        return beneficiaries;
+    }
+
+    @Test
+    public void testExportAccountWithDirectDebitData() {
+        int numDirectDebits = 4;
+        final List<OBReadDirectDebit2DataDirectDebitInner> directDebits = generateDirectDebitData(numDirectDebits);
+
+        final FRAccountData accountData = exportAccountData();
+
+        assertThat(accountData.getDirectDebits()).isEqualTo(directDebits);
+    }
+
+    private List<OBReadDirectDebit2DataDirectDebitInner> generateDirectDebitData(int numDirectDebits) {
+        final List<OBReadDirectDebit2DataDirectDebitInner> directDebits = new ArrayList<>(numDirectDebits);
+        for (int i = 0; i < numDirectDebits; i++) {
+            directDebits.add(new OBReadDirectDebit2DataDirectDebitInner().accountId(accountId).name("DirectDebit #" + i));
+        }
+        directDebitRepository.saveAll(directDebits.stream().map(obDirectDebit ->
+                        FRDirectDebit.builder().accountId(accountId)
+                                .directDebit(FRDirectDebitConverter.toFRDirectDebitData(obDirectDebit))
+                                .build())
+                .toList());
+        return directDebits;
+    }
+
+    @Test
+    public void testExportAccountWithStatementData() {
+        int numStatements = 36;
+        final List<OBStatement2> statements = generateStatements(numStatements);
+
+        final FRAccountData accountData = exportAccountData();
+
+        assertThat(accountData.getStatements()).isEqualTo(statements);
+    }
+
+    private List<OBStatement2> generateStatements(int numStatements) {
+        final List<OBStatement2> statements = new ArrayList<>(numStatements);
+        for (int i = 0; i < numStatements; i++) {
+            statements.add(new OBStatement2().accountId(accountId).statementReference("Statement #" + i).type(OBExternalStatementType1Code.REGULARPERIODIC));
+        }
+        statementRepository.saveAll(statements.stream().map(obStatement ->
+                        FRStatement.builder().accountId(accountId)
+                                .statement(FRStatementConverter.toFRStatementData(obStatement))
+                                .build())
+                .toList());
+        return statements;
+    }
+
+    @Test
+    public void testExportAccountWithStandingOrders() {
+        int numStandingOrders = 1;
+        final List<OBStandingOrder6> standingOrders = generateStandingOrders(numStandingOrders);
+
+        final FRAccountData accountData = exportAccountData();
+
+        assertThat(accountData.getStandingOrders()).isEqualTo(standingOrders);
+    }
+
+    private List<OBStandingOrder6> generateStandingOrders(int numStandingOrders) {
+        final List<OBStandingOrder6> standingOrders = new ArrayList<>(numStandingOrders);
+        for (int i = 0; i < numStandingOrders; i++) {
+            standingOrders.add(new OBStandingOrder6().accountId(accountId).reference("Standing Order #" + i));
+        }
+        standingOrderRepository.saveAll(standingOrders.stream().map(obStandingOrder ->
+                        FRStandingOrder.builder().accountId(accountId)
+                                .standingOrder(FRStandingOrderConverter.toFRStandingOrderData(obStandingOrder))
+                                .build())
+                .toList());
+        return standingOrders;
+    }
+
+    @Test
+    public void testExportAccountWithBalances() {
+        final int numBalances = 3;
+        final List<OBReadBalance1> balances = generateBalances(numBalances);
+
+        final FRAccountData accountData = exportAccountData();
+
+        validateBalances(accountData, balances);
+    }
+
+    private static void validateBalances(FRAccountData accountData, List<OBReadBalance1> balances) {
+        assertThat(accountData.getBalances()).isEqualTo(balances.stream().flatMap(balance -> balance.getData().getBalance().stream()).toList());
+    }
+
+    private List<OBReadBalance1> generateBalances(int numBalances) {
+        final List<OBReadBalance1> balances = new ArrayList<>(numBalances);
+        for (int i = 0; i < numBalances; i++) {
+            balances.add(new OBReadBalance1().data(
+                    new OBReadBalance1Data().balance(
+                            List.of(new OBReadBalance1DataBalanceInner().accountId(accountId)
+                                    .amount(new OBReadBalance1DataBalanceInnerAmount(i + ".01", "GBP"))))));
+        }
+        balanceRepository.saveAll(balances.stream().map(obBalance ->
+                        FRBalance.builder().accountId(accountId)
+                                .balance(FRCashBalanceConverter.toFRCashBalance(obBalance.getData().getBalance().get(0)))
+                                .build())
+                .toList());
+        return balances;
+    }
+
+    @Test
+    public void testExportingAccountWithAllData() {
+        final List<OBTransaction6> transactions = generateTransactions(9341);
+        final List<OBReadBalance1> balances = generateBalances(15);
+        final List<OBReadOffer1> offers = generateOffers(1);
+        final List<OBReadDirectDebit2DataDirectDebitInner> directDebits = generateDirectDebitData(128);
+        final List<OBBeneficiary5> beneficiaries = generateBeneficiaries(9);
+        final OBParty2 party = generatePartyData();
+        final OBReadProduct2DataProductInner product = generateProductData();
+        final List<OBScheduledPayment3> scheduledPayments = generateScheduledPayments(501);
+        final List<OBStandingOrder6> standingOrders = generateStandingOrders(12);
+        final List<OBStatement2> statements = generateStatements(128);
+
+        final FRAccountData accountData = exportAccountData();
+
+        assertThat(accountData.getTransactions()).isEqualTo(transactions);
+        assertThat(accountData.getProduct()).isEqualTo(product);
+        validateOffers(accountData, offers);
+        assertThat(accountData.getParty()).isEqualTo(party);
+        assertThat(accountData.getScheduledPayments()).isEqualTo(scheduledPayments);
+        assertThat(accountData.getBeneficiaries()).isEqualTo(beneficiaries);
+        assertThat(accountData.getDirectDebits()).isEqualTo(directDebits);
+        assertThat(accountData.getStatements()).isEqualTo(statements);
+        assertThat(accountData.getStandingOrders()).isEqualTo(standingOrders);
+        validateBalances(accountData, balances);
+    }
+
+}


### PR DESCRIPTION
A bug in the data export was causing the exported data for an individual user to contain data for all of the users.

The bug was due to the data paging being implemented incorrectly.

New service: DataExporter has been created which handles gathering the account data. It contains a reusable function which handles processing a paging query.

https://github.com/SecureApiGateway/SecureApiGateway/issues/1430