### PR TITLE
1430: Always set accountId in data created by FakeDataApiController

### DIFF
--- a/secure-api-gateway-ob-uk-rs-resource-store/secure-api-gateway-ob-uk-rs-resource-store-api/src/main/java/com/forgerock/sapi/gateway/rs/resource/store/api/admin/FakeDataApiController.java
+++ b/secure-api-gateway-ob-uk-rs-resource-store/secure-api-gateway-ob-uk-rs-resource-store-api/src/main/java/com/forgerock/sapi/gateway/rs/resource/store/api/admin/FakeDataApiController.java
@@ -660,6 +660,7 @@ public class FakeDataApiController implements FakeDataApi {
         scheduledPayment.setAccountId(account.getId());
         scheduledPayment.setStatus(FRScheduledPayment.ScheduledPaymentStatus.PENDING);
         scheduledPayment.setScheduledPayment(FRScheduledPaymentData.builder()
+                .accountId(account.getId())
                 .scheduledPaymentId(scheduledPaymentId)
                 .scheduledPaymentDateTime(DateTime.now().plusDays(ThreadLocalRandom.current().nextInt(15, 200)))
                 .scheduledType(FRScheduledPaymentData.FRScheduleType.EXECUTION)

--- a/secure-api-gateway-ob-uk-rs-resource-store/secure-api-gateway-ob-uk-rs-resource-store-api/src/main/java/com/forgerock/sapi/gateway/rs/resource/store/api/admin/FakeDataApiController.java
+++ b/secure-api-gateway-ob-uk-rs-resource-store/secure-api-gateway-ob-uk-rs-resource-store-api/src/main/java/com/forgerock/sapi/gateway/rs/resource/store/api/admin/FakeDataApiController.java
@@ -721,6 +721,7 @@ public class FakeDataApiController implements FakeDataApi {
         offer1.setAccountId(account2.getId());
         offer1.setId(offerId);
         offer1.setOffer(FROfferData.builder()
+                .accountId(account2.getId())
                 .offerId(offerId)
                 .offerType(FROfferData.FROfferType.LIMITINCREASE)
                 .description("Credit limit increase for the account up to £" + FORMAT_AMOUNT.format(amount))
@@ -745,6 +746,7 @@ public class FakeDataApiController implements FakeDataApi {
         offer1.setAccountId(account2.getId());
         offer1.setId(offerId);
         offer1.setOffer(FROfferData.builder()
+                .accountId(account2.getId())
                 .offerId(offerId)
                 .offerType(FROfferData.FROfferType.BALANCETRANSFER)
                 .description("Balance transfer offer up to £" + FORMAT_AMOUNT.format(amount))


### PR DESCRIPTION
Setting:
- FRScheduledPayment.scheduledPayment.accountId
- FROffer.offer.accountId

The nested accountId fields need to be set in order to allow the data to be updated by the Data API.

https://github.com/SecureApiGateway/SecureApiGateway/issues/1430