### PR TITLE
1430: Fix username in user data export

### DIFF
--- a/secure-api-gateway-ob-uk-rs-cloud-client/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/cloud/client/services/UserClientServiceTest.java
+++ b/secure-api-gateway-ob-uk-rs-cloud-client/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/cloud/client/services/UserClientServiceTest.java
@@ -61,7 +61,7 @@ public class UserClientServiceTest {
     private final static String ACCOUNT_ACTIVE_STATUS = "active";
 
     @Test
-    public void shouldGetUserDataFromPlatform() throws Exception {
+    public void shouldGetUserByUsername() throws Exception {
         // Given
         User user = User.builder()
                 .id(UUID.randomUUID().toString())
@@ -137,6 +137,29 @@ public class UserClientServiceTest {
         assertThat(exception.getErrorClient().getErrorType()).isEqualTo(ErrorType.PARAMETER_ERROR);
         assertThat(exception.getErrorClient().getErrorType().getErrorCode()).isEqualTo(ErrorType.PARAMETER_ERROR.getErrorCode());
         assertThat(exception.getErrorClient().getErrorType().getInternalCode()).isEqualTo(ErrorType.PARAMETER_ERROR.getInternalCode());
+    }
+
+    @Test
+    public void shouldGetUserById() throws Exception {
+        // Given
+        final String userId = UUID.randomUUID().toString();
+        User user = User.builder()
+                .id(userId)
+                .userName(USER_NAME)
+                .accountStatus(ACCOUNT_ACTIVE_STATUS)
+                .build();
+        // When
+        mockServer.expect(once(), requestTo("http://ig:80/repo/users/" + userId))
+                .andRespond(withStatus(HttpStatus.OK)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .body(objectMapper.writeValueAsString(user)));
+
+        User userResponse = userClientService.getUserById(userId);
+        // Then
+        assertThat(userResponse).isNotNull();
+        assertThat(userResponse.getAccountStatus()).isEqualTo(ACCOUNT_ACTIVE_STATUS);
+        assertThat(userResponse.getUserName()).isEqualTo(user.getUserName());
+        assertThat(userResponse.getId()).isEqualTo(user.getId());
     }
 
 }

--- a/secure-api-gateway-ob-uk-rs-resource-store/secure-api-gateway-ob-uk-rs-resource-store-api/src/test/java/com/forgerock/sapi/gateway/rs/resource/store/api/admin/DataApiControllerTest.java
+++ b/secure-api-gateway-ob-uk-rs-resource-store/secure-api-gateway-ob-uk-rs-resource-store-api/src/test/java/com/forgerock/sapi/gateway/rs/resource/store/api/admin/DataApiControllerTest.java
@@ -18,6 +18,7 @@ package com.forgerock.sapi.gateway.rs.resource.store.api.admin;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowableOfType;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
 import static org.springframework.http.HttpMethod.GET;
@@ -149,7 +150,7 @@ public class DataApiControllerTest {
         );
 
         // When
-        when(userClientService.getUserByName(anyString())).thenReturn(user);
+        when(userClientService.getUserByName(eq(user.getUserName()))).thenReturn(user);
 
         ResponseEntity<FRUserData> response = restTemplate.postForEntity(dataUrl(), userData, FRUserData.class);
 
@@ -162,9 +163,14 @@ public class DataApiControllerTest {
         final FRAccountData responseAccount = responseAccountData.get(0);
         assertThat(responseAccount.getTransactions()).hasSize(numTransactions);
 
+        when(userClientService.getUserById(eq(user.getId()))).thenReturn(user);
+
         ResponseEntity<FRUserData> exportedData = restTemplate.exchange(dataUrl() + "?userId=" + user.getId(), GET, HttpEntity.EMPTY, FRUserData.class);
         assertThat(exportedData.getStatusCode()).isEqualTo(HttpStatus.OK);
-        final List<FRAccountData> exportedAccountData = exportedData.getBody().getAccountDatas();
+        final FRUserData exportedUserData = exportedData.getBody();
+        assertThat(exportedUserData.getUserId()).isEqualTo(user.getId());
+        assertThat(exportedUserData.getUserName()).isEqualTo(user.getUserName());
+        final List<FRAccountData> exportedAccountData = exportedUserData.getAccountDatas();
         assertThat(exportedAccountData).hasSize(1);
         final FRAccountData exportedAccount = exportedAccountData.get(0);
         assertThat(exportedAccount.getTransactions()).hasSize(numTransactions);
@@ -225,7 +231,8 @@ public class DataApiControllerTest {
         );
 
         // When
-        when(userClientService.getUserByName(anyString())).thenReturn(user);
+        when(userClientService.getUserByName(eq(user.getUserName()))).thenReturn(user);
+        when(userClientService.getUserById(eq(user.getId()))).thenReturn(user);
 
         // When
         ResponseEntity<FRUserData> response = restTemplate.exchange(dataUrl(), PUT, new HttpEntity<>(userData), FRUserData.class);

--- a/secure-api-gateway-ob-uk-rs-resource-store/secure-api-gateway-ob-uk-rs-resource-store-datamodel/src/main/java/com/forgerock/sapi/gateway/rs/resource/store/datamodel/user/FRUserData.java
+++ b/secure-api-gateway-ob-uk-rs-resource-store/secure-api-gateway-ob-uk-rs-resource-store-datamodel/src/main/java/com/forgerock/sapi/gateway/rs/resource/store/datamodel/user/FRUserData.java
@@ -36,8 +36,8 @@ public class FRUserData {
     private List<FRAccountData> accountDatas = new ArrayList<>();
     private FRCustomerInfo customerInfo;
 
-    public FRUserData(String userName) {
-        this.userName = userName;
+    public FRUserData(String userId) {
+        this.userId = userId;
     }
 
     public void addAccountData(FRAccountData accountData) {


### PR DESCRIPTION
The username was previously being set to the userId.

Setting the username correctly by querying the platform for the user data.

This now allows exported data to be re-imported without any errors, which makes the process of updating an existing user's data more straightforward.

https://github.com/SecureApiGateway/SecureApiGateway/issues/1430