### PR TITLE
1479: Remove accountIdentifierName from account queries

### DIFF
--- a/secure-api-gateway-ob-uk-rs-backoffice-api/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/backoffice/api/account/AccountsApi.java
+++ b/secure-api-gateway-ob-uk-rs-backoffice-api/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/backoffice/api/account/AccountsApi.java
@@ -70,18 +70,14 @@ public interface AccountsApi {
     );
 
     /**
-     * Retrieves a user's bank account details, including it's associated balance(s) (if requested).
-     * @param userId
-     *         The ID of the user who owns the account
-     * @param accountIdentifierName
-     *         Indicates the name of account identifier to filter the account identifiers. Defaults to false.
-     * @param accountIdentifierIdentification
-     *         Indicates the identification of account identifier to filter the account identifiers. Defaults to false.
-     * @param accountIdentifierSchemeName
-     *         Indicates the schema name of account identifier to filter the account identifiers. Defaults to false.
-     * @return a {@link FRAccountIdentifier} instance if found, or void otherwise.
+     * Retrieves a user's bank account details, including it's associated balance(s).
+     *
+     * @param userId                          The ID of the user who owns the account
+     * @param accountIdentifierIdentification Indicates the value of account identifier to filter the account identifiers.
+     * @param accountIdentifierSchemeName     Indicates the schema name of account identifier to filter the account identifiers.
+     * @return a {@link FRAccountIdentifier} instance if found, or null otherwise.
      */
-    @ApiOperation(value = "Get User Account with balance filtered by name, identification and schema name",
+    @ApiOperation(value = "Get User Account with balance filtered by userId, identification and schema name",
             nickname = "getUserAccountIdentifier",
             notes = "", response = FRAccountIdentifier.class,
             tags = {"Get User Account identifier",})
@@ -99,14 +95,12 @@ public interface AccountsApi {
             produces = {"application/json; charset=utf-8"},
             method = RequestMethod.GET)
     ResponseEntity<FRAccountWithBalance> getAccountWithBalanceByIdentifiers(
-            @ApiParam(value = "The ID of the PSU who owns the account. (non mandatory)")
-            @RequestParam(value = "userId", required = false) String userId,
-            @ApiParam(value = "Indicates the name of account identifier to filter the account identifiers. Defaults to false.")
-            @RequestParam(value = "name", defaultValue = "false") String accountIdentifierName,
-            @ApiParam(value = "Indicates the identification of account identifier to filter the account identifiers. Defaults to false.")
-            @RequestParam(value = "identification", defaultValue = "false") String accountIdentifierIdentification,
-            @ApiParam(value = "Indicates the schema name of account identifier to filter the account identifiers. Defaults to false.")
-            @RequestParam(value = "schemeName", defaultValue = "false") String accountIdentifierSchemeName
+            @ApiParam(value = "The ID of the PSU who owns the account.")
+            @RequestParam(value = "userId") String userId,
+            @ApiParam(value = "Indicates the identification of account identifier to filter the account identifiers.")
+            @RequestParam(value = "identification") String accountIdentifierIdentification,
+            @ApiParam(value = "Indicates the schema name of account identifier to filter the account identifiers.")
+            @RequestParam(value = "schemeName") String accountIdentifierSchemeName
     );
 
 }

--- a/secure-api-gateway-ob-uk-rs-resource-store/secure-api-gateway-ob-uk-rs-resource-store-repo/src/main/java/com/forgerock/sapi/gateway/rs/resource/store/repo/mongo/accounts/accounts/FRAccountRepository.java
+++ b/secure-api-gateway-ob-uk-rs-resource-store/secure-api-gateway-ob-uk-rs-resource-store-repo/src/main/java/com/forgerock/sapi/gateway/rs/resource/store/repo/mongo/accounts/accounts/FRAccountRepository.java
@@ -26,17 +26,9 @@ public interface FRAccountRepository extends MongoRepository<FRAccount, String>,
 
     Collection<FRAccount> findByUserID(@Param("userID") String userID);
 
-    @Query("{ 'userID': ?0 , 'account.accounts.name' : ?1, 'account.accounts.identification' : ?2, 'account.accounts.schemeName': ?3}")
+    @Query("{ 'userID': ?0 , 'account.accounts.identification' : ?1, 'account.accounts.schemeName': ?2}")
     FRAccount findByUserIdAndAccountIdentifiers(
             @Param("userID") String userID,
-            @Param("account.accounts.name") String accountIdentifierName,
-            @Param("account.accounts.identification") String accountIdentifierIdentification,
-            @Param("account.accounts.schemeName") String accountIdentifierSchemeName
-    );
-
-    @Query("{ 'account.accounts.name' : ?0, 'account.accounts.identification' : ?1, 'account.accounts.schemeName': ?2}")
-    FRAccount findByAccountIdentifiers(
-            @Param("account.accounts.name") String accountIdentifierName,
             @Param("account.accounts.identification") String accountIdentifierIdentification,
             @Param("account.accounts.schemeName") String accountIdentifierSchemeName
     );

