### PR TITLE
1478: Fix backoffice accounts query to work with multiple balances

### DIFF
--- a/secure-api-gateway-ob-uk-rs-resource-store/secure-api-gateway-ob-uk-rs-resource-store-repo/src/main/java/com/forgerock/sapi/gateway/rs/resource/store/repo/mongo/accounts/balances/FRBalanceRepository.java
+++ b/secure-api-gateway-ob-uk-rs-resource-store/secure-api-gateway-ob-uk-rs-resource-store-repo/src/main/java/com/forgerock/sapi/gateway/rs/resource/store/repo/mongo/accounts/balances/FRBalanceRepository.java
@@ -31,7 +31,7 @@ public interface FRBalanceRepository extends MongoRepository<FRBalance, String>,
 
     Page<FRBalance> findByAccountId(@Param("accountId") String accountId, Pageable pageable);
 
-    FRBalance findByAccountId(@Param("accountId") String accountId);
+    Collection<FRBalance> findByAccountId(@Param("accountId") String accountId);
 
     Page<FRBalance> findByAccountIdIn(@Param("accountIds") List<String> accountIds, Pageable pageable);
 


### PR DESCRIPTION
This fixes a bug in the backoffice AccountsApiController.getAccountWithBalanceByIdentifiers method which fails if the account contains multiple balances.

Both methods for getting accounts now populate the balances in the same fashion (and can handle multiple accounts).

https://github.com/SecureApiGateway/SecureApiGateway/issues/1478