--- a/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/backoffice/account/AccountsApiController.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/backoffice/account/AccountsApiController.java
@@ -82,31 +82,17 @@ public class AccountsApiController implements AccountsApi {
     @Override
     public ResponseEntity<FRAccountWithBalance> getAccountWithBalanceByIdentifiers(
             String userId,
-            String accountIdentifierName,
             String accountIdentifierIdentification,
             String accountIdentifierSchemeName
     ) {
         log.info(
-                "Read all account identifier for user ID '{}', with name: {}, identification {} and schema name {}",
-                userId, accountIdentifierName, accountIdentifierIdentification, accountIdentifierSchemeName
+                "Read all account identifier for user ID '{}', identification {} and schema name {}",
+                userId, accountIdentifierIdentification, accountIdentifierSchemeName
         );
 
-        FRAccount account;
-        if(Objects.isNull(userId)) {
-            account = accountsRepository.findByAccountIdentifiers(
-                    accountIdentifierName,
-                    accountIdentifierIdentification,
-                    accountIdentifierSchemeName
-            );
-        } else {
-            account = accountsRepository.findByUserIdAndAccountIdentifiers(
-                    userId,
-                    accountIdentifierName,
-                    accountIdentifierIdentification,
-                    accountIdentifierSchemeName
-            );
-        }
-
+        final FRAccount account = accountsRepository.findByUserIdAndAccountIdentifiers(userId,
+                                                                                       accountIdentifierIdentification,
+                                                                                       accountIdentifierSchemeName);
         if (account != null) {
             final List<FRCashBalance> balances = balanceRepository.findByAccountId(account.getId())
                                                                   .stream()

--- a/secure-api-gateway-ob-uk-rs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/backoffice/account/AccountsApiControllerTest.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/backoffice/account/AccountsApiControllerTest.java
@@ -39,7 +39,6 @@ import org.springframework.web.util.UriComponentsBuilder;
 
 import java.net.URI;
 import java.util.List;
-import java.util.Objects;
 
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -259,35 +258,6 @@ public class AccountsApiControllerTest {
         return balances;
     }
 
-    @Test
-    public void shouldFindAccountWithBalanceByAccountIdentifiersNoUserId(){
-        // Given
-        FRAccount account = FRAccountTestDataFactory.aValidFRAccount();
-        frAccountRepository.save(account);
-        FRBalance accountBalance = aValidFRBalance(account.getId());
-        frBalanceRepository.save(accountBalance);
-        URI uri = findAccountUriByAccountIdentifiers(null, account.getAccount().getFirstAccount());
-        ParameterizedTypeReference<FRAccountWithBalance> typeReference = new ParameterizedTypeReference<>() {
-        };
-
-        // When
-        ResponseEntity<FRAccountWithBalance> response = restTemplate.exchange(
-                uri,
-                HttpMethod.GET,
-                new HttpEntity<>(httpHeaders()),
-                typeReference);
-
-        // Then
-        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-        assertThat(response.getBody()).isNotNull();
-        FRAccountWithBalance accountWithBalance = response.getBody();
-        assertThat(accountWithBalance.getId()).isEqualTo(account.getId());
-        assertThat(accountWithBalance.getUserId()).isEqualTo(account.getUserID());
-        assertThat(accountWithBalance.getAccount().getAccountId()).isEqualTo(account.getAccount().getAccountId());
-        assertThat(accountWithBalance.getBalances()).isNotEmpty();
-        assertThat(accountWithBalance.getBalances().get(0)).isEqualTo(accountBalance.getBalance());
-    }
-
     private FRBalance aValidFRBalance(String accountId) {
         return aValidFRBalance(accountId, FRBalanceType.INTERIMAVAILABLE);
     }
@@ -321,11 +291,8 @@ public class AccountsApiControllerTest {
 
     private URI findAccountUriByAccountIdentifiers(String userId, FRAccountIdentifier accountIdentifier){
         UriComponentsBuilder builder = UriComponentsBuilder.fromHttpUrl(BASE_URL + port + FIND_USER_ACCOUNTS_URI_BY_IDENTIFIERS);
-        if(Objects.nonNull(userId)) {
-            builder.queryParam("userId", userId);
-        }
+        builder.queryParam("userId", userId);
         builder.queryParam("identification", accountIdentifier.getIdentification());
-        builder.queryParam("name", accountIdentifier.getName());
         builder.queryParam("schemeName", accountIdentifier.getSchemeName());
         return builder.build().encode().toUri();
     }

--- a/secure-api-gateway-ob-uk-rs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/account/v3_1_10/accounts/AccountAccessConsentsApiControllerTest.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/account/v3_1_10/accounts/AccountAccessConsentsApiControllerTest.java
@@ -29,7 +29,6 @@ import static org.springframework.boot.test.context.SpringBootTest.WebEnvironmen
 import java.util.Date;
 import java.util.List;
 
-import org.joda.time.DateTime;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;


### PR DESCRIPTION
The accountIdentifierName corresponds to the name of the user that owns the account.

When querying by account identifiers the userId, identification value and schemeName must be provided, the name is optional for some payments (all except VRP) and the existing database data in the name field is unlikely to match what is provided by the TPP.

If name validation is required for certain flows (not being implemented currently), then it can be done in the biz logic using the data returned from the database.

https://github.com/SecureApiGateway/SecureApiGateway/issues/1479