### PR TITLE
1477: Fix imports for v3 datamodel

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,8 +50,8 @@
     </parent>
 
     <properties>
-        <uk.bom.version>3.1.0</uk.bom.version>
-        <consent.api.version>3.1.0</consent.api.version>
+        <uk.bom.version>4.0.0-SNAPSHOT</uk.bom.version>
+        <consent.api.version>4.0.0-SNAPSHOT</consent.api.version>
     </properties>
 
     <dependencyManagement>

--- a/secure-api-gateway-ob-uk-rs-backoffice-api/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/backoffice/api/account/AccountsApi.java
+++ b/secure-api-gateway-ob-uk-rs-backoffice-api/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/backoffice/api/account/AccountsApi.java
@@ -27,7 +27,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
-import uk.org.openbanking.datamodel.error.OBErrorResponse1;
+import uk.org.openbanking.datamodel.v3.error.OBErrorResponse1;
 
 import java.util.List;
 

--- a/secure-api-gateway-ob-uk-rs-obie-api/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/obie/api/account/v3_1_10/accounts/AccountAccessConsentsApi.java
+++ b/secure-api-gateway-ob-uk-rs-obie-api/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/obie/api/account/v3_1_10/accounts/AccountAccessConsentsApi.java
@@ -45,8 +45,8 @@ import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
 import io.swagger.annotations.Authorization;
 import io.swagger.annotations.AuthorizationScope;
-import uk.org.openbanking.datamodel.account.OBReadConsent1;
-import uk.org.openbanking.datamodel.account.OBReadConsentResponse1;
+import uk.org.openbanking.datamodel.v3.account.OBReadConsent1;
+import uk.org.openbanking.datamodel.v3.account.OBReadConsentResponse1;
 
 @Api(tags = "v3.1.10", description = "the account-access-consents API")
 @RequestMapping(value = "/open-banking/v3.1.10/aisp")

--- a/secure-api-gateway-ob-uk-rs-obie-api/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/obie/api/account/v3_1_10/accounts/AccountsApi.java
+++ b/secure-api-gateway-ob-uk-rs-obie-api/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/obie/api/account/v3_1_10/accounts/AccountsApi.java
@@ -30,7 +30,7 @@ import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
 import io.swagger.annotations.Authorization;
 import io.swagger.annotations.AuthorizationScope;
-import uk.org.openbanking.datamodel.account.OBReadAccount6;
+import uk.org.openbanking.datamodel.v3.account.OBReadAccount6;
 
 import org.joda.time.DateTime;
 import org.springframework.format.annotation.DateTimeFormat;

--- a/secure-api-gateway-ob-uk-rs-obie-api/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/obie/api/account/v3_1_10/balances/BalancesApi.java
+++ b/secure-api-gateway-ob-uk-rs-obie-api/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/obie/api/account/v3_1_10/balances/BalancesApi.java
@@ -30,7 +30,7 @@ import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
 import io.swagger.annotations.Authorization;
 import io.swagger.annotations.AuthorizationScope;
-import uk.org.openbanking.datamodel.account.OBReadBalance1;
+import uk.org.openbanking.datamodel.v3.account.OBReadBalance1;
 
 import org.joda.time.DateTime;
 import org.springframework.format.annotation.DateTimeFormat;

--- a/secure-api-gateway-ob-uk-rs-obie-api/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/obie/api/account/v3_1_10/beneficiaries/BeneficiariesApi.java
+++ b/secure-api-gateway-ob-uk-rs-obie-api/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/obie/api/account/v3_1_10/beneficiaries/BeneficiariesApi.java
@@ -31,7 +31,7 @@ import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
 import io.swagger.annotations.Authorization;
 import io.swagger.annotations.AuthorizationScope;
-import uk.org.openbanking.datamodel.account.OBReadBeneficiary5;
+import uk.org.openbanking.datamodel.v3.account.OBReadBeneficiary5;
 
 import org.joda.time.DateTime;
 import org.springframework.format.annotation.DateTimeFormat;

--- a/secure-api-gateway-ob-uk-rs-obie-api/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/obie/api/account/v3_1_10/directdebits/DirectDebitsApi.java
+++ b/secure-api-gateway-ob-uk-rs-obie-api/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/obie/api/account/v3_1_10/directdebits/DirectDebitsApi.java
@@ -31,7 +31,7 @@ import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
 import io.swagger.annotations.Authorization;
 import io.swagger.annotations.AuthorizationScope;
-import uk.org.openbanking.datamodel.account.OBReadDirectDebit2;
+import uk.org.openbanking.datamodel.v3.account.OBReadDirectDebit2;
 
 import org.joda.time.DateTime;
 import org.springframework.format.annotation.DateTimeFormat;

--- a/secure-api-gateway-ob-uk-rs-obie-api/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/obie/api/account/v3_1_10/offers/OffersApi.java
+++ b/secure-api-gateway-ob-uk-rs-obie-api/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/obie/api/account/v3_1_10/offers/OffersApi.java
@@ -31,7 +31,7 @@ import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
 import io.swagger.annotations.Authorization;
 import io.swagger.annotations.AuthorizationScope;
-import uk.org.openbanking.datamodel.account.OBReadOffer1;
+import uk.org.openbanking.datamodel.v3.account.OBReadOffer1;
 
 import org.joda.time.DateTime;
 import org.springframework.format.annotation.DateTimeFormat;

--- a/secure-api-gateway-ob-uk-rs-obie-api/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/obie/api/account/v3_1_10/party/PartyApi.java
+++ b/secure-api-gateway-ob-uk-rs-obie-api/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/obie/api/account/v3_1_10/party/PartyApi.java
@@ -31,8 +31,8 @@ import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
 import io.swagger.annotations.Authorization;
 import io.swagger.annotations.AuthorizationScope;
-import uk.org.openbanking.datamodel.account.OBReadParty2;
-import uk.org.openbanking.datamodel.account.OBReadParty3;
+import uk.org.openbanking.datamodel.v3.account.OBReadParty2;
+import uk.org.openbanking.datamodel.v3.account.OBReadParty3;
 
 import org.joda.time.DateTime;
 import org.springframework.format.annotation.DateTimeFormat;

--- a/secure-api-gateway-ob-uk-rs-obie-api/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/obie/api/account/v3_1_10/products/ProductsApi.java
+++ b/secure-api-gateway-ob-uk-rs-obie-api/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/obie/api/account/v3_1_10/products/ProductsApi.java
@@ -30,7 +30,7 @@ import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
 import io.swagger.annotations.Authorization;
 import io.swagger.annotations.AuthorizationScope;
-import uk.org.openbanking.datamodel.account.OBReadProduct2;
+import uk.org.openbanking.datamodel.v3.account.OBReadProduct2;
 
 import org.joda.time.DateTime;
 import org.springframework.format.annotation.DateTimeFormat;

--- a/secure-api-gateway-ob-uk-rs-obie-api/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/obie/api/account/v3_1_10/scheduledpayments/ScheduledPaymentsApi.java
+++ b/secure-api-gateway-ob-uk-rs-obie-api/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/obie/api/account/v3_1_10/scheduledpayments/ScheduledPaymentsApi.java
@@ -31,7 +31,7 @@ import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
 import io.swagger.annotations.Authorization;
 import io.swagger.annotations.AuthorizationScope;
-import uk.org.openbanking.datamodel.account.OBReadScheduledPayment3;
+import uk.org.openbanking.datamodel.v3.account.OBReadScheduledPayment3;
 
 import org.joda.time.DateTime;
 import org.springframework.format.annotation.DateTimeFormat;

--- a/secure-api-gateway-ob-uk-rs-obie-api/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/obie/api/account/v3_1_10/standingorders/StandingOrdersApi.java
+++ b/secure-api-gateway-ob-uk-rs-obie-api/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/obie/api/account/v3_1_10/standingorders/StandingOrdersApi.java
@@ -30,7 +30,7 @@ import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
 import io.swagger.annotations.Authorization;
 import io.swagger.annotations.AuthorizationScope;
-import uk.org.openbanking.datamodel.account.OBReadStandingOrder6;
+import uk.org.openbanking.datamodel.v3.account.OBReadStandingOrder6;
 
 import org.joda.time.DateTime;
 import org.springframework.format.annotation.DateTimeFormat;

--- a/secure-api-gateway-ob-uk-rs-obie-api/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/obie/api/account/v3_1_10/statements/StatementsApi.java
+++ b/secure-api-gateway-ob-uk-rs-obie-api/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/obie/api/account/v3_1_10/statements/StatementsApi.java
@@ -43,8 +43,8 @@ import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
 import io.swagger.annotations.Authorization;
 import io.swagger.annotations.AuthorizationScope;
-import uk.org.openbanking.datamodel.account.OBReadStatement2;
-import uk.org.openbanking.datamodel.error.OBErrorResponse1;
+import uk.org.openbanking.datamodel.v3.account.OBReadStatement2;
+import uk.org.openbanking.datamodel.v3.error.OBErrorResponse1;
 
 @Api(tags = {"v3.1.10", SwaggerApiTags.ACCOUNTS_AND_TRANSACTION_TAG})
 @RequestMapping(value = "/open-banking/v3.1.10/aisp")

--- a/secure-api-gateway-ob-uk-rs-obie-api/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/obie/api/account/v3_1_10/transactions/TransactionsApi.java
+++ b/secure-api-gateway-ob-uk-rs-obie-api/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/obie/api/account/v3_1_10/transactions/TransactionsApi.java
@@ -41,7 +41,7 @@ import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
 import io.swagger.annotations.Authorization;
 import io.swagger.annotations.AuthorizationScope;
-import uk.org.openbanking.datamodel.account.OBReadTransaction6;
+import uk.org.openbanking.datamodel.v3.account.OBReadTransaction6;
 
 @Api(tags = {"v3.1.10", SwaggerApiTags.ACCOUNTS_AND_TRANSACTION_TAG})
 @RequestMapping(value = "/open-banking/v3.1.10/aisp")

--- a/secure-api-gateway-ob-uk-rs-obie-api/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/obie/api/event/v3_1_10/aggregatedpolling/AggregatedPollingApi.java
+++ b/secure-api-gateway-ob-uk-rs-obie-api/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/obie/api/event/v3_1_10/aggregatedpolling/AggregatedPollingApi.java
@@ -34,9 +34,9 @@ import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
 import io.swagger.annotations.Authorization;
 import io.swagger.annotations.AuthorizationScope;
-import uk.org.openbanking.datamodel.error.OBErrorResponse1;
-import uk.org.openbanking.datamodel.event.OBEventPolling1;
-import uk.org.openbanking.datamodel.event.OBEventPollingResponse1;
+import uk.org.openbanking.datamodel.v3.error.OBErrorResponse1;
+import uk.org.openbanking.datamodel.v3.event.OBEventPolling1;
+import uk.org.openbanking.datamodel.v3.event.OBEventPollingResponse1;
 
 @Api(tags = {"v3.1.10", SwaggerApiTags.EVENT_NOTIFICATION_TAG})
 @RequestMapping(value = "/open-banking/v3.1.10/events")

--- a/secure-api-gateway-ob-uk-rs-obie-api/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/obie/api/event/v3_1_10/eventsubscription/EventSubscriptionsApi.java
+++ b/secure-api-gateway-ob-uk-rs-obie-api/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/obie/api/event/v3_1_10/eventsubscription/EventSubscriptionsApi.java
@@ -28,10 +28,10 @@ import io.swagger.annotations.Authorization;
 import io.swagger.annotations.AuthorizationScope;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
-import uk.org.openbanking.datamodel.error.OBErrorResponse1;
-import uk.org.openbanking.datamodel.event.OBEventSubscription1;
-import uk.org.openbanking.datamodel.event.OBEventSubscriptionResponse1;
-import uk.org.openbanking.datamodel.event.OBEventSubscriptionsResponse1;
+import uk.org.openbanking.datamodel.v3.error.OBErrorResponse1;
+import uk.org.openbanking.datamodel.v3.event.OBEventSubscription1;
+import uk.org.openbanking.datamodel.v3.event.OBEventSubscriptionResponse1;
+import uk.org.openbanking.datamodel.v3.event.OBEventSubscriptionsResponse1;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;

--- a/secure-api-gateway-ob-uk-rs-obie-api/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/obie/api/funds/v3_1_10/FundsConfirmationConsentsApi.java
+++ b/secure-api-gateway-ob-uk-rs-obie-api/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/obie/api/funds/v3_1_10/FundsConfirmationConsentsApi.java
@@ -21,9 +21,9 @@ import org.joda.time.DateTime;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-import uk.org.openbanking.datamodel.error.OBErrorResponse1;
-import uk.org.openbanking.datamodel.fund.OBFundsConfirmationConsent1;
-import uk.org.openbanking.datamodel.fund.OBFundsConfirmationConsentResponse1;
+import uk.org.openbanking.datamodel.v3.error.OBErrorResponse1;
+import uk.org.openbanking.datamodel.v3.fund.OBFundsConfirmationConsent1;
+import uk.org.openbanking.datamodel.v3.fund.OBFundsConfirmationConsentResponse1;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;

--- a/secure-api-gateway-ob-uk-rs-obie-api/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/obie/api/funds/v3_1_10/FundsConfirmationsApi.java
+++ b/secure-api-gateway-ob-uk-rs-obie-api/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/obie/api/funds/v3_1_10/FundsConfirmationsApi.java
@@ -29,9 +29,9 @@ import io.swagger.annotations.Authorization;
 import io.swagger.annotations.AuthorizationScope;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
-import uk.org.openbanking.datamodel.error.OBErrorResponse1;
-import uk.org.openbanking.datamodel.fund.OBFundsConfirmation1;
-import uk.org.openbanking.datamodel.fund.OBFundsConfirmationResponse1;
+import uk.org.openbanking.datamodel.v3.error.OBErrorResponse1;
+import uk.org.openbanking.datamodel.v3.fund.OBFundsConfirmation1;
+import uk.org.openbanking.datamodel.v3.fund.OBFundsConfirmationResponse1;
 
 import org.joda.time.DateTime;
 import org.springframework.format.annotation.DateTimeFormat;

--- a/secure-api-gateway-ob-uk-rs-obie-api/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/obie/api/payment/v3_1_10/domesticpayments/DomesticPaymentConsentsApi.java
+++ b/secure-api-gateway-ob-uk-rs-obie-api/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/obie/api/payment/v3_1_10/domesticpayments/DomesticPaymentConsentsApi.java
@@ -40,10 +40,10 @@ import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
 import io.swagger.annotations.Authorization;
 import io.swagger.annotations.AuthorizationScope;
-import uk.org.openbanking.datamodel.error.OBErrorResponse1;
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticConsent4;
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticConsentResponse5;
-import uk.org.openbanking.datamodel.payment.OBWriteFundsConfirmationResponse1;
+import uk.org.openbanking.datamodel.v3.error.OBErrorResponse1;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteDomesticConsent4;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteDomesticConsentResponse5;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteFundsConfirmationResponse1;
 
 @jakarta.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2020-05-22T14:20:48.770Z")
 

--- a/secure-api-gateway-ob-uk-rs-obie-api/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/obie/api/payment/v3_1_10/domesticpayments/DomesticPaymentsApi.java
+++ b/secure-api-gateway-ob-uk-rs-obie-api/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/obie/api/payment/v3_1_10/domesticpayments/DomesticPaymentsApi.java
@@ -35,10 +35,10 @@ import io.swagger.annotations.Authorization;
 import io.swagger.annotations.AuthorizationScope;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
-import uk.org.openbanking.datamodel.error.OBErrorResponse1;
-import uk.org.openbanking.datamodel.payment.OBWriteDomestic2;
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticResponse5;
-import uk.org.openbanking.datamodel.payment.OBWritePaymentDetailsResponse1;
+import uk.org.openbanking.datamodel.v3.error.OBErrorResponse1;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteDomestic2;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteDomesticResponse5;
+import uk.org.openbanking.datamodel.v3.payment.OBWritePaymentDetailsResponse1;
 
 import org.joda.time.DateTime;
 import org.springframework.format.annotation.DateTimeFormat;

--- a/secure-api-gateway-ob-uk-rs-obie-api/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/obie/api/payment/v3_1_10/domesticscheduledpayments/DomesticScheduledPaymentConsentsApi.java
+++ b/secure-api-gateway-ob-uk-rs-obie-api/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/obie/api/payment/v3_1_10/domesticscheduledpayments/DomesticScheduledPaymentConsentsApi.java
@@ -40,9 +40,9 @@ import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
 import io.swagger.annotations.Authorization;
 import io.swagger.annotations.AuthorizationScope;
-import uk.org.openbanking.datamodel.error.OBErrorResponse1;
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticScheduledConsent4;
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticScheduledConsentResponse5;
+import uk.org.openbanking.datamodel.v3.error.OBErrorResponse1;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteDomesticScheduledConsent4;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteDomesticScheduledConsentResponse5;
 
 @jakarta.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2020-05-22T14:20:48.770Z")
 

--- a/secure-api-gateway-ob-uk-rs-obie-api/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/obie/api/payment/v3_1_10/domesticscheduledpayments/DomesticScheduledPaymentsApi.java
+++ b/secure-api-gateway-ob-uk-rs-obie-api/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/obie/api/payment/v3_1_10/domesticscheduledpayments/DomesticScheduledPaymentsApi.java
@@ -35,10 +35,10 @@ import io.swagger.annotations.Authorization;
 import io.swagger.annotations.AuthorizationScope;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
-import uk.org.openbanking.datamodel.error.OBErrorResponse1;
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticScheduled2;
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticScheduledResponse5;
-import uk.org.openbanking.datamodel.payment.OBWritePaymentDetailsResponse1;
+import uk.org.openbanking.datamodel.v3.error.OBErrorResponse1;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteDomesticScheduled2;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteDomesticScheduledResponse5;
+import uk.org.openbanking.datamodel.v3.payment.OBWritePaymentDetailsResponse1;
 
 import org.joda.time.DateTime;
 import org.springframework.format.annotation.DateTimeFormat;

--- a/secure-api-gateway-ob-uk-rs-obie-api/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/obie/api/payment/v3_1_10/domesticstandingorders/DomesticStandingOrderConsentsApi.java
+++ b/secure-api-gateway-ob-uk-rs-obie-api/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/obie/api/payment/v3_1_10/domesticstandingorders/DomesticStandingOrderConsentsApi.java
@@ -46,9 +46,9 @@ import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
 import io.swagger.annotations.Authorization;
 import io.swagger.annotations.AuthorizationScope;
-import uk.org.openbanking.datamodel.error.OBErrorResponse1;
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticStandingOrderConsent5;
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticStandingOrderConsentResponse6;
+import uk.org.openbanking.datamodel.v3.error.OBErrorResponse1;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteDomesticStandingOrderConsent5;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteDomesticStandingOrderConsentResponse6;
 
 @jakarta.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2020-05-22T14:20:48.770Z")
 

--- a/secure-api-gateway-ob-uk-rs-obie-api/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/obie/api/payment/v3_1_10/domesticstandingorders/DomesticStandingOrdersApi.java
+++ b/secure-api-gateway-ob-uk-rs-obie-api/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/obie/api/payment/v3_1_10/domesticstandingorders/DomesticStandingOrdersApi.java
@@ -55,10 +55,10 @@ import io.swagger.annotations.Authorization;
 import io.swagger.annotations.AuthorizationScope;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
-import uk.org.openbanking.datamodel.error.OBErrorResponse1;
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticStandingOrder3;
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticStandingOrderResponse6;
-import uk.org.openbanking.datamodel.payment.OBWritePaymentDetailsResponse1;
+import uk.org.openbanking.datamodel.v3.error.OBErrorResponse1;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteDomesticStandingOrder3;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteDomesticStandingOrderResponse6;
+import uk.org.openbanking.datamodel.v3.payment.OBWritePaymentDetailsResponse1;
 
 import org.joda.time.DateTime;
 import org.springframework.format.annotation.DateTimeFormat;

--- a/secure-api-gateway-ob-uk-rs-obie-api/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/obie/api/payment/v3_1_10/file/FilePaymentConsentsApi.java
+++ b/secure-api-gateway-ob-uk-rs-obie-api/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/obie/api/payment/v3_1_10/file/FilePaymentConsentsApi.java
@@ -42,9 +42,9 @@ import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
 import io.swagger.annotations.Authorization;
 import io.swagger.annotations.AuthorizationScope;
-import uk.org.openbanking.datamodel.error.OBErrorResponse1;
-import uk.org.openbanking.datamodel.payment.OBWriteFileConsent3;
-import uk.org.openbanking.datamodel.payment.OBWriteFileConsentResponse4;
+import uk.org.openbanking.datamodel.v3.error.OBErrorResponse1;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteFileConsent3;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteFileConsentResponse4;
 
 @jakarta.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2020-05-22T14:20:48.770Z")
 

--- a/secure-api-gateway-ob-uk-rs-obie-api/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/obie/api/payment/v3_1_10/file/FilePaymentsApi.java
+++ b/secure-api-gateway-ob-uk-rs-obie-api/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/obie/api/payment/v3_1_10/file/FilePaymentsApi.java
@@ -36,10 +36,10 @@ import io.swagger.annotations.Authorization;
 import io.swagger.annotations.AuthorizationScope;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
-import uk.org.openbanking.datamodel.error.OBErrorResponse1;
-import uk.org.openbanking.datamodel.payment.OBWriteFile2;
-import uk.org.openbanking.datamodel.payment.OBWriteFileResponse3;
-import uk.org.openbanking.datamodel.payment.OBWritePaymentDetailsResponse1;
+import uk.org.openbanking.datamodel.v3.error.OBErrorResponse1;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteFile2;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteFileResponse3;
+import uk.org.openbanking.datamodel.v3.payment.OBWritePaymentDetailsResponse1;
 
 import org.joda.time.DateTime;
 import org.springframework.core.io.Resource;

--- a/secure-api-gateway-ob-uk-rs-obie-api/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/obie/api/payment/v3_1_10/internationalpayments/InternationalPaymentConsentsApi.java
+++ b/secure-api-gateway-ob-uk-rs-obie-api/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/obie/api/payment/v3_1_10/internationalpayments/InternationalPaymentConsentsApi.java
@@ -40,10 +40,10 @@ import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
 import io.swagger.annotations.Authorization;
 import io.swagger.annotations.AuthorizationScope;
-import uk.org.openbanking.datamodel.error.OBErrorResponse1;
-import uk.org.openbanking.datamodel.payment.OBWriteFundsConfirmationResponse1;
-import uk.org.openbanking.datamodel.payment.OBWriteInternationalConsent5;
-import uk.org.openbanking.datamodel.payment.OBWriteInternationalConsentResponse6;
+import uk.org.openbanking.datamodel.v3.error.OBErrorResponse1;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteFundsConfirmationResponse1;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteInternationalConsent5;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteInternationalConsentResponse6;
 
 @jakarta.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2020-05-22T14:20:48.770Z")
 

--- a/secure-api-gateway-ob-uk-rs-obie-api/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/obie/api/payment/v3_1_10/internationalpayments/InternationalPaymentsApi.java
+++ b/secure-api-gateway-ob-uk-rs-obie-api/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/obie/api/payment/v3_1_10/internationalpayments/InternationalPaymentsApi.java
@@ -35,10 +35,10 @@ import io.swagger.annotations.Authorization;
 import io.swagger.annotations.AuthorizationScope;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
-import uk.org.openbanking.datamodel.error.OBErrorResponse1;
-import uk.org.openbanking.datamodel.payment.OBWriteInternational3;
-import uk.org.openbanking.datamodel.payment.OBWriteInternationalResponse5;
-import uk.org.openbanking.datamodel.payment.OBWritePaymentDetailsResponse1;
+import uk.org.openbanking.datamodel.v3.error.OBErrorResponse1;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteInternational3;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteInternationalResponse5;
+import uk.org.openbanking.datamodel.v3.payment.OBWritePaymentDetailsResponse1;
 
 import org.joda.time.DateTime;
 import org.springframework.format.annotation.DateTimeFormat;

--- a/secure-api-gateway-ob-uk-rs-obie-api/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/obie/api/payment/v3_1_10/internationalscheduledpayments/InternationalScheduledPaymentConsentsApi.java
+++ b/secure-api-gateway-ob-uk-rs-obie-api/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/obie/api/payment/v3_1_10/internationalscheduledpayments/InternationalScheduledPaymentConsentsApi.java
@@ -40,10 +40,10 @@ import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
 import io.swagger.annotations.Authorization;
 import io.swagger.annotations.AuthorizationScope;
-import uk.org.openbanking.datamodel.error.OBErrorResponse1;
-import uk.org.openbanking.datamodel.payment.OBWriteFundsConfirmationResponse1;
-import uk.org.openbanking.datamodel.payment.OBWriteInternationalScheduledConsent5;
-import uk.org.openbanking.datamodel.payment.OBWriteInternationalScheduledConsentResponse6;
+import uk.org.openbanking.datamodel.v3.error.OBErrorResponse1;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteFundsConfirmationResponse1;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteInternationalScheduledConsent5;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteInternationalScheduledConsentResponse6;
 
 @jakarta.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2020-05-22T14:20:48.770Z")
 

--- a/secure-api-gateway-ob-uk-rs-obie-api/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/obie/api/payment/v3_1_10/internationalscheduledpayments/InternationalScheduledPaymentsApi.java
+++ b/secure-api-gateway-ob-uk-rs-obie-api/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/obie/api/payment/v3_1_10/internationalscheduledpayments/InternationalScheduledPaymentsApi.java
@@ -35,10 +35,10 @@ import io.swagger.annotations.Authorization;
 import io.swagger.annotations.AuthorizationScope;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
-import uk.org.openbanking.datamodel.error.OBErrorResponse1;
-import uk.org.openbanking.datamodel.payment.OBWriteInternationalScheduled3;
-import uk.org.openbanking.datamodel.payment.OBWriteInternationalScheduledResponse6;
-import uk.org.openbanking.datamodel.payment.OBWritePaymentDetailsResponse1;
+import uk.org.openbanking.datamodel.v3.error.OBErrorResponse1;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteInternationalScheduled3;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteInternationalScheduledResponse6;
+import uk.org.openbanking.datamodel.v3.payment.OBWritePaymentDetailsResponse1;
 
 import org.joda.time.DateTime;
 import org.springframework.format.annotation.DateTimeFormat;

--- a/secure-api-gateway-ob-uk-rs-obie-api/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/obie/api/payment/v3_1_10/internationalstandingorders/InternationalStandingOrderConsentsApi.java
+++ b/secure-api-gateway-ob-uk-rs-obie-api/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/obie/api/payment/v3_1_10/internationalstandingorders/InternationalStandingOrderConsentsApi.java
@@ -40,9 +40,9 @@ import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
 import io.swagger.annotations.Authorization;
 import io.swagger.annotations.AuthorizationScope;
-import uk.org.openbanking.datamodel.error.OBErrorResponse1;
-import uk.org.openbanking.datamodel.payment.OBWriteInternationalStandingOrderConsent6;
-import uk.org.openbanking.datamodel.payment.OBWriteInternationalStandingOrderConsentResponse7;
+import uk.org.openbanking.datamodel.v3.error.OBErrorResponse1;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteInternationalStandingOrderConsent6;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteInternationalStandingOrderConsentResponse7;
 
 @jakarta.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2020-05-22T14:20:48.770Z")
 

--- a/secure-api-gateway-ob-uk-rs-obie-api/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/obie/api/payment/v3_1_10/internationalstandingorders/InternationalStandingOrdersApi.java
+++ b/secure-api-gateway-ob-uk-rs-obie-api/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/obie/api/payment/v3_1_10/internationalstandingorders/InternationalStandingOrdersApi.java
@@ -35,10 +35,10 @@ import io.swagger.annotations.Authorization;
 import io.swagger.annotations.AuthorizationScope;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
-import uk.org.openbanking.datamodel.error.OBErrorResponse1;
-import uk.org.openbanking.datamodel.payment.OBWriteInternationalStandingOrder4;
-import uk.org.openbanking.datamodel.payment.OBWriteInternationalStandingOrderResponse7;
-import uk.org.openbanking.datamodel.payment.OBWritePaymentDetailsResponse1;
+import uk.org.openbanking.datamodel.v3.error.OBErrorResponse1;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteInternationalStandingOrder4;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteInternationalStandingOrderResponse7;
+import uk.org.openbanking.datamodel.v3.payment.OBWritePaymentDetailsResponse1;
 
 import org.joda.time.DateTime;
 import org.springframework.format.annotation.DateTimeFormat;

--- a/secure-api-gateway-ob-uk-rs-obie-api/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/obie/api/payment/v3_1_10/vrp/DomesticVrpConsentsApi.java
+++ b/secure-api-gateway-ob-uk-rs-obie-api/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/obie/api/payment/v3_1_10/vrp/DomesticVrpConsentsApi.java
@@ -40,11 +40,11 @@ import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
 import io.swagger.annotations.Authorization;
 import io.swagger.annotations.AuthorizationScope;
-import uk.org.openbanking.datamodel.error.OBErrorResponse1;
-import uk.org.openbanking.datamodel.vrp.OBDomesticVRPConsentRequest;
-import uk.org.openbanking.datamodel.vrp.OBDomesticVRPConsentResponse;
-import uk.org.openbanking.datamodel.vrp.OBVRPFundsConfirmationRequest;
-import uk.org.openbanking.datamodel.vrp.OBVRPFundsConfirmationResponse;
+import uk.org.openbanking.datamodel.v3.error.OBErrorResponse1;
+import uk.org.openbanking.datamodel.v3.vrp.OBDomesticVRPConsentRequest;
+import uk.org.openbanking.datamodel.v3.vrp.OBDomesticVRPConsentResponse;
+import uk.org.openbanking.datamodel.v3.vrp.OBVRPFundsConfirmationRequest;
+import uk.org.openbanking.datamodel.v3.vrp.OBVRPFundsConfirmationResponse;
 
 /**
  * NOTE: API operations other than funds-confirmation have been removed from this generated code.

--- a/secure-api-gateway-ob-uk-rs-obie-api/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/obie/api/payment/v3_1_10/vrp/DomesticVrpsApi.java
+++ b/secure-api-gateway-ob-uk-rs-obie-api/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/obie/api/payment/v3_1_10/vrp/DomesticVrpsApi.java
@@ -34,10 +34,10 @@ import io.swagger.annotations.Authorization;
 import io.swagger.annotations.AuthorizationScope;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
-import uk.org.openbanking.datamodel.error.OBErrorResponse1;
-import uk.org.openbanking.datamodel.vrp.OBDomesticVRPDetails;
-import uk.org.openbanking.datamodel.vrp.OBDomesticVRPRequest;
-import uk.org.openbanking.datamodel.vrp.OBDomesticVRPResponse;
+import uk.org.openbanking.datamodel.v3.error.OBErrorResponse1;
+import uk.org.openbanking.datamodel.v3.vrp.OBDomesticVRPDetails;
+import uk.org.openbanking.datamodel.v3.vrp.OBDomesticVRPRequest;
+import uk.org.openbanking.datamodel.v3.vrp.OBDomesticVRPResponse;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;

--- a/secure-api-gateway-ob-uk-rs-resource-store/secure-api-gateway-ob-uk-rs-resource-store-api/src/main/java/com/forgerock/sapi/gateway/rs/resource/store/api/admin/DataCreator.java
+++ b/secure-api-gateway-ob-uk-rs-resource-store/secure-api-gateway-ob-uk-rs-resource-store-api/src/main/java/com/forgerock/sapi/gateway/rs/resource/store/api/admin/DataCreator.java
@@ -71,15 +71,15 @@ import com.forgerock.sapi.gateway.rs.resource.store.repo.mongo.accounts.transact
 import com.forgerock.sapi.gateway.rs.resource.store.repo.mongo.customerinfo.FRCustomerInfoRepository;
 
 import lombok.NoArgsConstructor;
-import uk.org.openbanking.datamodel.account.OBBeneficiary5;
-import uk.org.openbanking.datamodel.account.OBReadBalance1DataBalanceInner;
-import uk.org.openbanking.datamodel.account.OBReadDirectDebit2DataDirectDebitInner;
-import uk.org.openbanking.datamodel.account.OBReadOffer1DataOfferInner;
-import uk.org.openbanking.datamodel.account.OBReadProduct2DataProductInner;
-import uk.org.openbanking.datamodel.account.OBScheduledPayment3;
-import uk.org.openbanking.datamodel.account.OBStandingOrder6;
-import uk.org.openbanking.datamodel.account.OBStatement2;
-import uk.org.openbanking.datamodel.account.OBTransaction6;
+import uk.org.openbanking.datamodel.v3.account.OBBeneficiary5;
+import uk.org.openbanking.datamodel.v3.account.OBReadBalance1DataBalanceInner;
+import uk.org.openbanking.datamodel.v3.account.OBReadDirectDebit2DataDirectDebitInner;
+import uk.org.openbanking.datamodel.v3.account.OBReadOffer1DataOfferInner;
+import uk.org.openbanking.datamodel.v3.account.OBReadProduct2DataProductInner;
+import uk.org.openbanking.datamodel.v3.account.OBScheduledPayment3;
+import uk.org.openbanking.datamodel.v3.account.OBStandingOrder6;
+import uk.org.openbanking.datamodel.v3.account.OBStatement2;
+import uk.org.openbanking.datamodel.v3.account.OBTransaction6;
 
 @Service
 @NoArgsConstructor

--- a/secure-api-gateway-ob-uk-rs-resource-store/secure-api-gateway-ob-uk-rs-resource-store-api/src/main/java/com/forgerock/sapi/gateway/rs/resource/store/api/admin/DataExporter.java
+++ b/secure-api-gateway-ob-uk-rs-resource-store/secure-api-gateway-ob-uk-rs-resource-store-api/src/main/java/com/forgerock/sapi/gateway/rs/resource/store/api/admin/DataExporter.java
@@ -56,16 +56,16 @@ import com.forgerock.sapi.gateway.rs.resource.store.repo.mongo.accounts.standing
 import com.forgerock.sapi.gateway.rs.resource.store.repo.mongo.accounts.statements.FRStatementRepository;
 import com.forgerock.sapi.gateway.rs.resource.store.repo.mongo.accounts.transactions.FRTransactionRepository;
 
-import uk.org.openbanking.datamodel.account.OBBeneficiary5;
-import uk.org.openbanking.datamodel.account.OBParty2;
-import uk.org.openbanking.datamodel.account.OBReadBalance1DataBalanceInner;
-import uk.org.openbanking.datamodel.account.OBReadDirectDebit2DataDirectDebitInner;
-import uk.org.openbanking.datamodel.account.OBReadOffer1DataOfferInner;
-import uk.org.openbanking.datamodel.account.OBReadProduct2DataProductInner;
-import uk.org.openbanking.datamodel.account.OBScheduledPayment3;
-import uk.org.openbanking.datamodel.account.OBStandingOrder6;
-import uk.org.openbanking.datamodel.account.OBStatement2;
-import uk.org.openbanking.datamodel.account.OBTransaction6;
+import uk.org.openbanking.datamodel.v3.account.OBBeneficiary5;
+import uk.org.openbanking.datamodel.v3.account.OBParty2;
+import uk.org.openbanking.datamodel.v3.account.OBReadBalance1DataBalanceInner;
+import uk.org.openbanking.datamodel.v3.account.OBReadDirectDebit2DataDirectDebitInner;
+import uk.org.openbanking.datamodel.v3.account.OBReadOffer1DataOfferInner;
+import uk.org.openbanking.datamodel.v3.account.OBReadProduct2DataProductInner;
+import uk.org.openbanking.datamodel.v3.account.OBScheduledPayment3;
+import uk.org.openbanking.datamodel.v3.account.OBStandingOrder6;
+import uk.org.openbanking.datamodel.v3.account.OBStatement2;
+import uk.org.openbanking.datamodel.v3.account.OBTransaction6;
 
 @Service
 public class DataExporter {

--- a/secure-api-gateway-ob-uk-rs-resource-store/secure-api-gateway-ob-uk-rs-resource-store-api/src/main/java/com/forgerock/sapi/gateway/rs/resource/store/api/admin/DataUpdater.java
+++ b/secure-api-gateway-ob-uk-rs-resource-store/secure-api-gateway-ob-uk-rs-resource-store-api/src/main/java/com/forgerock/sapi/gateway/rs/resource/store/api/admin/DataUpdater.java
@@ -42,7 +42,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.web.server.ResponseStatusException;
-import uk.org.openbanking.datamodel.account.*;
+import uk.org.openbanking.datamodel.v3.account.*;
 
 import java.util.*;
 

--- a/secure-api-gateway-ob-uk-rs-resource-store/secure-api-gateway-ob-uk-rs-resource-store-api/src/main/java/com/forgerock/sapi/gateway/rs/resource/store/api/admin/FakeDataApiController.java
+++ b/secure-api-gateway-ob-uk-rs-resource-store/secure-api-gateway-ob-uk-rs-resource-store-api/src/main/java/com/forgerock/sapi/gateway/rs/resource/store/api/admin/FakeDataApiController.java
@@ -96,11 +96,11 @@ import com.forgerock.sapi.gateway.rs.resource.store.repo.mongo.accounts.standing
 import com.forgerock.sapi.gateway.rs.resource.store.repo.mongo.accounts.statements.FRStatementRepository;
 import com.forgerock.sapi.gateway.rs.resource.store.repo.mongo.accounts.transactions.FRTransactionRepository;
 
-import uk.org.openbanking.datamodel.account.OBExternalStatementAmountType1Code;
-import uk.org.openbanking.datamodel.account.OBExternalStatementType1Code;
-import uk.org.openbanking.datamodel.account.OBReadProduct2DataProductInner;
-import uk.org.openbanking.datamodel.account.OBReadProduct2DataProductInnerProductType;
-import uk.org.openbanking.datamodel.common.OBExternalAccountIdentification4Code;
+import uk.org.openbanking.datamodel.v3.account.OBExternalStatementAmountType1Code;
+import uk.org.openbanking.datamodel.v3.account.OBExternalStatementType1Code;
+import uk.org.openbanking.datamodel.v3.account.OBReadProduct2DataProductInner;
+import uk.org.openbanking.datamodel.v3.account.OBReadProduct2DataProductInnerProductType;
+import uk.org.openbanking.datamodel.v3.common.OBExternalAccountIdentification4Code;
 
 @Controller("FakeDataApi")
 public class FakeDataApiController implements FakeDataApi {

--- a/secure-api-gateway-ob-uk-rs-resource-store/secure-api-gateway-ob-uk-rs-resource-store-api/src/main/java/com/forgerock/sapi/gateway/rs/resource/store/api/admin/events/FRDataEventsConverter.java
+++ b/secure-api-gateway-ob-uk-rs-resource-store/secure-api-gateway-ob-uk-rs-resource-store-api/src/main/java/com/forgerock/sapi/gateway/rs/resource/store/api/admin/events/FRDataEventsConverter.java
@@ -21,7 +21,7 @@ import com.forgerock.sapi.gateway.ob.uk.common.datamodel.converter.mapper.FRMode
 import com.forgerock.sapi.gateway.ob.uk.common.datamodel.event.FREventMessage;
 import com.forgerock.sapi.gateway.rs.resource.store.repo.entity.event.FREventMessageEntity;
 
-import uk.org.openbanking.datamodel.event.OBEventNotification1;
+import uk.org.openbanking.datamodel.v3.event.OBEventNotification1;
 
 public class FRDataEventsConverter {
 

--- a/secure-api-gateway-ob-uk-rs-resource-store/secure-api-gateway-ob-uk-rs-resource-store-api/src/main/java/com/forgerock/sapi/gateway/rs/resource/store/api/admin/exceptions/DataApiExceptionHandler.java
+++ b/secure-api-gateway-ob-uk-rs-resource-store/secure-api-gateway-ob-uk-rs-resource-store-api/src/main/java/com/forgerock/sapi/gateway/rs/resource/store/api/admin/exceptions/DataApiExceptionHandler.java
@@ -24,8 +24,8 @@ import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.context.request.WebRequest;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
-import uk.org.openbanking.datamodel.error.OBError1;
-import uk.org.openbanking.datamodel.error.OBErrorResponse1;
+import uk.org.openbanking.datamodel.v3.error.OBError1;
+import uk.org.openbanking.datamodel.v3.error.OBErrorResponse1;
 
 import java.util.Collections;
 

--- a/secure-api-gateway-ob-uk-rs-resource-store/secure-api-gateway-ob-uk-rs-resource-store-api/src/main/java/com/forgerock/sapi/gateway/rs/resource/store/api/resource/customerinfo/CustomerInfoResourceApi.java
+++ b/secure-api-gateway-ob-uk-rs-resource-store/secure-api-gateway-ob-uk-rs-resource-store-api/src/main/java/com/forgerock/sapi/gateway/rs/resource/store/api/resource/customerinfo/CustomerInfoResourceApi.java
@@ -24,7 +24,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
-import uk.org.openbanking.datamodel.error.OBErrorResponse1;
+import uk.org.openbanking.datamodel.v3.error.OBErrorResponse1;
 
 import java.util.List;
 

--- a/secure-api-gateway-ob-uk-rs-resource-store/secure-api-gateway-ob-uk-rs-resource-store-api/src/test/java/com/forgerock/sapi/gateway/rs/resource/store/api/admin/DataApiControllerTest.java
+++ b/secure-api-gateway-ob-uk-rs-resource-store/secure-api-gateway-ob-uk-rs-resource-store-api/src/test/java/com/forgerock/sapi/gateway/rs/resource/store/api/admin/DataApiControllerTest.java
@@ -65,13 +65,13 @@ import com.forgerock.sapi.gateway.rs.resource.store.repo.mongo.accounts.balances
 import com.forgerock.sapi.gateway.rs.resource.store.repo.mongo.accounts.transactions.FRTransactionRepository;
 import com.forgerock.sapi.gateway.rs.resource.store.repo.mongo.customerinfo.FRCustomerInfoRepository;
 
-import uk.org.openbanking.datamodel.account.OBAccount6;
-import uk.org.openbanking.datamodel.account.OBBalanceType1Code;
-import uk.org.openbanking.datamodel.account.OBCreditDebitCode2;
-import uk.org.openbanking.datamodel.account.OBReadBalance1DataBalanceInner;
-import uk.org.openbanking.datamodel.account.OBTransaction6;
-import uk.org.openbanking.datamodel.account.OBTransactionCashBalance;
-import uk.org.openbanking.datamodel.account.OBTransactionCashBalanceAmount;
+import uk.org.openbanking.datamodel.v3.account.OBAccount6;
+import uk.org.openbanking.datamodel.v3.account.OBBalanceType1Code;
+import uk.org.openbanking.datamodel.v3.account.OBCreditDebitCode2;
+import uk.org.openbanking.datamodel.v3.account.OBReadBalance1DataBalanceInner;
+import uk.org.openbanking.datamodel.v3.account.OBTransaction6;
+import uk.org.openbanking.datamodel.v3.account.OBTransactionCashBalance;
+import uk.org.openbanking.datamodel.v3.account.OBTransactionCashBalanceAmount;
 
 /**
  * A SpringBoot test for the {@link DataApiController}.

--- a/secure-api-gateway-ob-uk-rs-resource-store/secure-api-gateway-ob-uk-rs-resource-store-api/src/test/java/com/forgerock/sapi/gateway/rs/resource/store/api/admin/DataCreatorTest.java
+++ b/secure-api-gateway-ob-uk-rs-resource-store/secure-api-gateway-ob-uk-rs-resource-store-api/src/test/java/com/forgerock/sapi/gateway/rs/resource/store/api/admin/DataCreatorTest.java
@@ -42,7 +42,7 @@ import org.mockito.internal.util.collections.Iterables;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.server.ResponseStatusException;
-import uk.org.openbanking.datamodel.account.*;
+import uk.org.openbanking.datamodel.v3.account.*;
 
 import java.util.Collections;
 import java.util.List;

--- a/secure-api-gateway-ob-uk-rs-resource-store/secure-api-gateway-ob-uk-rs-resource-store-api/src/test/java/com/forgerock/sapi/gateway/rs/resource/store/api/admin/DataExporterTest.java
+++ b/secure-api-gateway-ob-uk-rs-resource-store/secure-api-gateway-ob-uk-rs-resource-store-api/src/test/java/com/forgerock/sapi/gateway/rs/resource/store/api/admin/DataExporterTest.java
@@ -62,31 +62,31 @@ import com.forgerock.sapi.gateway.rs.resource.store.repo.mongo.accounts.standing
 import com.forgerock.sapi.gateway.rs.resource.store.repo.mongo.accounts.statements.FRStatementRepository;
 import com.forgerock.sapi.gateway.rs.resource.store.repo.mongo.accounts.transactions.FRTransactionRepository;
 
-import uk.org.openbanking.datamodel.account.OBBalanceType1Code;
-import uk.org.openbanking.datamodel.account.OBBeneficiary5;
-import uk.org.openbanking.datamodel.account.OBBeneficiaryType1Code;
-import uk.org.openbanking.datamodel.account.OBCashAccount51;
-import uk.org.openbanking.datamodel.account.OBCreditDebitCode2;
-import uk.org.openbanking.datamodel.account.OBExternalPartyType1Code;
-import uk.org.openbanking.datamodel.account.OBExternalStatementType1Code;
-import uk.org.openbanking.datamodel.account.OBParty2;
-import uk.org.openbanking.datamodel.account.OBReadBalance1;
-import uk.org.openbanking.datamodel.account.OBReadBalance1Data;
-import uk.org.openbanking.datamodel.account.OBReadBalance1DataBalanceInner;
-import uk.org.openbanking.datamodel.account.OBReadBalance1DataBalanceInnerAmount;
-import uk.org.openbanking.datamodel.account.OBReadDirectDebit2DataDirectDebitInner;
-import uk.org.openbanking.datamodel.account.OBReadOffer1;
-import uk.org.openbanking.datamodel.account.OBReadOffer1Data;
-import uk.org.openbanking.datamodel.account.OBReadOffer1DataOfferInner;
-import uk.org.openbanking.datamodel.account.OBReadOffer1DataOfferInnerOfferType;
-import uk.org.openbanking.datamodel.account.OBReadProduct2DataProductInner;
-import uk.org.openbanking.datamodel.account.OBReadProduct2DataProductInnerProductType;
-import uk.org.openbanking.datamodel.account.OBScheduledPayment3;
-import uk.org.openbanking.datamodel.account.OBStandingOrder6;
-import uk.org.openbanking.datamodel.account.OBStatement2;
-import uk.org.openbanking.datamodel.account.OBTransaction6;
-import uk.org.openbanking.datamodel.account.OBTransactionCashBalance;
-import uk.org.openbanking.datamodel.account.OBTransactionCashBalanceAmount;
+import uk.org.openbanking.datamodel.v3.account.OBBalanceType1Code;
+import uk.org.openbanking.datamodel.v3.account.OBBeneficiary5;
+import uk.org.openbanking.datamodel.v3.account.OBBeneficiaryType1Code;
+import uk.org.openbanking.datamodel.v3.account.OBCashAccount51;
+import uk.org.openbanking.datamodel.v3.account.OBCreditDebitCode2;
+import uk.org.openbanking.datamodel.v3.account.OBExternalPartyType1Code;
+import uk.org.openbanking.datamodel.v3.account.OBExternalStatementType1Code;
+import uk.org.openbanking.datamodel.v3.account.OBParty2;
+import uk.org.openbanking.datamodel.v3.account.OBReadBalance1;
+import uk.org.openbanking.datamodel.v3.account.OBReadBalance1Data;
+import uk.org.openbanking.datamodel.v3.account.OBReadBalance1DataBalanceInner;
+import uk.org.openbanking.datamodel.v3.account.OBReadBalance1DataBalanceInnerAmount;
+import uk.org.openbanking.datamodel.v3.account.OBReadDirectDebit2DataDirectDebitInner;
+import uk.org.openbanking.datamodel.v3.account.OBReadOffer1;
+import uk.org.openbanking.datamodel.v3.account.OBReadOffer1Data;
+import uk.org.openbanking.datamodel.v3.account.OBReadOffer1DataOfferInner;
+import uk.org.openbanking.datamodel.v3.account.OBReadOffer1DataOfferInnerOfferType;
+import uk.org.openbanking.datamodel.v3.account.OBReadProduct2DataProductInner;
+import uk.org.openbanking.datamodel.v3.account.OBReadProduct2DataProductInnerProductType;
+import uk.org.openbanking.datamodel.v3.account.OBScheduledPayment3;
+import uk.org.openbanking.datamodel.v3.account.OBStandingOrder6;
+import uk.org.openbanking.datamodel.v3.account.OBStatement2;
+import uk.org.openbanking.datamodel.v3.account.OBTransaction6;
+import uk.org.openbanking.datamodel.v3.account.OBTransactionCashBalance;
+import uk.org.openbanking.datamodel.v3.account.OBTransactionCashBalanceAmount;
 
 @SpringBootTest
 @ActiveProfiles("test")

--- a/secure-api-gateway-ob-uk-rs-resource-store/secure-api-gateway-ob-uk-rs-resource-store-api/src/test/java/com/forgerock/sapi/gateway/rs/resource/store/api/admin/DataUpdaterTest.java
+++ b/secure-api-gateway-ob-uk-rs-resource-store/secure-api-gateway-ob-uk-rs-resource-store-api/src/test/java/com/forgerock/sapi/gateway/rs/resource/store/api/admin/DataUpdaterTest.java
@@ -45,7 +45,7 @@ import org.mockito.internal.util.collections.Iterables;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.server.ResponseStatusException;
-import uk.org.openbanking.datamodel.account.*;
+import uk.org.openbanking.datamodel.v3.account.*;
 
 import java.util.Arrays;
 import java.util.Collections;

--- a/secure-api-gateway-ob-uk-rs-resource-store/secure-api-gateway-ob-uk-rs-resource-store-api/src/test/java/com/forgerock/sapi/gateway/rs/resource/store/api/admin/events/DataEventsApiControllerTest.java
+++ b/secure-api-gateway-ob-uk-rs-resource-store/secure-api-gateway-ob-uk-rs-resource-store-api/src/test/java/com/forgerock/sapi/gateway/rs/resource/store/api/admin/events/DataEventsApiControllerTest.java
@@ -50,11 +50,11 @@ import com.forgerock.sapi.gateway.ob.uk.common.datamodel.event.FREventMessages;
 import com.forgerock.sapi.gateway.rs.resource.store.repo.entity.event.FREventMessageEntity;
 import com.forgerock.sapi.gateway.rs.resource.store.repo.mongo.events.FREventMessageRepository;
 
-import uk.org.openbanking.datamodel.event.OBEvent1;
-import uk.org.openbanking.datamodel.event.OBEventLink1;
-import uk.org.openbanking.datamodel.event.OBEventNotification1;
-import uk.org.openbanking.datamodel.event.OBEventResourceUpdate1;
-import uk.org.openbanking.datamodel.event.OBEventSubject1;
+import uk.org.openbanking.datamodel.v3.event.OBEvent1;
+import uk.org.openbanking.datamodel.v3.event.OBEventLink1;
+import uk.org.openbanking.datamodel.v3.event.OBEventNotification1;
+import uk.org.openbanking.datamodel.v3.event.OBEventResourceUpdate1;
+import uk.org.openbanking.datamodel.v3.event.OBEventSubject1;
 
 /**
  * Test for {@link DataEventsApiController}

--- a/secure-api-gateway-ob-uk-rs-resource-store/secure-api-gateway-ob-uk-rs-resource-store-api/src/test/java/com/forgerock/sapi/gateway/rs/resource/store/api/admin/events/FRDataEventsConverterTest.java
+++ b/secure-api-gateway-ob-uk-rs-resource-store/secure-api-gateway-ob-uk-rs-resource-store-api/src/test/java/com/forgerock/sapi/gateway/rs/resource/store/api/admin/events/FRDataEventsConverterTest.java
@@ -25,11 +25,11 @@ import org.junit.jupiter.api.Test;
 
 import com.forgerock.sapi.gateway.rs.resource.store.repo.entity.event.FREventMessageEntity;
 
-import uk.org.openbanking.datamodel.event.OBEvent1;
-import uk.org.openbanking.datamodel.event.OBEventLink1;
-import uk.org.openbanking.datamodel.event.OBEventNotification1;
-import uk.org.openbanking.datamodel.event.OBEventResourceUpdate1;
-import uk.org.openbanking.datamodel.event.OBEventSubject1;
+import uk.org.openbanking.datamodel.v3.event.OBEvent1;
+import uk.org.openbanking.datamodel.v3.event.OBEventLink1;
+import uk.org.openbanking.datamodel.v3.event.OBEventNotification1;
+import uk.org.openbanking.datamodel.v3.event.OBEventResourceUpdate1;
+import uk.org.openbanking.datamodel.v3.event.OBEventSubject1;
 
 /**
  * Unit test for {@link FRDataEventsConverter}

--- a/secure-api-gateway-ob-uk-rs-resource-store/secure-api-gateway-ob-uk-rs-resource-store-datamodel/src/main/java/com/forgerock/sapi/gateway/rs/resource/store/datamodel/account/FRAccountData.java
+++ b/secure-api-gateway-ob-uk-rs-resource-store/secure-api-gateway-ob-uk-rs-resource-store-datamodel/src/main/java/com/forgerock/sapi/gateway/rs/resource/store/datamodel/account/FRAccountData.java
@@ -19,7 +19,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import uk.org.openbanking.datamodel.account.*;
+import uk.org.openbanking.datamodel.v3.account.*;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/secure-api-gateway-ob-uk-rs-resource-store/secure-api-gateway-ob-uk-rs-resource-store-datamodel/src/main/java/com/forgerock/sapi/gateway/rs/resource/store/datamodel/shared/currency/CurrencyRateService.java
+++ b/secure-api-gateway-ob-uk-rs-resource-store/secure-api-gateway-ob-uk-rs-resource-store-datamodel/src/main/java/com/forgerock/sapi/gateway/rs/resource/store/datamodel/shared/currency/CurrencyRateService.java
@@ -17,7 +17,7 @@ package com.forgerock.sapi.gateway.rs.resource.store.datamodel.shared.currency;
 
 import com.forgerock.sapi.gateway.ob.uk.common.datamodel.common.FRExchangeRateInformation;
 import lombok.extern.slf4j.Slf4j;
-import uk.org.openbanking.datamodel.payment.OBExchangeRateType;
+import uk.org.openbanking.datamodel.v3.payment.OBExchangeRateType;
 
 import org.joda.time.DateTime;
 

--- a/secure-api-gateway-ob-uk-rs-resource-store/secure-api-gateway-ob-uk-rs-resource-store-datamodel/src/main/java/com/forgerock/sapi/gateway/rs/resource/store/datamodel/user/FRUserData.java
+++ b/secure-api-gateway-ob-uk-rs-resource-store/secure-api-gateway-ob-uk-rs-resource-store-datamodel/src/main/java/com/forgerock/sapi/gateway/rs/resource/store/datamodel/user/FRUserData.java
@@ -20,7 +20,7 @@ import com.forgerock.sapi.gateway.ob.uk.common.datamodel.customerinfo.FRCustomer
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import uk.org.openbanking.datamodel.account.OBParty2;
+import uk.org.openbanking.datamodel.v3.account.OBParty2;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/secure-api-gateway-ob-uk-rs-resource-store/secure-api-gateway-ob-uk-rs-resource-store-repo/src/main/java/com/forgerock/sapi/gateway/rs/resource/store/repo/entity/account/FRProduct.java
+++ b/secure-api-gateway-ob-uk-rs-resource-store/secure-api-gateway-ob-uk-rs-resource-store-repo/src/main/java/com/forgerock/sapi/gateway/rs/resource/store/repo/entity/account/FRProduct.java
@@ -26,7 +26,7 @@ import org.springframework.data.annotation.Id;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.mongodb.core.index.Indexed;
 import org.springframework.data.mongodb.core.mapping.Document;
-import uk.org.openbanking.datamodel.account.OBReadProduct2DataProductInner;
+import uk.org.openbanking.datamodel.v3.account.OBReadProduct2DataProductInner;
 
 /**
  * Representation of an account. This model is only useful for the demo

--- a/secure-api-gateway-ob-uk-rs-resource-store/secure-api-gateway-ob-uk-rs-resource-store-repo/src/main/java/com/forgerock/sapi/gateway/rs/resource/store/repo/entity/event/FREventMessageEntity.java
+++ b/secure-api-gateway-ob-uk-rs-resource-store/secure-api-gateway-ob-uk-rs-resource-store-repo/src/main/java/com/forgerock/sapi/gateway/rs/resource/store/repo/entity/event/FREventMessageEntity.java
@@ -23,7 +23,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import uk.org.openbanking.datamodel.event.OBEvent1;
+import uk.org.openbanking.datamodel.v3.event.OBEvent1;
 
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.Id;

--- a/secure-api-gateway-ob-uk-rs-resource-store/secure-api-gateway-ob-uk-rs-resource-store-repo/src/main/java/com/forgerock/sapi/gateway/rs/resource/store/repo/mongo/accounts/accounts/FRAccountRepositoryImpl.java
+++ b/secure-api-gateway-ob-uk-rs-resource-store/secure-api-gateway-ob-uk-rs-resource-store-repo/src/main/java/com/forgerock/sapi/gateway/rs/resource/store/repo/mongo/accounts/accounts/FRAccountRepositoryImpl.java
@@ -21,7 +21,7 @@ import com.forgerock.sapi.gateway.rs.resource.store.repo.entity.account.FRAccoun
 import lombok.Builder;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
-import uk.org.openbanking.datamodel.common.OBExternalAccountIdentification4Code;
+import uk.org.openbanking.datamodel.v3.common.OBExternalAccountIdentification4Code;
 
 import org.joda.time.DateTime;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/secure-api-gateway-ob-uk-rs-resource-store/secure-api-gateway-ob-uk-rs-resource-store-repo/src/main/java/com/forgerock/sapi/gateway/rs/resource/store/repo/mongo/accounts/transactions/FRTransactionRepository.java
+++ b/secure-api-gateway-ob-uk-rs-resource-store/secure-api-gateway-ob-uk-rs-resource-store-repo/src/main/java/com/forgerock/sapi/gateway/rs/resource/store/repo/mongo/accounts/transactions/FRTransactionRepository.java
@@ -27,7 +27,7 @@ import org.springframework.data.repository.query.Param;
 import com.forgerock.sapi.gateway.ob.uk.rs.obie.api.ApiConstants;
 import com.forgerock.sapi.gateway.rs.resource.store.repo.entity.account.FRTransaction;
 
-import uk.org.openbanking.datamodel.account.OBCreditDebitCode0;
+import uk.org.openbanking.datamodel.v3.account.OBCreditDebitCode0;
 
 public interface FRTransactionRepository extends MongoRepository<FRTransaction, String>, FRTransactionRepositoryCustom {
 

--- a/secure-api-gateway-ob-uk-rs-resource-store/secure-api-gateway-ob-uk-rs-resource-store-repo/src/main/java/com/forgerock/sapi/gateway/rs/resource/store/repo/mongo/accounts/transactions/FRTransactionRepositoryImpl.java
+++ b/secure-api-gateway-ob-uk-rs-resource-store/secure-api-gateway-ob-uk-rs-resource-store-repo/src/main/java/com/forgerock/sapi/gateway/rs/resource/store/repo/mongo/accounts/transactions/FRTransactionRepositoryImpl.java
@@ -30,8 +30,8 @@ import org.springframework.data.domain.Pageable;
 import com.forgerock.sapi.gateway.ob.uk.common.datamodel.account.FRExternalPermissionsCode;
 import com.forgerock.sapi.gateway.rs.resource.store.repo.entity.account.FRTransaction;
 
-import uk.org.openbanking.datamodel.account.OBCreditDebitCode0;
-import uk.org.openbanking.datamodel.common.OBExternalAccountIdentification4Code;
+import uk.org.openbanking.datamodel.v3.account.OBCreditDebitCode0;
+import uk.org.openbanking.datamodel.v3.common.OBExternalAccountIdentification4Code;
 
 public class FRTransactionRepositoryImpl implements FRTransactionRepositoryCustom {
     private static final Logger LOGGER = LoggerFactory.getLogger(FRTransactionRepositoryImpl.class);

--- a/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/discovery/DiscoveryApiService.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/discovery/DiscoveryApiService.java
@@ -22,8 +22,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
-import uk.org.openbanking.datamodel.discovery.GenericOBDiscoveryAPILinks;
-import uk.org.openbanking.datamodel.discovery.OBDiscoveryAPI;
+import uk.org.openbanking.datamodel.v3.discovery.GenericOBDiscoveryAPILinks;
+import uk.org.openbanking.datamodel.v3.discovery.OBDiscoveryAPI;
 
 import java.util.HashMap;
 import java.util.List;

--- a/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/discovery/DiscoveryController.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/discovery/DiscoveryController.java
@@ -25,9 +25,9 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
-import uk.org.openbanking.datamodel.discovery.OBDiscovery;
-import uk.org.openbanking.datamodel.discovery.OBDiscoveryAPI;
-import uk.org.openbanking.datamodel.discovery.OBDiscoveryResponse;
+import uk.org.openbanking.datamodel.v3.discovery.OBDiscovery;
+import uk.org.openbanking.datamodel.v3.discovery.OBDiscoveryAPI;
+import uk.org.openbanking.datamodel.v3.discovery.OBDiscoveryResponse;
 
 import java.util.Map;
 

--- a/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/account/factory/OBReadConsentResponseFactory.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/account/factory/OBReadConsentResponseFactory.java
@@ -27,10 +27,10 @@ import com.forgerock.sapi.gateway.ob.uk.rs.server.common.util.PaginationUtil;
 import com.forgerock.sapi.gateway.ob.uk.rs.server.common.util.link.LinksHelper;
 import com.forgerock.sapi.gateway.rcs.consent.store.datamodel.account.v3_1_10.AccountAccessConsent;
 
-import uk.org.openbanking.datamodel.account.OBReadConsentResponse1;
-import uk.org.openbanking.datamodel.account.OBReadConsentResponse1Data;
-import uk.org.openbanking.datamodel.account.OBRisk2;
-import uk.org.openbanking.datamodel.common.OBExternalRequestStatus1Code;
+import uk.org.openbanking.datamodel.v3.account.OBReadConsentResponse1;
+import uk.org.openbanking.datamodel.v3.account.OBReadConsentResponse1Data;
+import uk.org.openbanking.datamodel.v3.account.OBRisk2;
+import uk.org.openbanking.datamodel.v3.common.OBExternalRequestStatus1Code;
 
 @Component
 public class OBReadConsentResponseFactory {

--- a/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/account/v3_1_10/accounts/AccountAccessConsentsApiController.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/account/v3_1_10/accounts/AccountAccessConsentsApiController.java
@@ -34,8 +34,8 @@ import com.forgerock.sapi.gateway.rcs.consent.store.client.account.v3_1_10.Accou
 import com.forgerock.sapi.gateway.rcs.consent.store.datamodel.account.v3_1_10.AccountAccessConsent;
 import com.forgerock.sapi.gateway.rcs.consent.store.datamodel.account.v3_1_10.CreateAccountAccessConsentRequest;
 
-import uk.org.openbanking.datamodel.account.OBReadConsent1;
-import uk.org.openbanking.datamodel.account.OBReadConsentResponse1;
+import uk.org.openbanking.datamodel.v3.account.OBReadConsent1;
+import uk.org.openbanking.datamodel.v3.account.OBReadConsentResponse1;
 
 @Controller("AccountAccessConsentsApiV3.1.10")
 public class AccountAccessConsentsApiController implements AccountAccessConsentsApi {

--- a/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/account/v3_1_10/accounts/AccountsApiController.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/account/v3_1_10/accounts/AccountsApiController.java
@@ -38,9 +38,9 @@ import org.slf4j.LoggerFactory;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 
-import uk.org.openbanking.datamodel.account.OBAccount6;
-import uk.org.openbanking.datamodel.account.OBReadAccount6;
-import uk.org.openbanking.datamodel.account.OBReadAccount6Data;
+import uk.org.openbanking.datamodel.v3.account.OBAccount6;
+import uk.org.openbanking.datamodel.v3.account.OBReadAccount6;
+import uk.org.openbanking.datamodel.v3.account.OBReadAccount6Data;
 
 @Controller("AccountsApiV3.1.10")
 public class AccountsApiController implements AccountsApi {

--- a/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/account/v3_1_10/balances/BalancesApiController.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/account/v3_1_10/balances/BalancesApiController.java
@@ -39,8 +39,8 @@ import com.forgerock.sapi.gateway.rs.resource.store.repo.entity.account.FRBalanc
 import com.forgerock.sapi.gateway.rs.resource.store.repo.mongo.accounts.balances.FRBalanceRepository;
 import com.forgerock.sapi.gateway.ob.uk.rs.server.service.account.consent.AccountResourceAccessService;
 
-import uk.org.openbanking.datamodel.account.OBReadBalance1;
-import uk.org.openbanking.datamodel.account.OBReadBalance1Data;
+import uk.org.openbanking.datamodel.v3.account.OBReadBalance1;
+import uk.org.openbanking.datamodel.v3.account.OBReadBalance1Data;
 
 @Controller("BalancesApiV3.1.10")
 public class BalancesApiController implements BalancesApi {

--- a/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/account/v3_1_10/beneficiaries/BeneficiariesApiController.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/account/v3_1_10/beneficiaries/BeneficiariesApiController.java
@@ -41,8 +41,8 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 
-import uk.org.openbanking.datamodel.account.OBReadBeneficiary5;
-import uk.org.openbanking.datamodel.account.OBReadBeneficiary5Data;
+import uk.org.openbanking.datamodel.v3.account.OBReadBeneficiary5;
+import uk.org.openbanking.datamodel.v3.account.OBReadBeneficiary5Data;
 
 @Controller("BeneficiariesApiV3.1.10")
 public class BeneficiariesApiController  implements BeneficiariesApi {

--- a/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/account/v3_1_10/directdebits/DirectDebitsApiController.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/account/v3_1_10/directdebits/DirectDebitsApiController.java
@@ -41,8 +41,8 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 
-import uk.org.openbanking.datamodel.account.OBReadDirectDebit2;
-import uk.org.openbanking.datamodel.account.OBReadDirectDebit2Data;
+import uk.org.openbanking.datamodel.v3.account.OBReadDirectDebit2;
+import uk.org.openbanking.datamodel.v3.account.OBReadDirectDebit2Data;
 
 @Controller("DirectDebitsApiV3.1.10")
 public class DirectDebitsApiController implements DirectDebitsApi {

--- a/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/account/v3_1_10/offers/OffersApiController.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/account/v3_1_10/offers/OffersApiController.java
@@ -40,8 +40,8 @@ import com.forgerock.sapi.gateway.rs.resource.store.repo.entity.account.FROffer;
 import com.forgerock.sapi.gateway.rs.resource.store.repo.mongo.accounts.offers.FROfferRepository;
 import com.forgerock.sapi.gateway.ob.uk.rs.server.service.account.consent.AccountResourceAccessService;
 
-import uk.org.openbanking.datamodel.account.OBReadOffer1;
-import uk.org.openbanking.datamodel.account.OBReadOffer1Data;
+import uk.org.openbanking.datamodel.v3.account.OBReadOffer1;
+import uk.org.openbanking.datamodel.v3.account.OBReadOffer1Data;
 
 @Controller("OffersApiV3.1.10")
 public class OffersApiController implements OffersApi {

--- a/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/account/v3_1_10/party/PartyApiController.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/account/v3_1_10/party/PartyApiController.java
@@ -37,11 +37,11 @@ import com.forgerock.sapi.gateway.rs.resource.store.repo.entity.account.FRParty;
 import com.forgerock.sapi.gateway.rs.resource.store.repo.mongo.accounts.party.FRPartyRepository;
 import com.forgerock.sapi.gateway.ob.uk.rs.server.service.account.consent.AccountResourceAccessService;
 
-import uk.org.openbanking.datamodel.account.OBParty2;
-import uk.org.openbanking.datamodel.account.OBReadParty2;
-import uk.org.openbanking.datamodel.account.OBReadParty2Data;
-import uk.org.openbanking.datamodel.account.OBReadParty3;
-import uk.org.openbanking.datamodel.account.OBReadParty3Data;
+import uk.org.openbanking.datamodel.v3.account.OBParty2;
+import uk.org.openbanking.datamodel.v3.account.OBReadParty2;
+import uk.org.openbanking.datamodel.v3.account.OBReadParty2Data;
+import uk.org.openbanking.datamodel.v3.account.OBReadParty3;
+import uk.org.openbanking.datamodel.v3.account.OBReadParty3Data;
 
 @Controller("PartyApiV3.1.10")
 public class PartyApiController implements PartyApi {

--- a/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/account/v3_1_10/products/ProductsApiController.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/account/v3_1_10/products/ProductsApiController.java
@@ -39,8 +39,8 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 
-import uk.org.openbanking.datamodel.account.OBReadProduct2;
-import uk.org.openbanking.datamodel.account.OBReadProduct2Data;
+import uk.org.openbanking.datamodel.v3.account.OBReadProduct2;
+import uk.org.openbanking.datamodel.v3.account.OBReadProduct2Data;
 
 @Controller("ProductsApiV3.1.10")
 public class ProductsApiController implements ProductsApi {

--- a/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/account/v3_1_10/scheduledpayments/ScheduledPaymentsApiController.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/account/v3_1_10/scheduledpayments/ScheduledPaymentsApiController.java
@@ -33,8 +33,8 @@ import com.forgerock.sapi.gateway.ob.uk.rs.obie.api.account.v3_1_10.scheduledpay
 import com.forgerock.sapi.gateway.ob.uk.rs.server.service.account.consent.AccountResourceAccessService;
 
 import lombok.extern.slf4j.Slf4j;
-import uk.org.openbanking.datamodel.account.OBReadScheduledPayment3;
-import uk.org.openbanking.datamodel.account.OBReadScheduledPayment3Data;
+import uk.org.openbanking.datamodel.v3.account.OBReadScheduledPayment3;
+import uk.org.openbanking.datamodel.v3.account.OBReadScheduledPayment3Data;
 
 import org.joda.time.DateTime;
 import org.slf4j.Logger;

--- a/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/account/v3_1_10/standingorders/StandingOrdersApiController.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/account/v3_1_10/standingorders/StandingOrdersApiController.java
@@ -41,8 +41,8 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 
-import uk.org.openbanking.datamodel.account.OBReadStandingOrder6;
-import uk.org.openbanking.datamodel.account.OBReadStandingOrder6Data;
+import uk.org.openbanking.datamodel.v3.account.OBReadStandingOrder6;
+import uk.org.openbanking.datamodel.v3.account.OBReadStandingOrder6Data;
 
 @Controller("StandingOrdersApiV3.1.10")
 public class StandingOrdersApiController implements StandingOrdersApi {

--- a/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/account/v3_1_10/statements/StatementsApiController.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/account/v3_1_10/statements/StatementsApiController.java
@@ -54,8 +54,8 @@ import com.forgerock.sapi.gateway.rcs.consent.store.datamodel.account.v3_1_10.Ac
 import com.forgerock.sapi.gateway.rs.resource.store.repo.entity.account.FRStatement;
 import com.forgerock.sapi.gateway.rs.resource.store.repo.mongo.accounts.statements.FRStatementRepository;
 
-import uk.org.openbanking.datamodel.account.OBReadDataStatement2;
-import uk.org.openbanking.datamodel.account.OBReadStatement2;
+import uk.org.openbanking.datamodel.v3.account.OBReadDataStatement2;
+import uk.org.openbanking.datamodel.v3.account.OBReadStatement2;
 
 @Controller("StatementsApiV3.1.10")
 public class StatementsApiController implements StatementsApi {

--- a/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/account/v3_1_10/transactions/TransactionsApiController.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/account/v3_1_10/transactions/TransactionsApiController.java
@@ -46,9 +46,9 @@ import com.forgerock.sapi.gateway.rcs.consent.store.datamodel.account.v3_1_10.Ac
 import com.forgerock.sapi.gateway.rs.resource.store.repo.entity.account.FRTransaction;
 import com.forgerock.sapi.gateway.rs.resource.store.repo.mongo.accounts.transactions.FRTransactionRepository;
 
-import uk.org.openbanking.datamodel.account.OBReadDataTransaction6;
-import uk.org.openbanking.datamodel.account.OBReadTransaction6;
-import uk.org.openbanking.datamodel.account.OBTransaction6;
+import uk.org.openbanking.datamodel.v3.account.OBReadDataTransaction6;
+import uk.org.openbanking.datamodel.v3.account.OBReadTransaction6;
+import uk.org.openbanking.datamodel.v3.account.OBTransaction6;
 
 @Controller("TransactionsApiV3.1.10")
 public class TransactionsApiController implements TransactionsApi {

--- a/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/event/v3_1_10/aggregatedpolling/AggregatedPollingApiController.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/event/v3_1_10/aggregatedpolling/AggregatedPollingApiController.java
@@ -30,8 +30,8 @@ import com.forgerock.sapi.gateway.ob.uk.rs.obie.api.event.v3_1_10.aggregatedpoll
 import com.forgerock.sapi.gateway.ob.uk.rs.server.service.event.EventPollingService;
 
 import lombok.extern.slf4j.Slf4j;
-import uk.org.openbanking.datamodel.event.OBEventPolling1;
-import uk.org.openbanking.datamodel.event.OBEventPollingResponse1;
+import uk.org.openbanking.datamodel.v3.event.OBEventPolling1;
+import uk.org.openbanking.datamodel.v3.event.OBEventPollingResponse1;
 
 @Controller("AggregatedPollingApiV3.1.10")
 @Slf4j

--- a/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/event/v3_1_10/eventsubscription/EventSubscriptionsApiController.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/event/v3_1_10/eventsubscription/EventSubscriptionsApiController.java
@@ -46,15 +46,15 @@ import org.springframework.stereotype.Controller;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
-import uk.org.openbanking.datamodel.common.Links;
-import uk.org.openbanking.datamodel.common.Meta;
-import uk.org.openbanking.datamodel.event.OBEventSubscription1;
-import uk.org.openbanking.datamodel.event.OBEventSubscription1Data;
-import uk.org.openbanking.datamodel.event.OBEventSubscriptionResponse1;
-import uk.org.openbanking.datamodel.event.OBEventSubscriptionResponse1Data;
-import uk.org.openbanking.datamodel.event.OBEventSubscriptionsResponse1;
-import uk.org.openbanking.datamodel.event.OBEventSubscriptionsResponse1Data;
-import uk.org.openbanking.datamodel.event.OBEventSubscriptionsResponse1DataEventSubscriptionInner;
+import uk.org.openbanking.datamodel.v3.common.Links;
+import uk.org.openbanking.datamodel.v3.common.Meta;
+import uk.org.openbanking.datamodel.v3.event.OBEventSubscription1;
+import uk.org.openbanking.datamodel.v3.event.OBEventSubscription1Data;
+import uk.org.openbanking.datamodel.v3.event.OBEventSubscriptionResponse1;
+import uk.org.openbanking.datamodel.v3.event.OBEventSubscriptionResponse1Data;
+import uk.org.openbanking.datamodel.v3.event.OBEventSubscriptionsResponse1;
+import uk.org.openbanking.datamodel.v3.event.OBEventSubscriptionsResponse1Data;
+import uk.org.openbanking.datamodel.v3.event.OBEventSubscriptionsResponse1DataEventSubscriptionInner;
 
 @Controller("EventSubscriptionApiV3.1.10")
 public class EventSubscriptionsApiController implements EventSubscriptionsApi {

--- a/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/funds/factory/OBFundsConfirmationConsentResponseFactory.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/funds/factory/OBFundsConfirmationConsentResponseFactory.java
@@ -24,9 +24,9 @@ import com.forgerock.sapi.gateway.rcs.consent.store.datamodel.funds.v3_1_10.Fund
 
 import org.joda.time.DateTime;
 import org.springframework.stereotype.Component;
-import uk.org.openbanking.datamodel.fund.OBFundsConfirmationConsentResponse1;
-import uk.org.openbanking.datamodel.fund.OBFundsConfirmationConsentResponse1Data;
-import uk.org.openbanking.datamodel.fund.OBFundsConfirmationConsentResponse1Data.StatusEnum;
+import uk.org.openbanking.datamodel.v3.fund.OBFundsConfirmationConsentResponse1;
+import uk.org.openbanking.datamodel.v3.fund.OBFundsConfirmationConsentResponse1Data;
+import uk.org.openbanking.datamodel.v3.fund.OBFundsConfirmationConsentResponse1Data.StatusEnum;
 
 @Component
 public class OBFundsConfirmationConsentResponseFactory {

--- a/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/funds/v3_1_10/FundsConfirmationConsentsApiController.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/funds/v3_1_10/FundsConfirmationConsentsApiController.java
@@ -33,8 +33,8 @@ import com.forgerock.sapi.gateway.rcs.consent.store.datamodel.funds.v3_1_10.Crea
 import com.forgerock.sapi.gateway.rcs.consent.store.datamodel.funds.v3_1_10.FundsConfirmationConsent;
 
 import lombok.extern.slf4j.Slf4j;
-import uk.org.openbanking.datamodel.fund.OBFundsConfirmationConsent1;
-import uk.org.openbanking.datamodel.fund.OBFundsConfirmationConsentResponse1;
+import uk.org.openbanking.datamodel.v3.fund.OBFundsConfirmationConsent1;
+import uk.org.openbanking.datamodel.v3.fund.OBFundsConfirmationConsentResponse1;
 
 @Controller("FundsConfirmationConsentsApiV3.1.10")
 @Slf4j

--- a/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/funds/v3_1_10/FundsConfirmationsApiController.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/funds/v3_1_10/FundsConfirmationsApiController.java
@@ -48,10 +48,10 @@ import com.forgerock.sapi.gateway.rs.resource.store.repo.mongo.funds.FundsConfir
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
-import uk.org.openbanking.datamodel.common.Meta;
-import uk.org.openbanking.datamodel.fund.OBFundsConfirmation1;
-import uk.org.openbanking.datamodel.fund.OBFundsConfirmationResponse1;
-import uk.org.openbanking.datamodel.fund.OBFundsConfirmationResponse1Data;
+import uk.org.openbanking.datamodel.v3.common.Meta;
+import uk.org.openbanking.datamodel.v3.fund.OBFundsConfirmation1;
+import uk.org.openbanking.datamodel.v3.fund.OBFundsConfirmationResponse1;
+import uk.org.openbanking.datamodel.v3.fund.OBFundsConfirmationResponse1Data;
 
 @Controller("FundsConfirmationsApiV3.1.10")
 public class FundsConfirmationsApiController implements FundsConfirmationsApi {

--- a/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/factories/OBDomesticVRPConsentResponseFactory.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/factories/OBDomesticVRPConsentResponseFactory.java
@@ -23,12 +23,12 @@ import org.springframework.stereotype.Component;
 import com.forgerock.sapi.gateway.ob.uk.rs.server.common.util.link.LinksHelper;
 import com.forgerock.sapi.gateway.rcs.consent.store.datamodel.payment.vrp.v3_1_10.DomesticVRPConsent;
 
-import uk.org.openbanking.datamodel.common.Meta;
-import uk.org.openbanking.datamodel.vrp.OBDomesticVRPConsentRequest;
-import uk.org.openbanking.datamodel.vrp.OBDomesticVRPConsentRequestData;
-import uk.org.openbanking.datamodel.vrp.OBDomesticVRPConsentResponse;
-import uk.org.openbanking.datamodel.vrp.OBDomesticVRPConsentResponseData;
-import uk.org.openbanking.datamodel.vrp.OBDomesticVRPConsentResponseDataStatus;
+import uk.org.openbanking.datamodel.v3.common.Meta;
+import uk.org.openbanking.datamodel.v3.vrp.OBDomesticVRPConsentRequest;
+import uk.org.openbanking.datamodel.v3.vrp.OBDomesticVRPConsentRequestData;
+import uk.org.openbanking.datamodel.v3.vrp.OBDomesticVRPConsentResponse;
+import uk.org.openbanking.datamodel.v3.vrp.OBDomesticVRPConsentResponseData;
+import uk.org.openbanking.datamodel.v3.vrp.OBDomesticVRPConsentResponseDataStatus;
 
 @Component
 public class OBDomesticVRPConsentResponseFactory {

--- a/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/factories/OBWriteDomesticConsentResponse5Factory.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/factories/OBWriteDomesticConsentResponse5Factory.java
@@ -24,12 +24,12 @@ import com.forgerock.sapi.gateway.ob.uk.common.datamodel.converter.common.FRChar
 import com.forgerock.sapi.gateway.ob.uk.common.datamodel.converter.payment.FRWriteDomesticConsentConverter;
 import com.forgerock.sapi.gateway.rcs.consent.store.datamodel.payment.domestic.v3_1_10.DomesticPaymentConsent;
 
-import uk.org.openbanking.datamodel.common.Meta;
-import uk.org.openbanking.datamodel.payment.OBPaymentConsentStatus;
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticConsent4;
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticConsent4Data;
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticConsentResponse5;
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticConsentResponse5Data;
+import uk.org.openbanking.datamodel.v3.common.Meta;
+import uk.org.openbanking.datamodel.v3.payment.OBPaymentConsentStatus;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteDomesticConsent4;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteDomesticConsent4Data;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteDomesticConsentResponse5;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteDomesticConsentResponse5Data;
 
 /**
  * Factory to create {@link OBWriteDomesticConsentResponse5}

--- a/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/factories/OBWriteDomesticScheduledConsentResponse5Factory.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/factories/OBWriteDomesticScheduledConsentResponse5Factory.java
@@ -25,12 +25,12 @@ import com.forgerock.sapi.gateway.ob.uk.common.datamodel.converter.common.FRChar
 import com.forgerock.sapi.gateway.ob.uk.common.datamodel.converter.payment.FRWriteDomesticScheduledConsentConverter;
 import com.forgerock.sapi.gateway.rcs.consent.store.datamodel.payment.domesticscheduled.v3_1_10.DomesticScheduledPaymentConsent;
 
-import uk.org.openbanking.datamodel.common.Meta;
-import uk.org.openbanking.datamodel.payment.OBPaymentConsentStatus;
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticScheduledConsent4;
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticScheduledConsent4Data;
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticScheduledConsentResponse5;
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticScheduledConsentResponse5Data;
+import uk.org.openbanking.datamodel.v3.common.Meta;
+import uk.org.openbanking.datamodel.v3.payment.OBPaymentConsentStatus;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteDomesticScheduledConsent4;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteDomesticScheduledConsent4Data;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteDomesticScheduledConsentResponse5;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteDomesticScheduledConsentResponse5Data;
 
 @Component
 public class OBWriteDomesticScheduledConsentResponse5Factory {

--- a/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/factories/OBWriteDomesticStandingOrderConsentResponse6Factory.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/factories/OBWriteDomesticStandingOrderConsentResponse6Factory.java
@@ -26,13 +26,13 @@ import com.forgerock.sapi.gateway.ob.uk.common.datamodel.converter.mapper.FRMode
 import com.forgerock.sapi.gateway.ob.uk.common.datamodel.converter.payment.FRWriteDomesticStandingOrderConsentConverter;
 import com.forgerock.sapi.gateway.rcs.consent.store.datamodel.payment.domesticstandingorder.v3_1_10.DomesticStandingOrderConsent;
 
-import uk.org.openbanking.datamodel.common.Meta;
-import uk.org.openbanking.datamodel.payment.OBPaymentConsentStatus;
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticStandingOrderConsent5;
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticStandingOrderConsent5Data;
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticStandingOrderConsentResponse6;
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticStandingOrderConsentResponse6Data;
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticStandingOrderConsentResponse6DataInitiation;
+import uk.org.openbanking.datamodel.v3.common.Meta;
+import uk.org.openbanking.datamodel.v3.payment.OBPaymentConsentStatus;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteDomesticStandingOrderConsent5;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteDomesticStandingOrderConsent5Data;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteDomesticStandingOrderConsentResponse6;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteDomesticStandingOrderConsentResponse6Data;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteDomesticStandingOrderConsentResponse6DataInitiation;
 
 @Component
 public class OBWriteDomesticStandingOrderConsentResponse6Factory {

--- a/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/factories/OBWriteFileConsentResponse4Factory.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/factories/OBWriteFileConsentResponse4Factory.java
@@ -24,12 +24,12 @@ import com.forgerock.sapi.gateway.ob.uk.common.datamodel.converter.common.FRChar
 import com.forgerock.sapi.gateway.ob.uk.common.datamodel.converter.payment.FRWriteFileConsentConverter;
 import com.forgerock.sapi.gateway.rcs.consent.store.datamodel.payment.file.v3_1_10.FilePaymentConsent;
 
-import uk.org.openbanking.datamodel.common.Meta;
-import uk.org.openbanking.datamodel.payment.OBWriteFileConsent3;
-import uk.org.openbanking.datamodel.payment.OBWriteFileConsent3Data;
-import uk.org.openbanking.datamodel.payment.OBWriteFileConsentResponse4;
-import uk.org.openbanking.datamodel.payment.OBWriteFileConsentResponse4Data;
-import uk.org.openbanking.datamodel.payment.OBWriteFileConsentResponse4DataStatus;
+import uk.org.openbanking.datamodel.v3.common.Meta;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteFileConsent3;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteFileConsent3Data;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteFileConsentResponse4;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteFileConsentResponse4Data;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteFileConsentResponse4DataStatus;
 
 @Component
 public class OBWriteFileConsentResponse4Factory {

--- a/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/factories/OBWriteFundsConfirmationResponse1Factory.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/factories/OBWriteFundsConfirmationResponse1Factory.java
@@ -21,11 +21,11 @@ import java.util.function.Function;
 import org.joda.time.DateTime;
 import org.springframework.stereotype.Component;
 
-import uk.org.openbanking.datamodel.common.Links;
-import uk.org.openbanking.datamodel.common.Meta;
-import uk.org.openbanking.datamodel.payment.OBWriteFundsConfirmationResponse1;
-import uk.org.openbanking.datamodel.payment.OBWriteFundsConfirmationResponse1Data;
-import uk.org.openbanking.datamodel.payment.OBWriteFundsConfirmationResponse1DataFundsAvailableResult;
+import uk.org.openbanking.datamodel.v3.common.Links;
+import uk.org.openbanking.datamodel.v3.common.Meta;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteFundsConfirmationResponse1;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteFundsConfirmationResponse1Data;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteFundsConfirmationResponse1DataFundsAvailableResult;
 
 /**
  * Factory capable of producing {@link OBWriteFundsConfirmationResponse1} objects.

--- a/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/factories/OBWriteInternationalConsentResponse6Factory.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/factories/OBWriteInternationalConsentResponse6Factory.java
@@ -26,12 +26,12 @@ import com.forgerock.sapi.gateway.ob.uk.common.datamodel.converter.payment.FRWri
 import com.forgerock.sapi.gateway.ob.uk.common.datamodel.payment.FRWriteInternationalConsent;
 import com.forgerock.sapi.gateway.rcs.consent.store.datamodel.payment.international.v3_1_10.InternationalPaymentConsent;
 
-import uk.org.openbanking.datamodel.common.Meta;
-import uk.org.openbanking.datamodel.payment.OBPaymentConsentStatus;
-import uk.org.openbanking.datamodel.payment.OBWriteInternationalConsent5;
-import uk.org.openbanking.datamodel.payment.OBWriteInternationalConsent5Data;
-import uk.org.openbanking.datamodel.payment.OBWriteInternationalConsentResponse6;
-import uk.org.openbanking.datamodel.payment.OBWriteInternationalConsentResponse6Data;
+import uk.org.openbanking.datamodel.v3.common.Meta;
+import uk.org.openbanking.datamodel.v3.payment.OBPaymentConsentStatus;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteInternationalConsent5;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteInternationalConsent5Data;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteInternationalConsentResponse6;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteInternationalConsentResponse6Data;
 
 @Component
 public class OBWriteInternationalConsentResponse6Factory {

--- a/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/factories/OBWriteInternationalScheduledConsentResponse6Factory.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/factories/OBWriteInternationalScheduledConsentResponse6Factory.java
@@ -27,13 +27,13 @@ import com.forgerock.sapi.gateway.ob.uk.common.datamodel.converter.payment.FRWri
 import com.forgerock.sapi.gateway.ob.uk.common.datamodel.payment.FRWriteInternationalScheduledConsent;
 import com.forgerock.sapi.gateway.rcs.consent.store.datamodel.payment.internationalscheduled.v3_1_10.InternationalScheduledPaymentConsent;
 
-import uk.org.openbanking.datamodel.common.Meta;
-import uk.org.openbanking.datamodel.payment.OBPaymentConsentStatus;
-import uk.org.openbanking.datamodel.payment.OBWriteInternationalScheduledConsent5;
-import uk.org.openbanking.datamodel.payment.OBWriteInternationalScheduledConsent5Data;
-import uk.org.openbanking.datamodel.payment.OBWriteInternationalScheduledConsentResponse6;
-import uk.org.openbanking.datamodel.payment.OBWriteInternationalScheduledConsentResponse6Data;
-import uk.org.openbanking.datamodel.payment.OBWriteInternationalScheduledConsentResponse6DataInitiation;
+import uk.org.openbanking.datamodel.v3.common.Meta;
+import uk.org.openbanking.datamodel.v3.payment.OBPaymentConsentStatus;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteInternationalScheduledConsent5;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteInternationalScheduledConsent5Data;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteInternationalScheduledConsentResponse6;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteInternationalScheduledConsentResponse6Data;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteInternationalScheduledConsentResponse6DataInitiation;
 
 @Component
 public class OBWriteInternationalScheduledConsentResponse6Factory {

--- a/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/factories/OBWriteInternationalStandingOrderConsentResponse7Factory.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/factories/OBWriteInternationalStandingOrderConsentResponse7Factory.java
@@ -26,13 +26,13 @@ import com.forgerock.sapi.gateway.ob.uk.common.datamodel.payment.FRWriteInternat
 import com.forgerock.sapi.gateway.ob.uk.rs.server.common.util.link.LinksHelper;
 import com.forgerock.sapi.gateway.rcs.consent.store.datamodel.payment.internationalstandingorder.v3_1_10.InternationalStandingOrderConsent;
 
-import uk.org.openbanking.datamodel.common.Meta;
-import uk.org.openbanking.datamodel.payment.OBPaymentConsentStatus;
-import uk.org.openbanking.datamodel.payment.OBWriteInternationalStandingOrderConsent6;
-import uk.org.openbanking.datamodel.payment.OBWriteInternationalStandingOrderConsent6Data;
-import uk.org.openbanking.datamodel.payment.OBWriteInternationalStandingOrderConsentResponse7;
-import uk.org.openbanking.datamodel.payment.OBWriteInternationalStandingOrderConsentResponse7Data;
-import uk.org.openbanking.datamodel.payment.OBWriteInternationalStandingOrderConsentResponse7DataInitiation;
+import uk.org.openbanking.datamodel.v3.common.Meta;
+import uk.org.openbanking.datamodel.v3.payment.OBPaymentConsentStatus;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteInternationalStandingOrderConsent6;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteInternationalStandingOrderConsent6Data;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteInternationalStandingOrderConsentResponse7;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteInternationalStandingOrderConsentResponse7Data;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteInternationalStandingOrderConsentResponse7DataInitiation;
 
 @Component
 public class OBWriteInternationalStandingOrderConsentResponse7Factory {

--- a/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/services/validation/FilePaymentFileContentValidator.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/services/validation/FilePaymentFileContentValidator.java
@@ -23,8 +23,8 @@ import com.forgerock.sapi.gateway.ob.uk.rs.server.common.payment.file.PaymentFil
 import com.forgerock.sapi.gateway.ob.uk.rs.validation.ValidationResult;
 import com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.BaseOBValidator;
 
-import uk.org.openbanking.datamodel.error.OBError1;
-import uk.org.openbanking.datamodel.payment.OBWriteFileConsent3;
+import uk.org.openbanking.datamodel.v3.error.OBError1;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteFileConsent3;
 
 /**
  * Validator which verifies that the Payment File uploaded is valid for the Consent

--- a/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/services/validation/RiskValidationService.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/services/validation/RiskValidationService.java
@@ -20,8 +20,8 @@ import com.forgerock.sapi.gateway.ob.uk.common.error.OBRIErrorType;
 import com.forgerock.sapi.gateway.ob.uk.rs.server.validator.OBRisk1Validator;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
-import uk.org.openbanking.datamodel.common.OBExternalPaymentContext1Code;
-import uk.org.openbanking.datamodel.common.OBRisk1;
+import uk.org.openbanking.datamodel.v3.common.OBExternalPaymentContext1Code;
+import uk.org.openbanking.datamodel.v3.common.OBRisk1;
 
 import java.util.Objects;
 

--- a/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/v3_1_10/domesticpayments/DomesticPaymentConsentsApiController.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/v3_1_10/domesticpayments/DomesticPaymentConsentsApiController.java
@@ -42,10 +42,10 @@ import com.forgerock.sapi.gateway.rcs.consent.store.datamodel.payment.domestic.v
 import com.forgerock.sapi.gateway.rcs.consent.store.datamodel.payment.domestic.v3_1_10.DomesticPaymentConsent;
 
 import jakarta.servlet.http.HttpServletRequest;
-import uk.org.openbanking.datamodel.payment.OBPaymentConsentStatus;
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticConsent4;
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticConsentResponse5;
-import uk.org.openbanking.datamodel.payment.OBWriteFundsConfirmationResponse1;
+import uk.org.openbanking.datamodel.v3.payment.OBPaymentConsentStatus;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteDomesticConsent4;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteDomesticConsentResponse5;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteFundsConfirmationResponse1;
 
 @Controller("DomesticPaymentConsentsApiV3.1.10")
 public class DomesticPaymentConsentsApiController implements DomesticPaymentConsentsApi {

--- a/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/v3_1_10/domesticpayments/DomesticPaymentsApiController.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/v3_1_10/domesticpayments/DomesticPaymentsApiController.java
@@ -28,7 +28,7 @@ import static com.forgerock.sapi.gateway.ob.uk.common.datamodel.converter.paymen
 import static com.forgerock.sapi.gateway.ob.uk.common.datamodel.converter.payment.FRWriteDomesticConverter.toFRWriteDomestic;
 import static org.springframework.http.HttpStatus.BAD_REQUEST;
 import static org.springframework.http.HttpStatus.CREATED;
-import static uk.org.openbanking.datamodel.payment.OBWritePaymentDetailsResponse1DataPaymentStatusInnerStatusDetailStatusReason.PENDINGSETTLEMENT;
+import static uk.org.openbanking.datamodel.v3.payment.OBWritePaymentDetailsResponse1DataPaymentStatusInnerStatusDetailStatusReason.PENDINGSETTLEMENT;
 
 import java.security.Principal;
 import java.util.Date;
@@ -69,15 +69,15 @@ import com.forgerock.sapi.gateway.uk.common.shared.api.meta.obie.OBVersion;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.extern.slf4j.Slf4j;
-import uk.org.openbanking.datamodel.common.Meta;
-import uk.org.openbanking.datamodel.payment.OBWriteDomestic2;
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticResponse5;
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticResponse5Data;
-import uk.org.openbanking.datamodel.payment.OBWritePaymentDetailsResponse1;
-import uk.org.openbanking.datamodel.payment.OBWritePaymentDetailsResponse1Data;
-import uk.org.openbanking.datamodel.payment.OBWritePaymentDetailsResponse1DataPaymentStatusInner;
-import uk.org.openbanking.datamodel.payment.OBWritePaymentDetailsResponse1DataPaymentStatusInnerStatus;
-import uk.org.openbanking.datamodel.payment.OBWritePaymentDetailsResponse1DataPaymentStatusInnerStatusDetail;
+import uk.org.openbanking.datamodel.v3.common.Meta;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteDomestic2;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteDomesticResponse5;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteDomesticResponse5Data;
+import uk.org.openbanking.datamodel.v3.payment.OBWritePaymentDetailsResponse1;
+import uk.org.openbanking.datamodel.v3.payment.OBWritePaymentDetailsResponse1Data;
+import uk.org.openbanking.datamodel.v3.payment.OBWritePaymentDetailsResponse1DataPaymentStatusInner;
+import uk.org.openbanking.datamodel.v3.payment.OBWritePaymentDetailsResponse1DataPaymentStatusInnerStatus;
+import uk.org.openbanking.datamodel.v3.payment.OBWritePaymentDetailsResponse1DataPaymentStatusInnerStatusDetail;
 
 @Controller("DomesticPaymentsApiV3.1.10")
 @Slf4j

--- a/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/v3_1_10/domesticscheduledpayments/DomesticScheduledPaymentConsentsApiController.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/v3_1_10/domesticscheduledpayments/DomesticScheduledPaymentConsentsApiController.java
@@ -38,8 +38,8 @@ import com.forgerock.sapi.gateway.rcs.consent.store.client.payment.domesticsched
 import com.forgerock.sapi.gateway.rcs.consent.store.datamodel.payment.domesticscheduled.v3_1_10.CreateDomesticScheduledPaymentConsentRequest;
 import com.forgerock.sapi.gateway.rcs.consent.store.datamodel.payment.domesticscheduled.v3_1_10.DomesticScheduledPaymentConsent;
 
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticScheduledConsent4;
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticScheduledConsentResponse5;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteDomesticScheduledConsent4;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteDomesticScheduledConsentResponse5;
 
 @Controller("DomesticScheduledPaymentConsentsApiV3.1.10")
 public class DomesticScheduledPaymentConsentsApiController implements DomesticScheduledPaymentConsentsApi {

--- a/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/v3_1_10/domesticscheduledpayments/DomesticScheduledPaymentsApiController.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/v3_1_10/domesticscheduledpayments/DomesticScheduledPaymentsApiController.java
@@ -68,16 +68,16 @@ import com.forgerock.sapi.gateway.uk.common.shared.api.meta.obie.OBVersion;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
-import uk.org.openbanking.datamodel.common.Meta;
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticScheduled2;
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticScheduledResponse5;
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticScheduledResponse5Data;
-import uk.org.openbanking.datamodel.payment.OBWritePaymentDetailsResponse1;
-import uk.org.openbanking.datamodel.payment.OBWritePaymentDetailsResponse1Data;
-import uk.org.openbanking.datamodel.payment.OBWritePaymentDetailsResponse1DataPaymentStatusInner;
-import uk.org.openbanking.datamodel.payment.OBWritePaymentDetailsResponse1DataPaymentStatusInnerStatus;
-import uk.org.openbanking.datamodel.payment.OBWritePaymentDetailsResponse1DataPaymentStatusInnerStatusDetail;
-import uk.org.openbanking.datamodel.payment.OBWritePaymentDetailsResponse1DataPaymentStatusInnerStatusDetailStatusReason;
+import uk.org.openbanking.datamodel.v3.common.Meta;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteDomesticScheduled2;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteDomesticScheduledResponse5;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteDomesticScheduledResponse5Data;
+import uk.org.openbanking.datamodel.v3.payment.OBWritePaymentDetailsResponse1;
+import uk.org.openbanking.datamodel.v3.payment.OBWritePaymentDetailsResponse1Data;
+import uk.org.openbanking.datamodel.v3.payment.OBWritePaymentDetailsResponse1DataPaymentStatusInner;
+import uk.org.openbanking.datamodel.v3.payment.OBWritePaymentDetailsResponse1DataPaymentStatusInnerStatus;
+import uk.org.openbanking.datamodel.v3.payment.OBWritePaymentDetailsResponse1DataPaymentStatusInnerStatusDetail;
+import uk.org.openbanking.datamodel.v3.payment.OBWritePaymentDetailsResponse1DataPaymentStatusInnerStatusDetailStatusReason;
 
 @Controller("DomesticScheduledPaymentsApiV3.1.10")
 public class DomesticScheduledPaymentsApiController implements DomesticScheduledPaymentsApi {

--- a/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/v3_1_10/domesticstandingorders/DomesticStandingOrderConsentsApiController.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/v3_1_10/domesticstandingorders/DomesticStandingOrderConsentsApiController.java
@@ -39,8 +39,8 @@ import com.forgerock.sapi.gateway.rcs.consent.store.client.payment.domesticstand
 import com.forgerock.sapi.gateway.rcs.consent.store.datamodel.payment.domesticstandingorder.v3_1_10.CreateDomesticStandingOrderConsentRequest;
 import com.forgerock.sapi.gateway.rcs.consent.store.datamodel.payment.domesticstandingorder.v3_1_10.DomesticStandingOrderConsent;
 
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticStandingOrderConsent5;
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticStandingOrderConsentResponse6;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteDomesticStandingOrderConsent5;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteDomesticStandingOrderConsentResponse6;
 
 @Controller("DomesticStandingOrdersConsentsApiV3.1.10")
 public class DomesticStandingOrderConsentsApiController implements DomesticStandingOrderConsentsApi {

--- a/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/v3_1_10/domesticstandingorders/DomesticStandingOrdersApiController.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/v3_1_10/domesticstandingorders/DomesticStandingOrdersApiController.java
@@ -68,16 +68,16 @@ import com.forgerock.sapi.gateway.uk.common.shared.api.meta.obie.OBVersion;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
-import uk.org.openbanking.datamodel.common.Meta;
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticStandingOrder3;
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticStandingOrderResponse6;
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticStandingOrderResponse6Data;
-import uk.org.openbanking.datamodel.payment.OBWritePaymentDetailsResponse1;
-import uk.org.openbanking.datamodel.payment.OBWritePaymentDetailsResponse1Data;
-import uk.org.openbanking.datamodel.payment.OBWritePaymentDetailsResponse1DataPaymentStatusInner;
-import uk.org.openbanking.datamodel.payment.OBWritePaymentDetailsResponse1DataPaymentStatusInnerStatus;
-import uk.org.openbanking.datamodel.payment.OBWritePaymentDetailsResponse1DataPaymentStatusInnerStatusDetail;
-import uk.org.openbanking.datamodel.payment.OBWritePaymentDetailsResponse1DataPaymentStatusInnerStatusDetailStatusReason;
+import uk.org.openbanking.datamodel.v3.common.Meta;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteDomesticStandingOrder3;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteDomesticStandingOrderResponse6;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteDomesticStandingOrderResponse6Data;
+import uk.org.openbanking.datamodel.v3.payment.OBWritePaymentDetailsResponse1;
+import uk.org.openbanking.datamodel.v3.payment.OBWritePaymentDetailsResponse1Data;
+import uk.org.openbanking.datamodel.v3.payment.OBWritePaymentDetailsResponse1DataPaymentStatusInner;
+import uk.org.openbanking.datamodel.v3.payment.OBWritePaymentDetailsResponse1DataPaymentStatusInnerStatus;
+import uk.org.openbanking.datamodel.v3.payment.OBWritePaymentDetailsResponse1DataPaymentStatusInnerStatusDetail;
+import uk.org.openbanking.datamodel.v3.payment.OBWritePaymentDetailsResponse1DataPaymentStatusInnerStatusDetailStatusReason;
 
 
 @Controller("DomesticStandingOrdersApiV3.1.10")

--- a/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/v3_1_10/file/FilePaymentConsentsApiController.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/v3_1_10/file/FilePaymentConsentsApiController.java
@@ -48,8 +48,8 @@ import com.forgerock.sapi.gateway.rcs.consent.store.datamodel.payment.file.v3_1_
 import com.forgerock.sapi.gateway.rcs.consent.store.datamodel.payment.file.v3_1_10.FilePaymentConsent;
 import com.forgerock.sapi.gateway.rcs.consent.store.datamodel.payment.file.v3_1_10.FileUploadRequest;
 
-import uk.org.openbanking.datamodel.payment.OBWriteFileConsent3;
-import uk.org.openbanking.datamodel.payment.OBWriteFileConsentResponse4;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteFileConsent3;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteFileConsentResponse4;
 
 @Controller("FilePaymentConsentsApiV3.1.10")
 public class FilePaymentConsentsApiController implements FilePaymentConsentsApi {

--- a/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/v3_1_10/file/FilePaymentsApiController.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/v3_1_10/file/FilePaymentsApiController.java
@@ -65,12 +65,12 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 
 import jakarta.servlet.http.HttpServletRequest;
-import uk.org.openbanking.datamodel.common.Meta;
-import uk.org.openbanking.datamodel.payment.OBWriteFile2;
-import uk.org.openbanking.datamodel.payment.OBWriteFileConsent3;
-import uk.org.openbanking.datamodel.payment.OBWriteFileResponse3;
-import uk.org.openbanking.datamodel.payment.OBWriteFileResponse3Data;
-import uk.org.openbanking.datamodel.payment.OBWritePaymentDetailsResponse1;
+import uk.org.openbanking.datamodel.v3.common.Meta;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteFile2;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteFileConsent3;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteFileResponse3;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteFileResponse3Data;
+import uk.org.openbanking.datamodel.v3.payment.OBWritePaymentDetailsResponse1;
 
 @Controller("FilePaymentsApiV3.1.10")
 public class FilePaymentsApiController implements FilePaymentsApi {

--- a/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/v3_1_10/internationalpayments/InternationalPaymentConsentsApiController.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/v3_1_10/internationalpayments/InternationalPaymentConsentsApiController.java
@@ -44,12 +44,12 @@ import com.forgerock.sapi.gateway.rcs.consent.store.datamodel.payment.internatio
 import com.forgerock.sapi.gateway.rcs.consent.store.datamodel.payment.international.v3_1_10.InternationalPaymentConsent;
 
 import jakarta.servlet.http.HttpServletRequest;
-import uk.org.openbanking.datamodel.payment.OBPaymentConsentStatus;
-import uk.org.openbanking.datamodel.payment.OBWriteDomestic2DataInitiationInstructedAmount;
-import uk.org.openbanking.datamodel.payment.OBWriteFundsConfirmationResponse1;
-import uk.org.openbanking.datamodel.payment.OBWriteInternational3DataInitiation;
-import uk.org.openbanking.datamodel.payment.OBWriteInternationalConsent5;
-import uk.org.openbanking.datamodel.payment.OBWriteInternationalConsentResponse6;
+import uk.org.openbanking.datamodel.v3.payment.OBPaymentConsentStatus;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteDomestic2DataInitiationInstructedAmount;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteFundsConfirmationResponse1;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteInternational3DataInitiation;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteInternationalConsent5;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteInternationalConsentResponse6;
 
 @Controller("InternationalPaymentConsentsApiV3.1.10")
 public class InternationalPaymentConsentsApiController implements InternationalPaymentConsentsApi {

--- a/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/v3_1_10/internationalpayments/InternationalPaymentsApiController.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/v3_1_10/internationalpayments/InternationalPaymentsApiController.java
@@ -68,16 +68,16 @@ import com.forgerock.sapi.gateway.uk.common.shared.api.meta.obie.OBVersion;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
-import uk.org.openbanking.datamodel.common.Meta;
-import uk.org.openbanking.datamodel.payment.OBWriteInternational3;
-import uk.org.openbanking.datamodel.payment.OBWriteInternationalResponse5;
-import uk.org.openbanking.datamodel.payment.OBWriteInternationalResponse5Data;
-import uk.org.openbanking.datamodel.payment.OBWritePaymentDetailsResponse1;
-import uk.org.openbanking.datamodel.payment.OBWritePaymentDetailsResponse1Data;
-import uk.org.openbanking.datamodel.payment.OBWritePaymentDetailsResponse1DataPaymentStatusInner;
-import uk.org.openbanking.datamodel.payment.OBWritePaymentDetailsResponse1DataPaymentStatusInnerStatus;
-import uk.org.openbanking.datamodel.payment.OBWritePaymentDetailsResponse1DataPaymentStatusInnerStatusDetail;
-import uk.org.openbanking.datamodel.payment.OBWritePaymentDetailsResponse1DataPaymentStatusInnerStatusDetailStatusReason;
+import uk.org.openbanking.datamodel.v3.common.Meta;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteInternational3;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteInternationalResponse5;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteInternationalResponse5Data;
+import uk.org.openbanking.datamodel.v3.payment.OBWritePaymentDetailsResponse1;
+import uk.org.openbanking.datamodel.v3.payment.OBWritePaymentDetailsResponse1Data;
+import uk.org.openbanking.datamodel.v3.payment.OBWritePaymentDetailsResponse1DataPaymentStatusInner;
+import uk.org.openbanking.datamodel.v3.payment.OBWritePaymentDetailsResponse1DataPaymentStatusInnerStatus;
+import uk.org.openbanking.datamodel.v3.payment.OBWritePaymentDetailsResponse1DataPaymentStatusInnerStatusDetail;
+import uk.org.openbanking.datamodel.v3.payment.OBWritePaymentDetailsResponse1DataPaymentStatusInnerStatusDetailStatusReason;
 
 @Controller("InternationalPaymentsApiV3.1.10")
 public class InternationalPaymentsApiController implements InternationalPaymentsApi {

--- a/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/v3_1_10/internationalscheduledpayments/InternationalScheduledPaymentConsentsApiController.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/v3_1_10/internationalscheduledpayments/InternationalScheduledPaymentConsentsApiController.java
@@ -44,12 +44,12 @@ import com.forgerock.sapi.gateway.rcs.consent.store.datamodel.payment.internatio
 import com.forgerock.sapi.gateway.rcs.consent.store.datamodel.payment.internationalscheduled.v3_1_10.InternationalScheduledPaymentConsent;
 
 import jakarta.servlet.http.HttpServletRequest;
-import uk.org.openbanking.datamodel.payment.OBPaymentConsentStatus;
-import uk.org.openbanking.datamodel.payment.OBWriteDomestic2DataInitiationInstructedAmount;
-import uk.org.openbanking.datamodel.payment.OBWriteFundsConfirmationResponse1;
-import uk.org.openbanking.datamodel.payment.OBWriteInternationalScheduled3DataInitiation;
-import uk.org.openbanking.datamodel.payment.OBWriteInternationalScheduledConsent5;
-import uk.org.openbanking.datamodel.payment.OBWriteInternationalScheduledConsentResponse6;
+import uk.org.openbanking.datamodel.v3.payment.OBPaymentConsentStatus;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteDomestic2DataInitiationInstructedAmount;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteFundsConfirmationResponse1;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteInternationalScheduled3DataInitiation;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteInternationalScheduledConsent5;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteInternationalScheduledConsentResponse6;
 
 @Controller("InternationalScheduledPaymentConsentsApiV3.1.10")
 public class InternationalScheduledPaymentConsentsApiController implements InternationalScheduledPaymentConsentsApi {

--- a/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/v3_1_10/internationalscheduledpayments/InternationalScheduledPaymentsApiController.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/v3_1_10/internationalscheduledpayments/InternationalScheduledPaymentsApiController.java
@@ -69,16 +69,16 @@ import com.forgerock.sapi.gateway.uk.common.shared.api.meta.obie.OBVersion;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
-import uk.org.openbanking.datamodel.common.Meta;
-import uk.org.openbanking.datamodel.payment.OBWriteInternationalScheduled3;
-import uk.org.openbanking.datamodel.payment.OBWriteInternationalScheduledResponse6;
-import uk.org.openbanking.datamodel.payment.OBWriteInternationalScheduledResponse6Data;
-import uk.org.openbanking.datamodel.payment.OBWritePaymentDetailsResponse1;
-import uk.org.openbanking.datamodel.payment.OBWritePaymentDetailsResponse1Data;
-import uk.org.openbanking.datamodel.payment.OBWritePaymentDetailsResponse1DataPaymentStatusInner;
-import uk.org.openbanking.datamodel.payment.OBWritePaymentDetailsResponse1DataPaymentStatusInnerStatus;
-import uk.org.openbanking.datamodel.payment.OBWritePaymentDetailsResponse1DataPaymentStatusInnerStatusDetail;
-import uk.org.openbanking.datamodel.payment.OBWritePaymentDetailsResponse1DataPaymentStatusInnerStatusDetailStatusReason;
+import uk.org.openbanking.datamodel.v3.common.Meta;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteInternationalScheduled3;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteInternationalScheduledResponse6;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteInternationalScheduledResponse6Data;
+import uk.org.openbanking.datamodel.v3.payment.OBWritePaymentDetailsResponse1;
+import uk.org.openbanking.datamodel.v3.payment.OBWritePaymentDetailsResponse1Data;
+import uk.org.openbanking.datamodel.v3.payment.OBWritePaymentDetailsResponse1DataPaymentStatusInner;
+import uk.org.openbanking.datamodel.v3.payment.OBWritePaymentDetailsResponse1DataPaymentStatusInnerStatus;
+import uk.org.openbanking.datamodel.v3.payment.OBWritePaymentDetailsResponse1DataPaymentStatusInnerStatusDetail;
+import uk.org.openbanking.datamodel.v3.payment.OBWritePaymentDetailsResponse1DataPaymentStatusInnerStatusDetailStatusReason;
 
 @Controller("InternationalScheduledPaymentsApiV3.1.10")
 public class InternationalScheduledPaymentsApiController implements InternationalScheduledPaymentsApi {

--- a/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/v3_1_10/internationalstandingorders/InternationalStandingOrderConsentsApiController.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/v3_1_10/internationalstandingorders/InternationalStandingOrderConsentsApiController.java
@@ -38,8 +38,8 @@ import com.forgerock.sapi.gateway.rcs.consent.store.client.payment.international
 import com.forgerock.sapi.gateway.rcs.consent.store.datamodel.payment.internationalstandingorder.v3_1_10.CreateInternationalStandingOrderConsentRequest;
 import com.forgerock.sapi.gateway.rcs.consent.store.datamodel.payment.internationalstandingorder.v3_1_10.InternationalStandingOrderConsent;
 
-import uk.org.openbanking.datamodel.payment.OBWriteInternationalStandingOrderConsent6;
-import uk.org.openbanking.datamodel.payment.OBWriteInternationalStandingOrderConsentResponse7;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteInternationalStandingOrderConsent6;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteInternationalStandingOrderConsentResponse7;
 
 @Controller("InternationalStandingOrderConsentsApiV3.1.10")
 public class InternationalStandingOrderConsentsApiController implements InternationalStandingOrderConsentsApi {

--- a/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/v3_1_10/internationalstandingorders/InternationalStandingOrdersApiController.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/v3_1_10/internationalstandingorders/InternationalStandingOrdersApiController.java
@@ -68,16 +68,16 @@ import com.forgerock.sapi.gateway.uk.common.shared.api.meta.obie.OBVersion;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
-import uk.org.openbanking.datamodel.common.Meta;
-import uk.org.openbanking.datamodel.payment.OBWriteInternationalStandingOrder4;
-import uk.org.openbanking.datamodel.payment.OBWriteInternationalStandingOrderResponse7;
-import uk.org.openbanking.datamodel.payment.OBWriteInternationalStandingOrderResponse7Data;
-import uk.org.openbanking.datamodel.payment.OBWritePaymentDetailsResponse1;
-import uk.org.openbanking.datamodel.payment.OBWritePaymentDetailsResponse1Data;
-import uk.org.openbanking.datamodel.payment.OBWritePaymentDetailsResponse1DataPaymentStatusInner;
-import uk.org.openbanking.datamodel.payment.OBWritePaymentDetailsResponse1DataPaymentStatusInnerStatus;
-import uk.org.openbanking.datamodel.payment.OBWritePaymentDetailsResponse1DataPaymentStatusInnerStatusDetail;
-import uk.org.openbanking.datamodel.payment.OBWritePaymentDetailsResponse1DataPaymentStatusInnerStatusDetailStatusReason;
+import uk.org.openbanking.datamodel.v3.common.Meta;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteInternationalStandingOrder4;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteInternationalStandingOrderResponse7;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteInternationalStandingOrderResponse7Data;
+import uk.org.openbanking.datamodel.v3.payment.OBWritePaymentDetailsResponse1;
+import uk.org.openbanking.datamodel.v3.payment.OBWritePaymentDetailsResponse1Data;
+import uk.org.openbanking.datamodel.v3.payment.OBWritePaymentDetailsResponse1DataPaymentStatusInner;
+import uk.org.openbanking.datamodel.v3.payment.OBWritePaymentDetailsResponse1DataPaymentStatusInnerStatus;
+import uk.org.openbanking.datamodel.v3.payment.OBWritePaymentDetailsResponse1DataPaymentStatusInnerStatusDetail;
+import uk.org.openbanking.datamodel.v3.payment.OBWritePaymentDetailsResponse1DataPaymentStatusInnerStatusDetailStatusReason;
 
 @Controller("InternationalStandingOrdersApiV3.1.10")
 public class InternationalStandingOrdersApiController implements InternationalStandingOrdersApi {

--- a/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/v3_1_10/vrp/DomesticVrpConsentsApiController.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/v3_1_10/vrp/DomesticVrpConsentsApiController.java
@@ -32,7 +32,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 
-import uk.org.openbanking.datamodel.vrp.*;
+import uk.org.openbanking.datamodel.v3.vrp.*;
 
 import jakarta.servlet.http.HttpServletRequest;
 import java.util.UUID;

--- a/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/v3_1_10/vrp/DomesticVrpsApiController.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/v3_1_10/vrp/DomesticVrpsApiController.java
@@ -55,21 +55,21 @@ import com.forgerock.sapi.gateway.rs.resource.store.repo.mongo.payments.Domestic
 
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.extern.slf4j.Slf4j;
-import uk.org.openbanking.datamodel.common.Meta;
-import uk.org.openbanking.datamodel.common.OBActiveOrHistoricCurrencyAndAmount;
-import uk.org.openbanking.datamodel.common.OBChargeBearerType1Code;
-import uk.org.openbanking.datamodel.vrp.OBDomesticVRPDetails;
-import uk.org.openbanking.datamodel.vrp.OBDomesticVRPDetailsData;
-import uk.org.openbanking.datamodel.vrp.OBDomesticVRPDetailsDataPaymentStatusInner;
-import uk.org.openbanking.datamodel.vrp.OBDomesticVRPDetailsDataPaymentStatusInnerStatus;
-import uk.org.openbanking.datamodel.vrp.OBDomesticVRPDetailsDataPaymentStatusInnerStatusDetail;
-import uk.org.openbanking.datamodel.vrp.OBDomesticVRPDetailsDataPaymentStatusInnerStatusDetailStatusReason;
-import uk.org.openbanking.datamodel.vrp.OBDomesticVRPRequest;
-import uk.org.openbanking.datamodel.vrp.OBDomesticVRPResponse;
-import uk.org.openbanking.datamodel.vrp.OBDomesticVRPResponseData;
-import uk.org.openbanking.datamodel.vrp.OBDomesticVRPResponseDataChargesInner;
-import uk.org.openbanking.datamodel.vrp.OBDomesticVRPResponseDataStatus;
-import uk.org.openbanking.datamodel.vrp.OBExternalPaymentChargeType1Code;
+import uk.org.openbanking.datamodel.v3.common.Meta;
+import uk.org.openbanking.datamodel.v3.common.OBActiveOrHistoricCurrencyAndAmount;
+import uk.org.openbanking.datamodel.v3.common.OBChargeBearerType1Code;
+import uk.org.openbanking.datamodel.v3.vrp.OBDomesticVRPDetails;
+import uk.org.openbanking.datamodel.v3.vrp.OBDomesticVRPDetailsData;
+import uk.org.openbanking.datamodel.v3.vrp.OBDomesticVRPDetailsDataPaymentStatusInner;
+import uk.org.openbanking.datamodel.v3.vrp.OBDomesticVRPDetailsDataPaymentStatusInnerStatus;
+import uk.org.openbanking.datamodel.v3.vrp.OBDomesticVRPDetailsDataPaymentStatusInnerStatusDetail;
+import uk.org.openbanking.datamodel.v3.vrp.OBDomesticVRPDetailsDataPaymentStatusInnerStatusDetailStatusReason;
+import uk.org.openbanking.datamodel.v3.vrp.OBDomesticVRPRequest;
+import uk.org.openbanking.datamodel.v3.vrp.OBDomesticVRPResponse;
+import uk.org.openbanking.datamodel.v3.vrp.OBDomesticVRPResponseData;
+import uk.org.openbanking.datamodel.v3.vrp.OBDomesticVRPResponseDataChargesInner;
+import uk.org.openbanking.datamodel.v3.vrp.OBDomesticVRPResponseDataStatus;
+import uk.org.openbanking.datamodel.v3.vrp.OBExternalPaymentChargeType1Code;
 
 @Controller("DomesticVrpsApiV3.1.10")
 @Slf4j

--- a/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/common/payment/file/processor/json/schema/OBDomestic2.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/common/payment/file/processor/json/schema/OBDomestic2.java
@@ -26,9 +26,9 @@ import io.swagger.annotations.ApiModelProperty;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
-import uk.org.openbanking.datamodel.common.OBActiveOrHistoricCurrencyAndAmount;
-import uk.org.openbanking.datamodel.common.OBPostalAddress6;
-import uk.org.openbanking.datamodel.common.OBSupplementaryData1;
+import uk.org.openbanking.datamodel.v3.common.OBActiveOrHistoricCurrencyAndAmount;
+import uk.org.openbanking.datamodel.v3.common.OBPostalAddress6;
+import uk.org.openbanking.datamodel.v3.common.OBSupplementaryData1;
 
 /**
  * The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds from the debtor account to a creditor for a single domestic payment.

--- a/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/common/payment/file/processor/xml/OBIEPain001FileProcessor.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/common/payment/file/processor/xml/OBIEPain001FileProcessor.java
@@ -40,7 +40,7 @@ import com.forgerock.sapi.gateway.ob.uk.rs.server.common.payment.file.jaxb.pain0
 import com.forgerock.sapi.gateway.ob.uk.rs.server.common.payment.file.jaxb.pain001.StructuredRemittanceInformation13;
 import com.forgerock.sapi.gateway.ob.uk.rs.server.common.payment.file.processor.BasePaymentFileProcessor;
 
-import uk.org.openbanking.datamodel.common.OBActiveOrHistoricCurrencyAndAmount;
+import uk.org.openbanking.datamodel.v3.common.OBActiveOrHistoricCurrencyAndAmount;
 
 @Component
 public class OBIEPain001FileProcessor extends BasePaymentFileProcessor {

--- a/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/common/util/AccountDataInternalIdFilter.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/common/util/AccountDataInternalIdFilter.java
@@ -18,7 +18,7 @@ package com.forgerock.sapi.gateway.ob.uk.rs.server.common.util;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
-import uk.org.openbanking.datamodel.account.*;
+import uk.org.openbanking.datamodel.v3.account.*;
 
 import java.util.Objects;
 import java.util.function.Consumer;

--- a/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/common/util/PaginationUtil.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/common/util/PaginationUtil.java
@@ -16,8 +16,8 @@
 package com.forgerock.sapi.gateway.ob.uk.rs.server.common.util;
 
 import org.springframework.web.util.UriComponentsBuilder;
-import uk.org.openbanking.datamodel.common.Links;
-import uk.org.openbanking.datamodel.common.Meta;
+import uk.org.openbanking.datamodel.v3.common.Links;
+import uk.org.openbanking.datamodel.v3.common.Meta;
 
 import java.net.URI;
 

--- a/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/common/util/PaymentsUtils.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/common/util/PaymentsUtils.java
@@ -17,8 +17,8 @@ package com.forgerock.sapi.gateway.ob.uk.rs.server.common.util;
 
 import org.joda.time.DateTimeZone;
 
-import uk.org.openbanking.datamodel.common.OBReadRefundAccount;
-import uk.org.openbanking.datamodel.payment.*;
+import uk.org.openbanking.datamodel.v3.common.OBReadRefundAccount;
+import uk.org.openbanking.datamodel.v3.payment.*;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/common/util/link/LinksHelper.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/common/util/link/LinksHelper.java
@@ -16,7 +16,7 @@
 package com.forgerock.sapi.gateway.ob.uk.rs.server.common.util.link;
 
 import org.springframework.hateoas.Link;
-import uk.org.openbanking.datamodel.common.Links;
+import uk.org.openbanking.datamodel.v3.common.Links;
 
 import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.linkTo;
 

--- a/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/configuration/validation/DefaultOBValidationModule.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/configuration/validation/DefaultOBValidationModule.java
@@ -62,16 +62,16 @@ import com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.payment.consent.OBWri
 import com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.payment.consent.OBWriteInternationalScheduledConsent5Validator;
 import com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.payment.consent.OBWriteInternationalStandingOrderConsent6Validator;
 
-import uk.org.openbanking.datamodel.common.OBRisk1;
-import uk.org.openbanking.datamodel.payment.OBWriteDomestic2DataInitiationInstructedAmount;
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticConsent4;
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticScheduledConsent4;
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticStandingOrderConsent5;
-import uk.org.openbanking.datamodel.payment.OBWriteFileConsent3;
-import uk.org.openbanking.datamodel.payment.OBWriteInternationalConsent5;
-import uk.org.openbanking.datamodel.payment.OBWriteInternationalScheduledConsent5;
-import uk.org.openbanking.datamodel.payment.OBWriteInternationalStandingOrderConsent6;
-import uk.org.openbanking.datamodel.vrp.OBDomesticVRPConsentRequest;
+import uk.org.openbanking.datamodel.v3.common.OBRisk1;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteDomestic2DataInitiationInstructedAmount;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteDomesticConsent4;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteDomesticScheduledConsent4;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteDomesticStandingOrderConsent5;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteFileConsent3;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteInternationalConsent5;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteInternationalScheduledConsent5;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteInternationalStandingOrderConsent6;
+import uk.org.openbanking.datamodel.v3.vrp.OBDomesticVRPConsentRequest;
 
 /**
  * Spring Boot configuration for the Open Banking validation module with the default set of rules.

--- a/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/exceptions/GlobalExceptionHandler.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/exceptions/GlobalExceptionHandler.java
@@ -19,7 +19,7 @@ import static com.forgerock.sapi.gateway.ob.uk.common.error.ErrorCode.FR_OBRI_ID
 import static com.forgerock.sapi.gateway.ob.uk.common.error.ErrorCode.OBRI_CONSENT_NOT_FOUND;
 import static com.forgerock.sapi.gateway.ob.uk.common.error.ErrorCode.OBRI_PERMISSION_INVALID;
 import static com.forgerock.sapi.gateway.ob.uk.common.error.ErrorCode.OBRI_SERVER_INTERNAL_ERROR;
-import static uk.org.openbanking.datamodel.error.OBStandardErrorCodes1.UK_OBIE_RESOURCE_INVALID_CONSENT_STATUS;
+import static uk.org.openbanking.datamodel.v3.error.OBStandardErrorCodes1.UK_OBIE_RESOURCE_INVALID_CONSENT_STATUS;
 
 import com.forgerock.sapi.gateway.ob.uk.common.error.OBErrorException;
 import com.forgerock.sapi.gateway.ob.uk.common.error.OBErrorResponseException;
@@ -49,8 +49,8 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.context.request.WebRequest;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
-import uk.org.openbanking.datamodel.error.OBError1;
-import uk.org.openbanking.datamodel.error.OBErrorResponse1;
+import uk.org.openbanking.datamodel.v3.error.OBError1;
+import uk.org.openbanking.datamodel.v3.error.OBErrorResponse1;
 
 import java.util.ArrayList;
 import java.util.Collections;

--- a/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/service/account/consent/DefaultAccountResourceAccessService.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/service/account/consent/DefaultAccountResourceAccessService.java
@@ -22,7 +22,7 @@ import com.forgerock.sapi.gateway.ob.uk.common.error.OBRIErrorType;
 import com.forgerock.sapi.gateway.rcs.consent.store.client.account.v3_1_10.AccountAccessConsentStoreClient;
 import com.forgerock.sapi.gateway.rcs.consent.store.datamodel.account.v3_1_10.AccountAccessConsent;
 
-import uk.org.openbanking.datamodel.common.OBExternalRequestStatus1Code;
+import uk.org.openbanking.datamodel.v3.common.OBExternalRequestStatus1Code;
 
 @Service
 public class DefaultAccountResourceAccessService implements AccountResourceAccessService {

--- a/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/service/currency/DefaultExchangeRateService.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/service/currency/DefaultExchangeRateService.java
@@ -26,7 +26,7 @@ import com.forgerock.sapi.gateway.ob.uk.common.datamodel.common.FRAmount;
 import com.forgerock.sapi.gateway.ob.uk.common.datamodel.common.FRExchangeRateInformation;
 import com.forgerock.sapi.gateway.ob.uk.common.datamodel.common.FRExchangeRateInformation.FRRateType;
 
-import uk.org.openbanking.datamodel.payment.OBWriteInternational3DataInitiationExchangeRateInformation;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteInternational3DataInitiationExchangeRateInformation;
 
 /**
  * Default implementation of the ExchangeRateService.

--- a/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/service/currency/ExchangeRateService.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/service/currency/ExchangeRateService.java
@@ -18,7 +18,7 @@ package com.forgerock.sapi.gateway.ob.uk.rs.server.service.currency;
 import com.forgerock.sapi.gateway.ob.uk.common.datamodel.common.FRAmount;
 import com.forgerock.sapi.gateway.ob.uk.common.datamodel.common.FRExchangeRateInformation;
 
-import uk.org.openbanking.datamodel.payment.OBWriteInternational3DataInitiationExchangeRateInformation;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteInternational3DataInitiationExchangeRateInformation;
 
 /**
  * Calculates Exchange Rates for Consent Responses

--- a/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/service/event/EventPollingService.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/service/event/EventPollingService.java
@@ -36,7 +36,7 @@ import com.forgerock.sapi.gateway.rs.resource.store.repo.mongo.events.FREventMes
 import com.google.common.base.Preconditions;
 
 import lombok.extern.slf4j.Slf4j;
-import uk.org.openbanking.datamodel.event.OBEventNotification1;
+import uk.org.openbanking.datamodel.v3.event.OBEventNotification1;
 
 /*
  * Intended to hold the business logic of polling and acknowledge the events separately to the persistence layer (Mongo

--- a/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/validator/OBRisk1Validator.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/validator/OBRisk1Validator.java
@@ -20,7 +20,7 @@ import com.forgerock.sapi.gateway.ob.uk.common.error.OBRIErrorType;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
-import uk.org.openbanking.datamodel.common.OBRisk1;
+import uk.org.openbanking.datamodel.v3.common.OBRisk1;
 
 /**
  * Provides validation for OBRisk1 objects passed to payment interfaces.

--- a/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/validator/PaymentSubmissionValidator.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/validator/PaymentSubmissionValidator.java
@@ -20,7 +20,7 @@ import com.forgerock.sapi.gateway.ob.uk.common.error.OBErrorResponseException;
 import com.forgerock.sapi.gateway.ob.uk.common.error.OBRIErrorResponseCategory;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
-import uk.org.openbanking.datamodel.common.OBRisk1;
+import uk.org.openbanking.datamodel.v3.common.OBRisk1;
 
 /**
  * Performs validation that is common across the Payments API.

--- a/secure-api-gateway-ob-uk-rs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/discovery/ControllerEndpointBlacklistHandlerTest.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/discovery/ControllerEndpointBlacklistHandlerTest.java
@@ -31,7 +31,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.TestPropertySource;
-import uk.org.openbanking.datamodel.payment.*;
+import uk.org.openbanking.datamodel.v3.payment.*;
 
 
 import static com.forgerock.sapi.gateway.uk.common.shared.api.meta.obie.OBVersion.v3_1_5;

--- a/secure-api-gateway-ob-uk-rs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/discovery/DiscoveryApiServiceTest.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/discovery/DiscoveryApiServiceTest.java
@@ -26,8 +26,8 @@ import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.web.context.request.RequestContextHolder;
 import org.springframework.web.context.request.ServletRequestAttributes;
 
-import uk.org.openbanking.datamodel.discovery.GenericOBDiscoveryAPILinks;
-import uk.org.openbanking.datamodel.discovery.OBDiscoveryAPI;
+import uk.org.openbanking.datamodel.v3.discovery.GenericOBDiscoveryAPILinks;
+import uk.org.openbanking.datamodel.v3.discovery.OBDiscoveryAPI;
 
 import java.util.HashMap;
 import java.util.Map;

--- a/secure-api-gateway-ob-uk-rs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/discovery/DiscoveryControllerTest.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/discovery/DiscoveryControllerTest.java
@@ -29,7 +29,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.TestPropertySource;
-import uk.org.openbanking.datamodel.discovery.*;
+import uk.org.openbanking.datamodel.v3.discovery.*;
 
 import java.util.ArrayList;
 import java.util.Collections;

--- a/secure-api-gateway-ob-uk-rs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/account/factory/OBReadConsentResponseFactoryTest.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/account/factory/OBReadConsentResponseFactoryTest.java
@@ -27,13 +27,13 @@ import com.forgerock.sapi.gateway.ob.uk.common.datamodel.converter.account.FRRea
 import com.forgerock.sapi.gateway.ob.uk.rs.obie.api.account.v3_1_10.accounts.AccountAccessConsentsApi;
 import com.forgerock.sapi.gateway.rcs.consent.store.datamodel.account.v3_1_10.AccountAccessConsent;
 
-import uk.org.openbanking.datamodel.account.OBReadConsent1;
-import uk.org.openbanking.datamodel.account.OBReadConsent1Data;
-import uk.org.openbanking.datamodel.account.OBReadConsentResponse1;
-import uk.org.openbanking.datamodel.account.OBReadConsentResponse1Data;
-import uk.org.openbanking.datamodel.account.OBRisk2;
-import uk.org.openbanking.datamodel.common.OBExternalPermissions1Code;
-import uk.org.openbanking.datamodel.common.OBExternalRequestStatus1Code;
+import uk.org.openbanking.datamodel.v3.account.OBReadConsent1;
+import uk.org.openbanking.datamodel.v3.account.OBReadConsent1Data;
+import uk.org.openbanking.datamodel.v3.account.OBReadConsentResponse1;
+import uk.org.openbanking.datamodel.v3.account.OBReadConsentResponse1Data;
+import uk.org.openbanking.datamodel.v3.account.OBRisk2;
+import uk.org.openbanking.datamodel.v3.common.OBExternalPermissions1Code;
+import uk.org.openbanking.datamodel.v3.common.OBExternalRequestStatus1Code;
 
 class OBReadConsentResponseFactoryTest {
 

--- a/secure-api-gateway-ob-uk-rs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/account/v3_1_10/accounts/AccountAccessConsentsApiControllerTest.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/account/v3_1_10/accounts/AccountAccessConsentsApiControllerTest.java
@@ -51,15 +51,15 @@ import com.forgerock.sapi.gateway.rcs.consent.store.datamodel.account.v3_1_10.Ac
 import com.forgerock.sapi.gateway.rcs.consent.store.datamodel.account.v3_1_10.CreateAccountAccessConsentRequest;
 import com.forgerock.sapi.gateway.uk.common.shared.api.meta.share.IntentType;
 
-import uk.org.openbanking.datamodel.account.OBReadConsent1;
-import uk.org.openbanking.datamodel.account.OBReadConsent1Data;
-import uk.org.openbanking.datamodel.account.OBReadConsentResponse1;
-import uk.org.openbanking.datamodel.account.OBRisk2;
-import uk.org.openbanking.datamodel.common.OBExternalPermissions1Code;
-import uk.org.openbanking.datamodel.common.OBExternalRequestStatus1Code;
-import uk.org.openbanking.datamodel.error.OBError1;
-import uk.org.openbanking.datamodel.error.OBErrorResponse1;
-import uk.org.openbanking.datamodel.error.OBStandardErrorCodes1;
+import uk.org.openbanking.datamodel.v3.account.OBReadConsent1;
+import uk.org.openbanking.datamodel.v3.account.OBReadConsent1Data;
+import uk.org.openbanking.datamodel.v3.account.OBReadConsentResponse1;
+import uk.org.openbanking.datamodel.v3.account.OBRisk2;
+import uk.org.openbanking.datamodel.v3.common.OBExternalPermissions1Code;
+import uk.org.openbanking.datamodel.v3.common.OBExternalRequestStatus1Code;
+import uk.org.openbanking.datamodel.v3.error.OBError1;
+import uk.org.openbanking.datamodel.v3.error.OBErrorResponse1;
+import uk.org.openbanking.datamodel.v3.error.OBStandardErrorCodes1;
 
 @SpringBootTest(webEnvironment = RANDOM_PORT)
 @ActiveProfiles("test")

--- a/secure-api-gateway-ob-uk-rs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/account/v3_1_10/accounts/AccountsApiControllerTest.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/account/v3_1_10/accounts/AccountsApiControllerTest.java
@@ -35,8 +35,8 @@ import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.ActiveProfiles;
-import uk.org.openbanking.datamodel.account.OBAccount6;
-import uk.org.openbanking.datamodel.account.OBReadAccount6;
+import uk.org.openbanking.datamodel.v3.account.OBAccount6;
+import uk.org.openbanking.datamodel.v3.account.OBReadAccount6;
 
 import java.util.List;
 

--- a/secure-api-gateway-ob-uk-rs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/account/v3_1_10/balances/BalancesApiControllerTest.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/account/v3_1_10/balances/BalancesApiControllerTest.java
@@ -46,7 +46,7 @@ import com.forgerock.sapi.gateway.ob.uk.rs.server.service.account.consent.Accoun
 import com.forgerock.sapi.gateway.ob.uk.rs.server.testsupport.api.HttpHeadersTestDataFactory;
 import com.forgerock.sapi.gateway.rcs.consent.store.datamodel.account.v3_1_10.AccountAccessConsent;
 
-import uk.org.openbanking.datamodel.account.OBReadBalance1;
+import uk.org.openbanking.datamodel.v3.account.OBReadBalance1;
 
 /**
  * Spring Boot Test for {@link BalancesApiController}.

--- a/secure-api-gateway-ob-uk-rs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/account/v3_1_10/beneficiaries/BeneficiariesApiControllerTest.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/account/v3_1_10/beneficiaries/BeneficiariesApiControllerTest.java
@@ -46,7 +46,7 @@ import com.forgerock.sapi.gateway.rs.resource.store.repo.mongo.accounts.benefici
 import com.forgerock.sapi.gateway.ob.uk.rs.server.service.account.consent.AccountResourceAccessService;
 import com.forgerock.sapi.gateway.rcs.consent.store.datamodel.account.v3_1_10.AccountAccessConsent;
 
-import uk.org.openbanking.datamodel.account.OBReadBeneficiary5;
+import uk.org.openbanking.datamodel.v3.account.OBReadBeneficiary5;
 
 /**
  * Spring Boot Test for {@link BeneficiariesApiController}.

--- a/secure-api-gateway-ob-uk-rs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/account/v3_1_10/directdebits/DirectDebitsApiControllerTest.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/account/v3_1_10/directdebits/DirectDebitsApiControllerTest.java
@@ -46,7 +46,7 @@ import com.forgerock.sapi.gateway.rs.resource.store.repo.mongo.accounts.directde
 import com.forgerock.sapi.gateway.ob.uk.rs.server.service.account.consent.AccountResourceAccessService;
 import com.forgerock.sapi.gateway.rcs.consent.store.datamodel.account.v3_1_10.AccountAccessConsent;
 
-import uk.org.openbanking.datamodel.account.OBReadDirectDebit2;
+import uk.org.openbanking.datamodel.v3.account.OBReadDirectDebit2;
 
 /**
  * Spring Boot Test for {@link DirectDebitsApiController}.

--- a/secure-api-gateway-ob-uk-rs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/account/v3_1_10/offers/OffersApiControllerTest.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/account/v3_1_10/offers/OffersApiControllerTest.java
@@ -46,7 +46,7 @@ import com.forgerock.sapi.gateway.rs.resource.store.repo.entity.account.FROffer;
 import com.forgerock.sapi.gateway.rs.resource.store.repo.mongo.accounts.accounts.FRAccountRepository;
 import com.forgerock.sapi.gateway.rs.resource.store.repo.mongo.accounts.offers.FROfferRepository;
 
-import uk.org.openbanking.datamodel.account.OBReadOffer1;
+import uk.org.openbanking.datamodel.v3.account.OBReadOffer1;
 
 /**
  * Spring Boot Test for {@link OffersApiController}.

--- a/secure-api-gateway-ob-uk-rs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/account/v3_1_10/party/PartyApiControllerTest.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/account/v3_1_10/party/PartyApiControllerTest.java
@@ -46,7 +46,7 @@ import com.forgerock.sapi.gateway.rs.resource.store.repo.entity.account.FRParty;
 import com.forgerock.sapi.gateway.rs.resource.store.repo.mongo.accounts.accounts.FRAccountRepository;
 import com.forgerock.sapi.gateway.rs.resource.store.repo.mongo.accounts.party.FRPartyRepository;
 
-import uk.org.openbanking.datamodel.account.OBReadParty2;
+import uk.org.openbanking.datamodel.v3.account.OBReadParty2;
 
 /**
  * Spring Boot Test for {@link PartyApiController}.

--- a/secure-api-gateway-ob-uk-rs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/account/v3_1_10/products/ProductsApiControllerTest.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/account/v3_1_10/products/ProductsApiControllerTest.java
@@ -36,9 +36,9 @@ import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.ActiveProfiles;
-import uk.org.openbanking.datamodel.account.OBReadProduct2;
-import uk.org.openbanking.datamodel.account.OBReadProduct2DataProductInner;
-import uk.org.openbanking.datamodel.account.OBReadProduct2DataProductInnerProductType;
+import uk.org.openbanking.datamodel.v3.account.OBReadProduct2;
+import uk.org.openbanking.datamodel.v3.account.OBReadProduct2DataProductInner;
+import uk.org.openbanking.datamodel.v3.account.OBReadProduct2DataProductInnerProductType;
 
 import java.util.UUID;
 

--- a/secure-api-gateway-ob-uk-rs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/account/v3_1_10/scheduledpayments/ScheduledPaymentsApiControllerTest.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/account/v3_1_10/scheduledpayments/ScheduledPaymentsApiControllerTest.java
@@ -46,7 +46,7 @@ import com.forgerock.sapi.gateway.rs.resource.store.repo.mongo.accounts.schedule
 import com.forgerock.sapi.gateway.ob.uk.rs.server.service.account.consent.AccountResourceAccessService;
 import com.forgerock.sapi.gateway.rcs.consent.store.datamodel.account.v3_1_10.AccountAccessConsent;
 
-import uk.org.openbanking.datamodel.account.OBReadScheduledPayment3;
+import uk.org.openbanking.datamodel.v3.account.OBReadScheduledPayment3;
 
 /**
  * Spring Boot Test for {@link ScheduledPaymentsApiController}.

--- a/secure-api-gateway-ob-uk-rs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/account/v3_1_10/standingorders/StandingOrdersApiControllerTest.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/account/v3_1_10/standingorders/StandingOrdersApiControllerTest.java
@@ -46,7 +46,7 @@ import com.forgerock.sapi.gateway.rs.resource.store.repo.entity.account.FRStandi
 import com.forgerock.sapi.gateway.rs.resource.store.repo.mongo.accounts.accounts.FRAccountRepository;
 import com.forgerock.sapi.gateway.rs.resource.store.repo.mongo.accounts.standingorders.FRStandingOrderRepository;
 
-import uk.org.openbanking.datamodel.account.OBReadStandingOrder6;
+import uk.org.openbanking.datamodel.v3.account.OBReadStandingOrder6;
 
 /**
  * Spring Boot Test for {@link StandingOrdersApiController}.

--- a/secure-api-gateway-ob-uk-rs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/account/v3_1_10/statements/StatementsApiControllerTest.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/account/v3_1_10/statements/StatementsApiControllerTest.java
@@ -54,8 +54,8 @@ import com.forgerock.sapi.gateway.rs.resource.store.repo.entity.account.FRStatem
 import com.forgerock.sapi.gateway.rs.resource.store.repo.mongo.accounts.accounts.FRAccountRepository;
 import com.forgerock.sapi.gateway.rs.resource.store.repo.mongo.accounts.statements.FRStatementRepository;
 
-import uk.org.openbanking.datamodel.account.OBReadStatement2;
-import uk.org.openbanking.datamodel.error.OBErrorResponse1;
+import uk.org.openbanking.datamodel.v3.account.OBReadStatement2;
+import uk.org.openbanking.datamodel.v3.error.OBErrorResponse1;
 
 /**
  * Spring Boot Test for {@link StatementsApiController}.

--- a/secure-api-gateway-ob-uk-rs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/account/v3_1_10/transactions/TransactionsApiControllerTest.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/account/v3_1_10/transactions/TransactionsApiControllerTest.java
@@ -52,7 +52,7 @@ import com.forgerock.sapi.gateway.rs.resource.store.repo.entity.account.FRTransa
 import com.forgerock.sapi.gateway.rs.resource.store.repo.mongo.accounts.accounts.FRAccountRepository;
 import com.forgerock.sapi.gateway.rs.resource.store.repo.mongo.accounts.transactions.FRTransactionRepository;
 
-import uk.org.openbanking.datamodel.account.OBReadTransaction6;
+import uk.org.openbanking.datamodel.v3.account.OBReadTransaction6;
 
 /**
  * Spring Boot Test for {@link TransactionsApiController}.

--- a/secure-api-gateway-ob-uk-rs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/event/EventTestHelper.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/event/EventTestHelper.java
@@ -21,11 +21,11 @@ import java.util.UUID;
 
 import com.forgerock.sapi.gateway.rs.resource.store.repo.entity.event.FREventMessageEntity;
 
-import uk.org.openbanking.datamodel.event.OBEvent1;
-import uk.org.openbanking.datamodel.event.OBEventLink1;
-import uk.org.openbanking.datamodel.event.OBEventPolling1;
-import uk.org.openbanking.datamodel.event.OBEventResourceUpdate1;
-import uk.org.openbanking.datamodel.event.OBEventSubject1;
+import uk.org.openbanking.datamodel.v3.event.OBEvent1;
+import uk.org.openbanking.datamodel.v3.event.OBEventLink1;
+import uk.org.openbanking.datamodel.v3.event.OBEventPolling1;
+import uk.org.openbanking.datamodel.v3.event.OBEventResourceUpdate1;
+import uk.org.openbanking.datamodel.v3.event.OBEventSubject1;
 
 public class EventTestHelper {
 

--- a/secure-api-gateway-ob-uk-rs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/event/v3_1_10/aggregatedpolling/AggregatedPollingApiControllerTest.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/event/v3_1_10/aggregatedpolling/AggregatedPollingApiControllerTest.java
@@ -43,9 +43,9 @@ import com.forgerock.sapi.gateway.ob.uk.rs.server.testsupport.api.HttpHeadersTes
 import com.forgerock.sapi.gateway.rs.resource.store.repo.entity.event.FREventMessageEntity;
 import com.forgerock.sapi.gateway.rs.resource.store.repo.mongo.events.FREventMessageRepository;
 
-import uk.org.openbanking.datamodel.event.OBEventPolling1;
-import uk.org.openbanking.datamodel.event.OBEventPolling1SetErrsValue;
-import uk.org.openbanking.datamodel.event.OBEventPollingResponse1;
+import uk.org.openbanking.datamodel.v3.event.OBEventPolling1;
+import uk.org.openbanking.datamodel.v3.event.OBEventPolling1SetErrsValue;
+import uk.org.openbanking.datamodel.v3.event.OBEventPollingResponse1;
 
 /**
  * A SpringBoot test for the {@link AggregatedPollingApiController}.

--- a/secure-api-gateway-ob-uk-rs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/event/v3_1_10/eventsubscription/EventSubscriptionsApiControllerTest.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/event/v3_1_10/eventsubscription/EventSubscriptionsApiControllerTest.java
@@ -28,7 +28,7 @@ import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.ActiveProfiles;
-import uk.org.openbanking.datamodel.event.*;
+import uk.org.openbanking.datamodel.v3.event.*;
 
 import java.net.URI;
 import java.util.List;

--- a/secure-api-gateway-ob-uk-rs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/funds/v3_1_10/FundsConfirmationConsentsApiControllerTest.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/funds/v3_1_10/FundsConfirmationConsentsApiControllerTest.java
@@ -54,15 +54,15 @@ import com.forgerock.sapi.gateway.rcs.consent.store.datamodel.funds.v3_1_10.Fund
 import com.forgerock.sapi.gateway.uk.common.shared.api.meta.obie.OBVersion;
 import com.forgerock.sapi.gateway.uk.common.shared.api.meta.share.IntentType;
 
-import uk.org.openbanking.datamodel.common.OBExternalRequestStatus1Code;
-import uk.org.openbanking.datamodel.error.OBError1;
-import uk.org.openbanking.datamodel.error.OBErrorResponse1;
-import uk.org.openbanking.datamodel.error.OBStandardErrorCodes1;
-import uk.org.openbanking.datamodel.fund.OBFundsConfirmationConsent1;
-import uk.org.openbanking.datamodel.fund.OBFundsConfirmationConsent1Data;
-import uk.org.openbanking.datamodel.fund.OBFundsConfirmationConsent1DataDebtorAccount;
-import uk.org.openbanking.datamodel.fund.OBFundsConfirmationConsentResponse1;
-import uk.org.openbanking.datamodel.fund.OBFundsConfirmationConsentResponse1Data.StatusEnum;
+import uk.org.openbanking.datamodel.v3.common.OBExternalRequestStatus1Code;
+import uk.org.openbanking.datamodel.v3.error.OBError1;
+import uk.org.openbanking.datamodel.v3.error.OBErrorResponse1;
+import uk.org.openbanking.datamodel.v3.error.OBStandardErrorCodes1;
+import uk.org.openbanking.datamodel.v3.fund.OBFundsConfirmationConsent1;
+import uk.org.openbanking.datamodel.v3.fund.OBFundsConfirmationConsent1Data;
+import uk.org.openbanking.datamodel.v3.fund.OBFundsConfirmationConsent1DataDebtorAccount;
+import uk.org.openbanking.datamodel.v3.fund.OBFundsConfirmationConsentResponse1;
+import uk.org.openbanking.datamodel.v3.fund.OBFundsConfirmationConsentResponse1Data.StatusEnum;
 
 /**
  * Test for {@link FundsConfirmationConsentsApiController}

--- a/secure-api-gateway-ob-uk-rs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/funds/v3_1_10/FundsConfirmationsApiControllerTest.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/funds/v3_1_10/FundsConfirmationsApiControllerTest.java
@@ -21,9 +21,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
-import static uk.org.openbanking.datamodel.fund.OBFundsConfirmationConsentResponse1Data.StatusEnum.AUTHORISED;
-import static uk.org.openbanking.datamodel.fund.OBFundsConfirmationConsentResponse1Data.StatusEnum.REJECTED;
-import static uk.org.openbanking.datamodel.fund.OBFundsConfirmationConsentResponse1Data.StatusEnum.REVOKED;
+import static uk.org.openbanking.datamodel.v3.fund.OBFundsConfirmationConsentResponse1Data.StatusEnum.AUTHORISED;
+import static uk.org.openbanking.datamodel.v3.fund.OBFundsConfirmationConsentResponse1Data.StatusEnum.REJECTED;
+import static uk.org.openbanking.datamodel.v3.fund.OBFundsConfirmationConsentResponse1Data.StatusEnum.REVOKED;
 
 import java.math.BigDecimal;
 import java.util.List;
@@ -66,17 +66,17 @@ import com.forgerock.sapi.gateway.rs.resource.store.repo.mongo.accounts.accounts
 import com.forgerock.sapi.gateway.rs.resource.store.repo.mongo.funds.FundsConfirmationRepository;
 import com.forgerock.sapi.gateway.uk.common.shared.api.meta.share.IntentType;
 
-import uk.org.openbanking.datamodel.error.OBError1;
-import uk.org.openbanking.datamodel.error.OBErrorResponse1;
-import uk.org.openbanking.datamodel.fund.OBFundsConfirmation1;
-import uk.org.openbanking.datamodel.fund.OBFundsConfirmation1Data;
-import uk.org.openbanking.datamodel.fund.OBFundsConfirmation1DataInstructedAmount;
-import uk.org.openbanking.datamodel.fund.OBFundsConfirmationConsent1;
-import uk.org.openbanking.datamodel.fund.OBFundsConfirmationConsent1Data;
-import uk.org.openbanking.datamodel.fund.OBFundsConfirmationConsent1DataDebtorAccount;
-import uk.org.openbanking.datamodel.fund.OBFundsConfirmationConsentResponse1Data;
-import uk.org.openbanking.datamodel.fund.OBFundsConfirmationResponse1;
-import uk.org.openbanking.datamodel.fund.OBFundsConfirmationResponse1Data;
+import uk.org.openbanking.datamodel.v3.error.OBError1;
+import uk.org.openbanking.datamodel.v3.error.OBErrorResponse1;
+import uk.org.openbanking.datamodel.v3.fund.OBFundsConfirmation1;
+import uk.org.openbanking.datamodel.v3.fund.OBFundsConfirmation1Data;
+import uk.org.openbanking.datamodel.v3.fund.OBFundsConfirmation1DataInstructedAmount;
+import uk.org.openbanking.datamodel.v3.fund.OBFundsConfirmationConsent1;
+import uk.org.openbanking.datamodel.v3.fund.OBFundsConfirmationConsent1Data;
+import uk.org.openbanking.datamodel.v3.fund.OBFundsConfirmationConsent1DataDebtorAccount;
+import uk.org.openbanking.datamodel.v3.fund.OBFundsConfirmationConsentResponse1Data;
+import uk.org.openbanking.datamodel.v3.fund.OBFundsConfirmationResponse1;
+import uk.org.openbanking.datamodel.v3.fund.OBFundsConfirmationResponse1Data;
 
 /**
  * Test for {@link FundsConfirmationsApiController}

--- a/secure-api-gateway-ob-uk-rs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/FundsConfirmationTestHelpers.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/FundsConfirmationTestHelpers.java
@@ -24,8 +24,8 @@ import org.springframework.http.ResponseEntity;
 
 import com.forgerock.sapi.gateway.ob.uk.common.error.OBRIErrorType;
 
-import uk.org.openbanking.datamodel.error.OBError1;
-import uk.org.openbanking.datamodel.error.OBErrorResponse1;
+import uk.org.openbanking.datamodel.v3.error.OBError1;
+import uk.org.openbanking.datamodel.v3.error.OBErrorResponse1;
 
 public class FundsConfirmationTestHelpers {
 

--- a/secure-api-gateway-ob-uk-rs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/factories/OBDomesticVRPConsentResponseFactoryTest.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/factories/OBDomesticVRPConsentResponseFactoryTest.java
@@ -25,10 +25,10 @@ import com.forgerock.sapi.gateway.ob.uk.rs.server.api.obie.payment.v3_1_10.vrp.D
 import com.forgerock.sapi.gateway.ob.uk.rs.server.api.obie.payment.v3_1_10.vrp.DomesticVrpConsentsApiControllerTest;
 import com.forgerock.sapi.gateway.rcs.consent.store.datamodel.payment.vrp.v3_1_10.DomesticVRPConsent;
 
-import uk.org.openbanking.datamodel.vrp.OBDomesticVRPConsentRequest;
-import uk.org.openbanking.datamodel.vrp.OBDomesticVRPConsentResponse;
-import uk.org.openbanking.datamodel.vrp.OBDomesticVRPConsentResponseData;
-import uk.org.openbanking.datamodel.vrp.OBDomesticVRPConsentResponseDataStatus;
+import uk.org.openbanking.datamodel.v3.vrp.OBDomesticVRPConsentRequest;
+import uk.org.openbanking.datamodel.v3.vrp.OBDomesticVRPConsentResponse;
+import uk.org.openbanking.datamodel.v3.vrp.OBDomesticVRPConsentResponseData;
+import uk.org.openbanking.datamodel.v3.vrp.OBDomesticVRPConsentResponseDataStatus;
 import uk.org.openbanking.testsupport.vrp.OBDomesticVrpConsentRequestTestDataFactory;
 
 class OBDomesticVRPConsentResponseFactoryTest {

--- a/secure-api-gateway-ob-uk-rs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/factories/OBWriteDomesticConsentResponse5FactoryTest.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/factories/OBWriteDomesticConsentResponse5FactoryTest.java
@@ -25,11 +25,11 @@ import com.forgerock.sapi.gateway.ob.uk.rs.server.api.obie.payment.v3_1_10.domes
 import com.forgerock.sapi.gateway.ob.uk.rs.server.api.obie.payment.v3_1_10.domesticpayments.DomesticPaymentConsentsApiControllerTest;
 import com.forgerock.sapi.gateway.rcs.consent.store.datamodel.payment.domestic.v3_1_10.DomesticPaymentConsent;
 
-import uk.org.openbanking.datamodel.payment.OBPaymentConsentStatus;
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticConsent4;
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticConsent4Data;
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticConsentResponse5;
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticConsentResponse5Data;
+import uk.org.openbanking.datamodel.v3.payment.OBPaymentConsentStatus;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteDomesticConsent4;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteDomesticConsent4Data;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteDomesticConsentResponse5;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteDomesticConsentResponse5Data;
 import uk.org.openbanking.testsupport.payment.OBWriteDomesticConsentTestDataFactory;
 
 class OBWriteDomesticConsentResponse5FactoryTest {

--- a/secure-api-gateway-ob-uk-rs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/factories/OBWriteDomesticScheduledConsentResponse5FactoryTest.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/factories/OBWriteDomesticScheduledConsentResponse5FactoryTest.java
@@ -25,11 +25,11 @@ import com.forgerock.sapi.gateway.ob.uk.rs.obie.api.payment.v3_1_10.domesticsche
 import com.forgerock.sapi.gateway.ob.uk.rs.server.api.obie.payment.v3_1_10.domesticscheduledpayments.DomesticScheduledPaymentConsentsApiControllerTest;
 import com.forgerock.sapi.gateway.rcs.consent.store.datamodel.payment.domesticscheduled.v3_1_10.DomesticScheduledPaymentConsent;
 
-import uk.org.openbanking.datamodel.payment.OBPaymentConsentStatus;
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticScheduledConsent4;
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticScheduledConsent4Data;
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticScheduledConsentResponse5;
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticScheduledConsentResponse5Data;
+import uk.org.openbanking.datamodel.v3.payment.OBPaymentConsentStatus;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteDomesticScheduledConsent4;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteDomesticScheduledConsent4Data;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteDomesticScheduledConsentResponse5;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteDomesticScheduledConsentResponse5Data;
 import uk.org.openbanking.testsupport.payment.OBWriteDomesticScheduledConsentTestDataFactory;
 
 class OBWriteDomesticScheduledConsentResponse5FactoryTest {

--- a/secure-api-gateway-ob-uk-rs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/factories/OBWriteDomesticStandingOrderConsentResponse6FactoryTest.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/factories/OBWriteDomesticStandingOrderConsentResponse6FactoryTest.java
@@ -25,11 +25,11 @@ import com.forgerock.sapi.gateway.ob.uk.rs.obie.api.payment.v3_1_10.domesticstan
 import com.forgerock.sapi.gateway.ob.uk.rs.server.api.obie.payment.v3_1_10.domesticstandingorders.DomesticStandingOrderConsentsApiControllerTest;
 import com.forgerock.sapi.gateway.rcs.consent.store.datamodel.payment.domesticstandingorder.v3_1_10.DomesticStandingOrderConsent;
 
-import uk.org.openbanking.datamodel.payment.OBPaymentConsentStatus;
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticStandingOrderConsent5;
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticStandingOrderConsent5Data;
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticStandingOrderConsentResponse6;
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticStandingOrderConsentResponse6Data;
+import uk.org.openbanking.datamodel.v3.payment.OBPaymentConsentStatus;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteDomesticStandingOrderConsent5;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteDomesticStandingOrderConsent5Data;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteDomesticStandingOrderConsentResponse6;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteDomesticStandingOrderConsentResponse6Data;
 import uk.org.openbanking.testsupport.payment.OBWriteDomesticStandingOrderConsentTestDataFactory;
 
 class OBWriteDomesticStandingOrderConsentResponse6FactoryTest {

--- a/secure-api-gateway-ob-uk-rs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/factories/OBWriteFileConsentResponse4FactoryTest.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/factories/OBWriteFileConsentResponse4FactoryTest.java
@@ -27,11 +27,11 @@ import com.forgerock.sapi.gateway.ob.uk.rs.obie.api.payment.v3_1_10.domesticstan
 import com.forgerock.sapi.gateway.ob.uk.rs.server.api.obie.payment.v3_1_10.file.FilePaymentConsentsApiControllerTest;
 import com.forgerock.sapi.gateway.rcs.consent.store.datamodel.payment.file.v3_1_10.FilePaymentConsent;
 
-import uk.org.openbanking.datamodel.payment.OBWriteFileConsent3;
-import uk.org.openbanking.datamodel.payment.OBWriteFileConsent3Data;
-import uk.org.openbanking.datamodel.payment.OBWriteFileConsentResponse4;
-import uk.org.openbanking.datamodel.payment.OBWriteFileConsentResponse4Data;
-import uk.org.openbanking.datamodel.payment.OBWriteFileConsentResponse4DataStatus;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteFileConsent3;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteFileConsent3Data;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteFileConsentResponse4;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteFileConsentResponse4Data;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteFileConsentResponse4DataStatus;
 import uk.org.openbanking.testsupport.payment.OBWriteFileConsentTestDataFactory;
 
 class OBWriteFileConsentResponse4FactoryTest {

--- a/secure-api-gateway-ob-uk-rs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/factories/OBWriteInternationalConsentResponse6FactoryTest.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/factories/OBWriteInternationalConsentResponse6FactoryTest.java
@@ -26,11 +26,11 @@ import com.forgerock.sapi.gateway.ob.uk.rs.server.api.obie.payment.v3_1_10.domes
 import com.forgerock.sapi.gateway.ob.uk.rs.server.api.obie.payment.v3_1_10.internationalpayments.InternationalPaymentConsentsApiControllerTest;
 import com.forgerock.sapi.gateway.rcs.consent.store.datamodel.payment.international.v3_1_10.InternationalPaymentConsent;
 
-import uk.org.openbanking.datamodel.payment.OBPaymentConsentStatus;
-import uk.org.openbanking.datamodel.payment.OBWriteInternationalConsent5;
-import uk.org.openbanking.datamodel.payment.OBWriteInternationalConsent5Data;
-import uk.org.openbanking.datamodel.payment.OBWriteInternationalConsentResponse6;
-import uk.org.openbanking.datamodel.payment.OBWriteInternationalConsentResponse6Data;
+import uk.org.openbanking.datamodel.v3.payment.OBPaymentConsentStatus;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteInternationalConsent5;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteInternationalConsent5Data;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteInternationalConsentResponse6;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteInternationalConsentResponse6Data;
 import uk.org.openbanking.testsupport.payment.OBWriteInternationalConsentTestDataFactory;
 
 class OBWriteInternationalConsentResponse6FactoryTest {

--- a/secure-api-gateway-ob-uk-rs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/factories/OBWriteInternationalScheduledConsentResponse6FactoryTest.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/factories/OBWriteInternationalScheduledConsentResponse6FactoryTest.java
@@ -26,11 +26,11 @@ import com.forgerock.sapi.gateway.ob.uk.rs.server.api.obie.payment.v3_1_10.domes
 import com.forgerock.sapi.gateway.ob.uk.rs.server.api.obie.payment.v3_1_10.internationalscheduledpayments.InternationalScheduledPaymentConsentsApiControllerTest;
 import com.forgerock.sapi.gateway.rcs.consent.store.datamodel.payment.internationalscheduled.v3_1_10.InternationalScheduledPaymentConsent;
 
-import uk.org.openbanking.datamodel.payment.OBPaymentConsentStatus;
-import uk.org.openbanking.datamodel.payment.OBWriteInternationalScheduledConsent5;
-import uk.org.openbanking.datamodel.payment.OBWriteInternationalScheduledConsent5Data;
-import uk.org.openbanking.datamodel.payment.OBWriteInternationalScheduledConsentResponse6;
-import uk.org.openbanking.datamodel.payment.OBWriteInternationalScheduledConsentResponse6Data;
+import uk.org.openbanking.datamodel.v3.payment.OBPaymentConsentStatus;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteInternationalScheduledConsent5;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteInternationalScheduledConsent5Data;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteInternationalScheduledConsentResponse6;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteInternationalScheduledConsentResponse6Data;
 import uk.org.openbanking.testsupport.payment.OBWriteInternationalScheduledConsentTestDataFactory;
 
 class OBWriteInternationalScheduledConsentResponse6FactoryTest {

--- a/secure-api-gateway-ob-uk-rs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/factories/OBWriteInternationalStandingOrderConsentResponse7FactoryTest.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/factories/OBWriteInternationalStandingOrderConsentResponse7FactoryTest.java
@@ -25,11 +25,11 @@ import com.forgerock.sapi.gateway.ob.uk.rs.server.api.obie.payment.v3_1_10.inter
 import com.forgerock.sapi.gateway.ob.uk.rs.server.api.obie.payment.v3_1_10.internationalstandingorders.InternationalStandingOrderConsentsApiControllerTest;
 import com.forgerock.sapi.gateway.rcs.consent.store.datamodel.payment.internationalstandingorder.v3_1_10.InternationalStandingOrderConsent;
 
-import uk.org.openbanking.datamodel.payment.OBPaymentConsentStatus;
-import uk.org.openbanking.datamodel.payment.OBWriteInternationalStandingOrderConsent6;
-import uk.org.openbanking.datamodel.payment.OBWriteInternationalStandingOrderConsent6Data;
-import uk.org.openbanking.datamodel.payment.OBWriteInternationalStandingOrderConsentResponse7;
-import uk.org.openbanking.datamodel.payment.OBWriteInternationalStandingOrderConsentResponse7Data;
+import uk.org.openbanking.datamodel.v3.payment.OBPaymentConsentStatus;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteInternationalStandingOrderConsent6;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteInternationalStandingOrderConsent6Data;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteInternationalStandingOrderConsentResponse7;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteInternationalStandingOrderConsentResponse7Data;
 import uk.org.openbanking.testsupport.payment.OBWriteInternationalStandingOrderConsentTestDataFactory;
 
 class OBWriteInternationalStandingOrderConsentResponse7FactoryTest {

--- a/secure-api-gateway-ob-uk-rs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/services/validation/FilePaymentFileContentValidatorTest.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/services/validation/FilePaymentFileContentValidatorTest.java
@@ -35,8 +35,8 @@ import com.forgerock.sapi.gateway.ob.uk.rs.server.util.payment.file.TestPaymentF
 import com.forgerock.sapi.gateway.ob.uk.rs.server.util.payment.file.TestPaymentFileResources.TestPaymentFile;
 import com.forgerock.sapi.gateway.ob.uk.rs.validation.ValidationResult;
 
-import uk.org.openbanking.datamodel.error.OBError1;
-import uk.org.openbanking.datamodel.payment.OBWriteFileConsent3;
+import uk.org.openbanking.datamodel.v3.error.OBError1;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteFileConsent3;
 import uk.org.openbanking.testsupport.payment.OBWriteFileConsentTestDataFactory;
 
 class FilePaymentFileContentValidatorTest {

--- a/secure-api-gateway-ob-uk-rs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/v3_1_10/domesticpayments/DomesticPaymentConsentsApiControllerTest.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/v3_1_10/domesticpayments/DomesticPaymentConsentsApiControllerTest.java
@@ -57,13 +57,13 @@ import com.forgerock.sapi.gateway.rcs.consent.store.datamodel.payment.domestic.v
 import com.forgerock.sapi.gateway.uk.common.shared.api.meta.share.IntentType;
 
 import jakarta.annotation.PostConstruct;
-import uk.org.openbanking.datamodel.error.OBError1;
-import uk.org.openbanking.datamodel.error.OBErrorResponse1;
-import uk.org.openbanking.datamodel.error.OBStandardErrorCodes1;
-import uk.org.openbanking.datamodel.payment.OBPaymentConsentStatus;
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticConsent4;
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticConsentResponse5;
-import uk.org.openbanking.datamodel.payment.OBWriteFundsConfirmationResponse1;
+import uk.org.openbanking.datamodel.v3.error.OBError1;
+import uk.org.openbanking.datamodel.v3.error.OBErrorResponse1;
+import uk.org.openbanking.datamodel.v3.error.OBStandardErrorCodes1;
+import uk.org.openbanking.datamodel.v3.payment.OBPaymentConsentStatus;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteDomesticConsent4;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteDomesticConsentResponse5;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteFundsConfirmationResponse1;
 import uk.org.openbanking.testsupport.payment.OBWriteDomesticConsentTestDataFactory;
 
 @SpringBootTest(webEnvironment = RANDOM_PORT)

--- a/secure-api-gateway-ob-uk-rs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/v3_1_10/domesticpayments/DomesticPaymentsApiControllerTest.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/v3_1_10/domesticpayments/DomesticPaymentsApiControllerTest.java
@@ -67,18 +67,18 @@ import com.forgerock.sapi.gateway.rs.resource.store.repo.entity.account.FRAccoun
 import com.forgerock.sapi.gateway.rs.resource.store.repo.mongo.accounts.accounts.FRAccountRepository;
 import com.forgerock.sapi.gateway.rs.resource.store.repo.mongo.payments.DomesticPaymentSubmissionRepository;
 
-import uk.org.openbanking.datamodel.common.OBReadRefundAccount;
-import uk.org.openbanking.datamodel.error.OBError1;
-import uk.org.openbanking.datamodel.error.OBErrorResponse1;
-import uk.org.openbanking.datamodel.payment.OBPaymentConsentStatus;
-import uk.org.openbanking.datamodel.payment.OBWriteDomestic2;
-import uk.org.openbanking.datamodel.payment.OBWriteDomestic2DataInitiationInstructedAmount;
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticConsent4;
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticResponse5;
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticResponse5Data;
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticResponse5DataRefundAccount;
-import uk.org.openbanking.datamodel.payment.OBWritePaymentDetailsResponse1;
-import uk.org.openbanking.datamodel.payment.OBWritePaymentDetailsResponse1DataPaymentStatusInner;
+import uk.org.openbanking.datamodel.v3.common.OBReadRefundAccount;
+import uk.org.openbanking.datamodel.v3.error.OBError1;
+import uk.org.openbanking.datamodel.v3.error.OBErrorResponse1;
+import uk.org.openbanking.datamodel.v3.payment.OBPaymentConsentStatus;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteDomestic2;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteDomestic2DataInitiationInstructedAmount;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteDomesticConsent4;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteDomesticResponse5;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteDomesticResponse5Data;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteDomesticResponse5DataRefundAccount;
+import uk.org.openbanking.datamodel.v3.payment.OBWritePaymentDetailsResponse1;
+import uk.org.openbanking.datamodel.v3.payment.OBWritePaymentDetailsResponse1DataPaymentStatusInner;
 
 /**
  * A SpringBoot test for the DomesticPaymentsApiController.<br/>

--- a/secure-api-gateway-ob-uk-rs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/v3_1_10/domesticscheduledpayments/DomesticScheduledPaymentConsentsApiControllerTest.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/v3_1_10/domesticscheduledpayments/DomesticScheduledPaymentConsentsApiControllerTest.java
@@ -54,12 +54,12 @@ import com.forgerock.sapi.gateway.rcs.consent.store.datamodel.payment.domesticsc
 import com.forgerock.sapi.gateway.uk.common.shared.api.meta.share.IntentType;
 
 import jakarta.annotation.PostConstruct;
-import uk.org.openbanking.datamodel.error.OBError1;
-import uk.org.openbanking.datamodel.error.OBErrorResponse1;
-import uk.org.openbanking.datamodel.error.OBStandardErrorCodes1;
-import uk.org.openbanking.datamodel.payment.OBPaymentConsentStatus;
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticScheduledConsent4;
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticScheduledConsentResponse5;
+import uk.org.openbanking.datamodel.v3.error.OBError1;
+import uk.org.openbanking.datamodel.v3.error.OBErrorResponse1;
+import uk.org.openbanking.datamodel.v3.error.OBStandardErrorCodes1;
+import uk.org.openbanking.datamodel.v3.payment.OBPaymentConsentStatus;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteDomesticScheduledConsent4;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteDomesticScheduledConsentResponse5;
 import uk.org.openbanking.testsupport.payment.OBWriteDomesticScheduledConsentTestDataFactory;
 
 @SpringBootTest(webEnvironment = RANDOM_PORT)

--- a/secure-api-gateway-ob-uk-rs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/v3_1_10/domesticscheduledpayments/DomesticScheduledPaymentsApiControllerTest.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/v3_1_10/domesticscheduledpayments/DomesticScheduledPaymentsApiControllerTest.java
@@ -61,20 +61,20 @@ import com.forgerock.sapi.gateway.rs.resource.store.repo.entity.account.FRAccoun
 import com.forgerock.sapi.gateway.rs.resource.store.repo.mongo.accounts.accounts.FRAccountRepository;
 import com.forgerock.sapi.gateway.rs.resource.store.repo.mongo.payments.DomesticScheduledPaymentSubmissionRepository;
 
-import uk.org.openbanking.datamodel.common.OBReadRefundAccount;
-import uk.org.openbanking.datamodel.error.OBError1;
-import uk.org.openbanking.datamodel.error.OBErrorResponse1;
-import uk.org.openbanking.datamodel.payment.OBPaymentConsentStatus;
-import uk.org.openbanking.datamodel.payment.OBWriteDomestic2DataInitiationInstructedAmount;
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticResponse5DataRefundAccount;
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticScheduled2;
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticScheduled2Data;
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticScheduledConsent4;
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticScheduledConsent4Data;
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticScheduledResponse5;
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticScheduledResponse5Data;
-import uk.org.openbanking.datamodel.payment.OBWritePaymentDetailsResponse1;
-import uk.org.openbanking.datamodel.payment.OBWritePaymentDetailsResponse1DataPaymentStatusInner;
+import uk.org.openbanking.datamodel.v3.common.OBReadRefundAccount;
+import uk.org.openbanking.datamodel.v3.error.OBError1;
+import uk.org.openbanking.datamodel.v3.error.OBErrorResponse1;
+import uk.org.openbanking.datamodel.v3.payment.OBPaymentConsentStatus;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteDomestic2DataInitiationInstructedAmount;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteDomesticResponse5DataRefundAccount;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteDomesticScheduled2;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteDomesticScheduled2Data;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteDomesticScheduledConsent4;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteDomesticScheduledConsent4Data;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteDomesticScheduledResponse5;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteDomesticScheduledResponse5Data;
+import uk.org.openbanking.datamodel.v3.payment.OBWritePaymentDetailsResponse1;
+import uk.org.openbanking.datamodel.v3.payment.OBWritePaymentDetailsResponse1DataPaymentStatusInner;
 
 /**
  * A SpringBoot test for the {@link DomesticScheduledPaymentsApiController}.<br/>

--- a/secure-api-gateway-ob-uk-rs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/v3_1_10/domesticstandingorders/DomesticStandingOrderConsentsApiControllerTest.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/v3_1_10/domesticstandingorders/DomesticStandingOrderConsentsApiControllerTest.java
@@ -54,13 +54,13 @@ import com.forgerock.sapi.gateway.rcs.consent.store.datamodel.payment.domesticst
 import com.forgerock.sapi.gateway.uk.common.shared.api.meta.share.IntentType;
 
 import jakarta.annotation.PostConstruct;
-import uk.org.openbanking.datamodel.error.OBError1;
-import uk.org.openbanking.datamodel.error.OBErrorResponse1;
-import uk.org.openbanking.datamodel.error.OBStandardErrorCodes1;
-import uk.org.openbanking.datamodel.payment.OBPaymentConsentStatus;
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticStandingOrder3DataInitiation;
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticStandingOrderConsent5;
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticStandingOrderConsentResponse6;
+import uk.org.openbanking.datamodel.v3.error.OBError1;
+import uk.org.openbanking.datamodel.v3.error.OBErrorResponse1;
+import uk.org.openbanking.datamodel.v3.error.OBStandardErrorCodes1;
+import uk.org.openbanking.datamodel.v3.payment.OBPaymentConsentStatus;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteDomesticStandingOrder3DataInitiation;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteDomesticStandingOrderConsent5;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteDomesticStandingOrderConsentResponse6;
 import uk.org.openbanking.testsupport.payment.OBWriteDomesticStandingOrderConsentTestDataFactory;
 
 @SpringBootTest(webEnvironment = RANDOM_PORT)

--- a/secure-api-gateway-ob-uk-rs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/v3_1_10/domesticstandingorders/DomesticStandingOrdersApiControllerTest.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/v3_1_10/domesticstandingorders/DomesticStandingOrdersApiControllerTest.java
@@ -63,22 +63,22 @@ import com.forgerock.sapi.gateway.rs.resource.store.repo.entity.account.FRAccoun
 import com.forgerock.sapi.gateway.rs.resource.store.repo.mongo.accounts.accounts.FRAccountRepository;
 import com.forgerock.sapi.gateway.rs.resource.store.repo.mongo.payments.DomesticStandingOrderPaymentSubmissionRepository;
 
-import uk.org.openbanking.datamodel.common.OBReadRefundAccount;
-import uk.org.openbanking.datamodel.error.OBError1;
-import uk.org.openbanking.datamodel.error.OBErrorResponse1;
-import uk.org.openbanking.datamodel.payment.OBPaymentConsentStatus;
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticResponse5DataRefundAccount;
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticStandingOrder3;
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticStandingOrder3Data;
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticStandingOrder3DataInitiation;
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticStandingOrder3DataInitiationFirstPaymentAmount;
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticStandingOrderConsent5;
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticStandingOrderConsent5Data;
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticStandingOrderConsentResponse6;
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticStandingOrderResponse6;
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticStandingOrderResponse6Data;
-import uk.org.openbanking.datamodel.payment.OBWritePaymentDetailsResponse1;
-import uk.org.openbanking.datamodel.payment.OBWritePaymentDetailsResponse1DataPaymentStatusInner;
+import uk.org.openbanking.datamodel.v3.common.OBReadRefundAccount;
+import uk.org.openbanking.datamodel.v3.error.OBError1;
+import uk.org.openbanking.datamodel.v3.error.OBErrorResponse1;
+import uk.org.openbanking.datamodel.v3.payment.OBPaymentConsentStatus;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteDomesticResponse5DataRefundAccount;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteDomesticStandingOrder3;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteDomesticStandingOrder3Data;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteDomesticStandingOrder3DataInitiation;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteDomesticStandingOrder3DataInitiationFirstPaymentAmount;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteDomesticStandingOrderConsent5;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteDomesticStandingOrderConsent5Data;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteDomesticStandingOrderConsentResponse6;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteDomesticStandingOrderResponse6;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteDomesticStandingOrderResponse6Data;
+import uk.org.openbanking.datamodel.v3.payment.OBWritePaymentDetailsResponse1;
+import uk.org.openbanking.datamodel.v3.payment.OBWritePaymentDetailsResponse1DataPaymentStatusInner;
 
 /**
  * A SpringBoot test for the {@link DomesticStandingOrdersApiController}.<br/>

--- a/secure-api-gateway-ob-uk-rs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/v3_1_10/file/FilePaymentConsentsApiControllerTest.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/v3_1_10/file/FilePaymentConsentsApiControllerTest.java
@@ -63,12 +63,12 @@ import com.forgerock.sapi.gateway.rcs.consent.store.datamodel.payment.file.v3_1_
 import com.forgerock.sapi.gateway.rcs.consent.store.datamodel.payment.file.v3_1_10.FileUploadRequest;
 import com.forgerock.sapi.gateway.uk.common.shared.api.meta.share.IntentType;
 
-import uk.org.openbanking.datamodel.error.OBError1;
-import uk.org.openbanking.datamodel.error.OBErrorResponse1;
-import uk.org.openbanking.datamodel.error.OBStandardErrorCodes1;
-import uk.org.openbanking.datamodel.payment.OBWriteFileConsent3;
-import uk.org.openbanking.datamodel.payment.OBWriteFileConsentResponse4;
-import uk.org.openbanking.datamodel.payment.OBWriteFileConsentResponse4DataStatus;
+import uk.org.openbanking.datamodel.v3.error.OBError1;
+import uk.org.openbanking.datamodel.v3.error.OBErrorResponse1;
+import uk.org.openbanking.datamodel.v3.error.OBStandardErrorCodes1;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteFileConsent3;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteFileConsentResponse4;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteFileConsentResponse4DataStatus;
 import uk.org.openbanking.testsupport.payment.OBWriteFileConsentTestDataFactory;
 
 @SpringBootTest(webEnvironment = RANDOM_PORT)

--- a/secure-api-gateway-ob-uk-rs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/v3_1_10/file/FilePaymentsApiControllerTest.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/v3_1_10/file/FilePaymentsApiControllerTest.java
@@ -51,13 +51,13 @@ import com.forgerock.sapi.gateway.rcs.consent.store.datamodel.payment.file.v3_1_
 import com.forgerock.sapi.gateway.rs.resource.store.repo.mongo.payments.FilePaymentSubmissionRepository;
 import com.forgerock.sapi.gateway.uk.common.shared.api.meta.share.IntentType;
 
-import uk.org.openbanking.datamodel.error.OBErrorResponse1;
-import uk.org.openbanking.datamodel.payment.OBWriteFile2;
-import uk.org.openbanking.datamodel.payment.OBWriteFile2Data;
-import uk.org.openbanking.datamodel.payment.OBWriteFileConsent3;
-import uk.org.openbanking.datamodel.payment.OBWriteFileConsentResponse4DataStatus;
-import uk.org.openbanking.datamodel.payment.OBWriteFileResponse3;
-import uk.org.openbanking.datamodel.payment.OBWriteFileResponse3Data;
+import uk.org.openbanking.datamodel.v3.error.OBErrorResponse1;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteFile2;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteFile2Data;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteFileConsent3;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteFileConsentResponse4DataStatus;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteFileResponse3;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteFileResponse3Data;
 import uk.org.openbanking.testsupport.payment.OBWriteFileConsentTestDataFactory;
 
 /**

--- a/secure-api-gateway-ob-uk-rs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/v3_1_10/internationalpayments/InternationalPaymentConsentsApiControllerTest.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/v3_1_10/internationalpayments/InternationalPaymentConsentsApiControllerTest.java
@@ -59,15 +59,15 @@ import com.forgerock.sapi.gateway.rcs.consent.store.datamodel.payment.internatio
 import com.forgerock.sapi.gateway.uk.common.shared.api.meta.share.IntentType;
 
 import jakarta.annotation.PostConstruct;
-import uk.org.openbanking.datamodel.error.OBError1;
-import uk.org.openbanking.datamodel.error.OBErrorResponse1;
-import uk.org.openbanking.datamodel.error.OBStandardErrorCodes1;
-import uk.org.openbanking.datamodel.payment.OBExchangeRateType;
-import uk.org.openbanking.datamodel.payment.OBPaymentConsentStatus;
-import uk.org.openbanking.datamodel.payment.OBWriteFundsConfirmationResponse1;
-import uk.org.openbanking.datamodel.payment.OBWriteInternational3DataInitiationExchangeRateInformation;
-import uk.org.openbanking.datamodel.payment.OBWriteInternationalConsent5;
-import uk.org.openbanking.datamodel.payment.OBWriteInternationalConsentResponse6;
+import uk.org.openbanking.datamodel.v3.error.OBError1;
+import uk.org.openbanking.datamodel.v3.error.OBErrorResponse1;
+import uk.org.openbanking.datamodel.v3.error.OBStandardErrorCodes1;
+import uk.org.openbanking.datamodel.v3.payment.OBExchangeRateType;
+import uk.org.openbanking.datamodel.v3.payment.OBPaymentConsentStatus;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteFundsConfirmationResponse1;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteInternational3DataInitiationExchangeRateInformation;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteInternationalConsent5;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteInternationalConsentResponse6;
 import uk.org.openbanking.testsupport.payment.OBWriteInternationalConsentTestDataFactory;
 
 @SpringBootTest(webEnvironment = RANDOM_PORT)

--- a/secure-api-gateway-ob-uk-rs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/v3_1_10/internationalpayments/InternationalPaymentsApiControllerTest.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/v3_1_10/internationalpayments/InternationalPaymentsApiControllerTest.java
@@ -61,18 +61,18 @@ import com.forgerock.sapi.gateway.rs.resource.store.repo.entity.account.FRAccoun
 import com.forgerock.sapi.gateway.rs.resource.store.repo.mongo.accounts.accounts.FRAccountRepository;
 import com.forgerock.sapi.gateway.rs.resource.store.repo.mongo.payments.InternationalPaymentSubmissionRepository;
 
-import uk.org.openbanking.datamodel.common.OBReadRefundAccount;
-import uk.org.openbanking.datamodel.error.OBErrorResponse1;
-import uk.org.openbanking.datamodel.payment.OBPaymentConsentStatus;
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticResponse5DataRefundAccount;
-import uk.org.openbanking.datamodel.payment.OBWriteInternational3;
-import uk.org.openbanking.datamodel.payment.OBWriteInternational3Data;
-import uk.org.openbanking.datamodel.payment.OBWriteInternationalConsent5;
-import uk.org.openbanking.datamodel.payment.OBWriteInternationalConsentResponse6;
-import uk.org.openbanking.datamodel.payment.OBWriteInternationalResponse5;
-import uk.org.openbanking.datamodel.payment.OBWriteInternationalResponse5Data;
-import uk.org.openbanking.datamodel.payment.OBWritePaymentDetailsResponse1;
-import uk.org.openbanking.datamodel.payment.OBWritePaymentDetailsResponse1DataPaymentStatusInner;
+import uk.org.openbanking.datamodel.v3.common.OBReadRefundAccount;
+import uk.org.openbanking.datamodel.v3.error.OBErrorResponse1;
+import uk.org.openbanking.datamodel.v3.payment.OBPaymentConsentStatus;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteDomesticResponse5DataRefundAccount;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteInternational3;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteInternational3Data;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteInternationalConsent5;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteInternationalConsentResponse6;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteInternationalResponse5;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteInternationalResponse5Data;
+import uk.org.openbanking.datamodel.v3.payment.OBWritePaymentDetailsResponse1;
+import uk.org.openbanking.datamodel.v3.payment.OBWritePaymentDetailsResponse1DataPaymentStatusInner;
 
 /**
  * A SpringBoot test for the {@link InternationalPaymentsApiController}.<br/>

--- a/secure-api-gateway-ob-uk-rs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/v3_1_10/internationalscheduledpayments/InternationalScheduledPaymentApiControllerTest.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/v3_1_10/internationalscheduledpayments/InternationalScheduledPaymentApiControllerTest.java
@@ -62,20 +62,20 @@ import com.forgerock.sapi.gateway.rs.resource.store.repo.entity.account.FRAccoun
 import com.forgerock.sapi.gateway.rs.resource.store.repo.mongo.accounts.accounts.FRAccountRepository;
 import com.forgerock.sapi.gateway.rs.resource.store.repo.mongo.payments.InternationalScheduledPaymentSubmissionRepository;
 
-import uk.org.openbanking.datamodel.common.OBReadRefundAccount;
-import uk.org.openbanking.datamodel.error.OBError1;
-import uk.org.openbanking.datamodel.error.OBErrorResponse1;
-import uk.org.openbanking.datamodel.payment.OBPaymentConsentStatus;
-import uk.org.openbanking.datamodel.payment.OBWriteDomestic2DataInitiationInstructedAmount;
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticResponse5DataRefundAccount;
-import uk.org.openbanking.datamodel.payment.OBWriteInternationalScheduled3;
-import uk.org.openbanking.datamodel.payment.OBWriteInternationalScheduled3Data;
-import uk.org.openbanking.datamodel.payment.OBWriteInternationalScheduledConsent5;
-import uk.org.openbanking.datamodel.payment.OBWriteInternationalScheduledConsent5Data;
-import uk.org.openbanking.datamodel.payment.OBWriteInternationalScheduledResponse6;
-import uk.org.openbanking.datamodel.payment.OBWriteInternationalScheduledResponse6Data;
-import uk.org.openbanking.datamodel.payment.OBWritePaymentDetailsResponse1;
-import uk.org.openbanking.datamodel.payment.OBWritePaymentDetailsResponse1DataPaymentStatusInner;
+import uk.org.openbanking.datamodel.v3.common.OBReadRefundAccount;
+import uk.org.openbanking.datamodel.v3.error.OBError1;
+import uk.org.openbanking.datamodel.v3.error.OBErrorResponse1;
+import uk.org.openbanking.datamodel.v3.payment.OBPaymentConsentStatus;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteDomestic2DataInitiationInstructedAmount;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteDomesticResponse5DataRefundAccount;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteInternationalScheduled3;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteInternationalScheduled3Data;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteInternationalScheduledConsent5;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteInternationalScheduledConsent5Data;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteInternationalScheduledResponse6;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteInternationalScheduledResponse6Data;
+import uk.org.openbanking.datamodel.v3.payment.OBWritePaymentDetailsResponse1;
+import uk.org.openbanking.datamodel.v3.payment.OBWritePaymentDetailsResponse1DataPaymentStatusInner;
 
 /**
  * A SpringBoot test for the {@link InternationalScheduledPaymentsApiController}.<br/>

--- a/secure-api-gateway-ob-uk-rs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/v3_1_10/internationalscheduledpayments/InternationalScheduledPaymentConsentsApiControllerTest.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/v3_1_10/internationalscheduledpayments/InternationalScheduledPaymentConsentsApiControllerTest.java
@@ -59,15 +59,15 @@ import com.forgerock.sapi.gateway.rcs.consent.store.datamodel.payment.internatio
 import com.forgerock.sapi.gateway.uk.common.shared.api.meta.share.IntentType;
 
 import jakarta.annotation.PostConstruct;
-import uk.org.openbanking.datamodel.error.OBError1;
-import uk.org.openbanking.datamodel.error.OBErrorResponse1;
-import uk.org.openbanking.datamodel.error.OBStandardErrorCodes1;
-import uk.org.openbanking.datamodel.payment.OBExchangeRateType;
-import uk.org.openbanking.datamodel.payment.OBPaymentConsentStatus;
-import uk.org.openbanking.datamodel.payment.OBWriteFundsConfirmationResponse1;
-import uk.org.openbanking.datamodel.payment.OBWriteInternational3DataInitiationExchangeRateInformation;
-import uk.org.openbanking.datamodel.payment.OBWriteInternationalScheduledConsent5;
-import uk.org.openbanking.datamodel.payment.OBWriteInternationalScheduledConsentResponse6;
+import uk.org.openbanking.datamodel.v3.error.OBError1;
+import uk.org.openbanking.datamodel.v3.error.OBErrorResponse1;
+import uk.org.openbanking.datamodel.v3.error.OBStandardErrorCodes1;
+import uk.org.openbanking.datamodel.v3.payment.OBExchangeRateType;
+import uk.org.openbanking.datamodel.v3.payment.OBPaymentConsentStatus;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteFundsConfirmationResponse1;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteInternational3DataInitiationExchangeRateInformation;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteInternationalScheduledConsent5;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteInternationalScheduledConsentResponse6;
 import uk.org.openbanking.testsupport.payment.OBWriteInternationalScheduledConsentTestDataFactory;
 
 @SpringBootTest(webEnvironment = RANDOM_PORT)

--- a/secure-api-gateway-ob-uk-rs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/v3_1_10/internationalstandingorders/InternationalStandingOrderConsentsApiControllerTest.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/v3_1_10/internationalstandingorders/InternationalStandingOrderConsentsApiControllerTest.java
@@ -53,13 +53,13 @@ import com.forgerock.sapi.gateway.rcs.consent.store.datamodel.payment.internatio
 import com.forgerock.sapi.gateway.uk.common.shared.api.meta.share.IntentType;
 
 import jakarta.annotation.PostConstruct;
-import uk.org.openbanking.datamodel.error.OBError1;
-import uk.org.openbanking.datamodel.error.OBErrorResponse1;
-import uk.org.openbanking.datamodel.error.OBStandardErrorCodes1;
-import uk.org.openbanking.datamodel.payment.OBPaymentConsentStatus;
-import uk.org.openbanking.datamodel.payment.OBWriteInternationalScheduledConsent5;
-import uk.org.openbanking.datamodel.payment.OBWriteInternationalStandingOrderConsent6;
-import uk.org.openbanking.datamodel.payment.OBWriteInternationalStandingOrderConsentResponse7;
+import uk.org.openbanking.datamodel.v3.error.OBError1;
+import uk.org.openbanking.datamodel.v3.error.OBErrorResponse1;
+import uk.org.openbanking.datamodel.v3.error.OBStandardErrorCodes1;
+import uk.org.openbanking.datamodel.v3.payment.OBPaymentConsentStatus;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteInternationalScheduledConsent5;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteInternationalStandingOrderConsent6;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteInternationalStandingOrderConsentResponse7;
 import uk.org.openbanking.testsupport.payment.OBWriteInternationalStandingOrderConsentTestDataFactory;
 
 @SpringBootTest(webEnvironment = RANDOM_PORT)

--- a/secure-api-gateway-ob-uk-rs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/v3_1_10/internationalstandingorders/InternationalStandingOrdersApiControllerTest.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/v3_1_10/internationalstandingorders/InternationalStandingOrdersApiControllerTest.java
@@ -61,20 +61,20 @@ import com.forgerock.sapi.gateway.rs.resource.store.repo.entity.account.FRAccoun
 import com.forgerock.sapi.gateway.rs.resource.store.repo.mongo.accounts.accounts.FRAccountRepository;
 import com.forgerock.sapi.gateway.rs.resource.store.repo.mongo.payments.InternationalStandingOrderPaymentSubmissionRepository;
 
-import uk.org.openbanking.datamodel.common.OBReadRefundAccount;
-import uk.org.openbanking.datamodel.error.OBError1;
-import uk.org.openbanking.datamodel.error.OBErrorResponse1;
-import uk.org.openbanking.datamodel.payment.OBPaymentConsentStatus;
-import uk.org.openbanking.datamodel.payment.OBWriteDomestic2DataInitiationInstructedAmount;
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticResponse5DataRefundAccount;
-import uk.org.openbanking.datamodel.payment.OBWriteInternationalStandingOrder4;
-import uk.org.openbanking.datamodel.payment.OBWriteInternationalStandingOrder4Data;
-import uk.org.openbanking.datamodel.payment.OBWriteInternationalStandingOrderConsent6;
-import uk.org.openbanking.datamodel.payment.OBWriteInternationalStandingOrderConsent6Data;
-import uk.org.openbanking.datamodel.payment.OBWriteInternationalStandingOrderResponse7;
-import uk.org.openbanking.datamodel.payment.OBWriteInternationalStandingOrderResponse7Data;
-import uk.org.openbanking.datamodel.payment.OBWritePaymentDetailsResponse1;
-import uk.org.openbanking.datamodel.payment.OBWritePaymentDetailsResponse1DataPaymentStatusInner;
+import uk.org.openbanking.datamodel.v3.common.OBReadRefundAccount;
+import uk.org.openbanking.datamodel.v3.error.OBError1;
+import uk.org.openbanking.datamodel.v3.error.OBErrorResponse1;
+import uk.org.openbanking.datamodel.v3.payment.OBPaymentConsentStatus;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteDomestic2DataInitiationInstructedAmount;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteDomesticResponse5DataRefundAccount;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteInternationalStandingOrder4;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteInternationalStandingOrder4Data;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteInternationalStandingOrderConsent6;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteInternationalStandingOrderConsent6Data;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteInternationalStandingOrderResponse7;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteInternationalStandingOrderResponse7Data;
+import uk.org.openbanking.datamodel.v3.payment.OBWritePaymentDetailsResponse1;
+import uk.org.openbanking.datamodel.v3.payment.OBWritePaymentDetailsResponse1DataPaymentStatusInner;
 
 /**
  * A SpringBoot test for the {@link InternationalStandingOrdersApiController}.<br/>

--- a/secure-api-gateway-ob-uk-rs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/v3_1_10/vrp/DomesticVrpConsentsApiControllerTest.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/v3_1_10/vrp/DomesticVrpConsentsApiControllerTest.java
@@ -28,8 +28,8 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
-import static uk.org.openbanking.datamodel.vrp.OBPAFundsAvailableResult1FundsAvailable.AVAILABLE;
-import static uk.org.openbanking.datamodel.vrp.OBPAFundsAvailableResult1FundsAvailable.NOTAVAILABLE;
+import static uk.org.openbanking.datamodel.v3.vrp.OBPAFundsAvailableResult1FundsAvailable.AVAILABLE;
+import static uk.org.openbanking.datamodel.v3.vrp.OBPAFundsAvailableResult1FundsAvailable.NOTAVAILABLE;
 
 import java.math.BigDecimal;
 import java.util.Date;
@@ -67,17 +67,17 @@ import com.forgerock.sapi.gateway.rcs.consent.store.datamodel.payment.vrp.v3_1_1
 import com.forgerock.sapi.gateway.rs.resource.store.repo.entity.account.FRBalance;
 import com.forgerock.sapi.gateway.uk.common.shared.api.meta.share.IntentType;
 
-import uk.org.openbanking.datamodel.common.OBActiveOrHistoricCurrencyAndAmount;
-import uk.org.openbanking.datamodel.error.OBError1;
-import uk.org.openbanking.datamodel.error.OBErrorResponse1;
-import uk.org.openbanking.datamodel.error.OBStandardErrorCodes1;
-import uk.org.openbanking.datamodel.payment.OBPaymentConsentStatus;
-import uk.org.openbanking.datamodel.vrp.OBDomesticVRPConsentRequest;
-import uk.org.openbanking.datamodel.vrp.OBDomesticVRPConsentResponse;
-import uk.org.openbanking.datamodel.vrp.OBDomesticVRPConsentResponseDataStatus;
-import uk.org.openbanking.datamodel.vrp.OBVRPFundsConfirmationRequest;
-import uk.org.openbanking.datamodel.vrp.OBVRPFundsConfirmationRequestData;
-import uk.org.openbanking.datamodel.vrp.OBVRPFundsConfirmationResponse;
+import uk.org.openbanking.datamodel.v3.common.OBActiveOrHistoricCurrencyAndAmount;
+import uk.org.openbanking.datamodel.v3.error.OBError1;
+import uk.org.openbanking.datamodel.v3.error.OBErrorResponse1;
+import uk.org.openbanking.datamodel.v3.error.OBStandardErrorCodes1;
+import uk.org.openbanking.datamodel.v3.payment.OBPaymentConsentStatus;
+import uk.org.openbanking.datamodel.v3.vrp.OBDomesticVRPConsentRequest;
+import uk.org.openbanking.datamodel.v3.vrp.OBDomesticVRPConsentResponse;
+import uk.org.openbanking.datamodel.v3.vrp.OBDomesticVRPConsentResponseDataStatus;
+import uk.org.openbanking.datamodel.v3.vrp.OBVRPFundsConfirmationRequest;
+import uk.org.openbanking.datamodel.v3.vrp.OBVRPFundsConfirmationRequestData;
+import uk.org.openbanking.datamodel.v3.vrp.OBVRPFundsConfirmationResponse;
 import uk.org.openbanking.testsupport.vrp.OBDomesticVrpConsentRequestTestDataFactory;
 
 /**

--- a/secure-api-gateway-ob-uk-rs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/v3_1_10/vrp/DomesticVrpsApiControllerTest.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/v3_1_10/vrp/DomesticVrpsApiControllerTest.java
@@ -38,11 +38,11 @@ import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.http.*;
 import org.springframework.test.context.ActiveProfiles;
-import uk.org.openbanking.datamodel.common.OBActiveOrHistoricCurrencyAndAmount;
-import uk.org.openbanking.datamodel.error.OBError1;
-import uk.org.openbanking.datamodel.error.OBErrorResponse1;
-import uk.org.openbanking.datamodel.payment.OBPaymentConsentStatus;
-import uk.org.openbanking.datamodel.vrp.*;
+import uk.org.openbanking.datamodel.v3.common.OBActiveOrHistoricCurrencyAndAmount;
+import uk.org.openbanking.datamodel.v3.error.OBError1;
+import uk.org.openbanking.datamodel.v3.error.OBErrorResponse1;
+import uk.org.openbanking.datamodel.v3.payment.OBPaymentConsentStatus;
+import uk.org.openbanking.datamodel.v3.vrp.*;
 import uk.org.openbanking.testsupport.vrp.OBDomesticVrpConsentRequestTestDataFactory;
 import uk.org.openbanking.testsupport.vrp.OBDomesticVrpRequestTestDataFactory;
 

--- a/secure-api-gateway-ob-uk-rs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/server/exceptions/GlobalExceptionHandlerTest.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/server/exceptions/GlobalExceptionHandlerTest.java
@@ -35,9 +35,9 @@ import org.springframework.test.context.ActiveProfiles;
 import com.forgerock.sapi.gateway.ob.uk.common.error.OBRIErrorResponseCategory;
 import com.forgerock.sapi.gateway.ob.uk.common.error.OBRIErrorType;
 
-import uk.org.openbanking.datamodel.error.OBError1;
-import uk.org.openbanking.datamodel.error.OBErrorResponse1;
-import uk.org.openbanking.datamodel.error.OBStandardErrorCodes1;
+import uk.org.openbanking.datamodel.v3.error.OBError1;
+import uk.org.openbanking.datamodel.v3.error.OBErrorResponse1;
+import uk.org.openbanking.datamodel.v3.error.OBStandardErrorCodes1;
 
 /**
  * Tests for the GlobalExceptionHandler, uses the {@link com.forgerock.sapi.gateway.ob.uk.rs.obie.api.account.v3_1_10.accounts.AccountAccessConsentsApi}

--- a/secure-api-gateway-ob-uk-rs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/server/service/currency/DefaultExchangeRateServiceTest.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/server/service/currency/DefaultExchangeRateServiceTest.java
@@ -27,8 +27,8 @@ import com.forgerock.sapi.gateway.ob.uk.common.datamodel.common.FRAmount;
 import com.forgerock.sapi.gateway.ob.uk.common.datamodel.common.FRExchangeRateInformation;
 import com.forgerock.sapi.gateway.ob.uk.common.datamodel.common.FRExchangeRateInformation.FRRateType;
 
-import uk.org.openbanking.datamodel.payment.OBExchangeRateType;
-import uk.org.openbanking.datamodel.payment.OBWriteInternational3DataInitiationExchangeRateInformation;
+import uk.org.openbanking.datamodel.v3.payment.OBExchangeRateType;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteInternational3DataInitiationExchangeRateInformation;
 
 class DefaultExchangeRateServiceTest {
 

--- a/secure-api-gateway-ob-uk-rs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/server/service/event/EventPollingServiceTest.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/server/service/event/EventPollingServiceTest.java
@@ -48,10 +48,10 @@ import com.forgerock.sapi.gateway.rs.resource.store.repo.mongo.events.FREventMes
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 
-import uk.org.openbanking.datamodel.event.OBEvent1;
-import uk.org.openbanking.datamodel.event.OBEventLink1;
-import uk.org.openbanking.datamodel.event.OBEventResourceUpdate1;
-import uk.org.openbanking.datamodel.event.OBEventSubject1;
+import uk.org.openbanking.datamodel.v3.event.OBEvent1;
+import uk.org.openbanking.datamodel.v3.event.OBEventLink1;
+import uk.org.openbanking.datamodel.v3.event.OBEventResourceUpdate1;
+import uk.org.openbanking.datamodel.v3.event.OBEventSubject1;
 
 /**
  * Unit test for {@link EventPollingService}.

--- a/secure-api-gateway-ob-uk-rs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/server/validator/PaymentSubmissionValidatorTest.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/server/validator/PaymentSubmissionValidatorTest.java
@@ -20,8 +20,8 @@ import com.forgerock.sapi.gateway.ob.uk.common.error.OBRIErrorResponseCategory;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
-import uk.org.openbanking.datamodel.common.OBRisk1;
-import uk.org.openbanking.datamodel.error.OBError1;
+import uk.org.openbanking.datamodel.v3.common.OBRisk1;
+import uk.org.openbanking.datamodel.v3.error.OBError1;
 
 import java.util.UUID;
 

--- a/secure-api-gateway-ob-uk-rs-validation/secure-api-gateway-ob-uk-rs-validation-obie/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/validation/obie/BaseOBValidator.java
+++ b/secure-api-gateway-ob-uk-rs-validation/secure-api-gateway-ob-uk-rs-validation-obie/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/validation/obie/BaseOBValidator.java
@@ -23,7 +23,7 @@ import com.forgerock.sapi.gateway.ob.uk.common.error.OBRIErrorType;
 import com.forgerock.sapi.gateway.ob.uk.rs.validation.ValidationResult;
 import com.forgerock.sapi.gateway.ob.uk.rs.validation.Validator;
 
-import uk.org.openbanking.datamodel.error.OBError1;
+import uk.org.openbanking.datamodel.v3.error.OBError1;
 
 /**
  * Implementation of Validator which can be extended to provide Open Banking specific validation.

--- a/secure-api-gateway-ob-uk-rs-validation/secure-api-gateway-ob-uk-rs-validation-obie/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/validation/obie/OBValidationService.java
+++ b/secure-api-gateway-ob-uk-rs-validation/secure-api-gateway-ob-uk-rs-validation-obie/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/validation/obie/OBValidationService.java
@@ -27,7 +27,7 @@ import com.forgerock.sapi.gateway.ob.uk.rs.validation.ValidateAll;
 import com.forgerock.sapi.gateway.ob.uk.rs.validation.ValidationResult;
 import com.forgerock.sapi.gateway.ob.uk.rs.validation.Validator;
 
-import uk.org.openbanking.datamodel.error.OBError1;
+import uk.org.openbanking.datamodel.v3.error.OBError1;
 
 /**
  * A service which invokes 1 or more validators and throws an exception if there are any errors in the results.

--- a/secure-api-gateway-ob-uk-rs-validation/secure-api-gateway-ob-uk-rs-validation-obie/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/validation/obie/account/consent/OBReadConsent1Validator.java
+++ b/secure-api-gateway-ob-uk-rs-validation/secure-api-gateway-ob-uk-rs-validation-obie/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/validation/obie/account/consent/OBReadConsent1Validator.java
@@ -21,9 +21,9 @@ import com.forgerock.sapi.gateway.ob.uk.common.error.OBRIErrorType;
 import com.forgerock.sapi.gateway.ob.uk.rs.validation.ValidationResult;
 import com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.BaseOBValidator;
 
-import uk.org.openbanking.datamodel.account.OBReadConsent1;
-import uk.org.openbanking.datamodel.account.OBReadConsent1Data;
-import uk.org.openbanking.datamodel.error.OBError1;
+import uk.org.openbanking.datamodel.v3.account.OBReadConsent1;
+import uk.org.openbanking.datamodel.v3.account.OBReadConsent1Data;
+import uk.org.openbanking.datamodel.v3.error.OBError1;
 
 /**
  * Validator of OBReadConsent1 objects (Accounts Access Consents)

--- a/secure-api-gateway-ob-uk-rs-validation/secure-api-gateway-ob-uk-rs-validation-obie/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/validation/obie/funds/FundsConfirmationValidator.java
+++ b/secure-api-gateway-ob-uk-rs-validation/secure-api-gateway-ob-uk-rs-validation-obie/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/validation/obie/funds/FundsConfirmationValidator.java
@@ -25,9 +25,9 @@ import com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.BaseOBValidator;
 import com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.funds.FundsConfirmationValidator.FundsConfirmationValidationContext;
 
 import lombok.extern.slf4j.Slf4j;
-import uk.org.openbanking.datamodel.common.OBExternalRequestStatus1Code;
-import uk.org.openbanking.datamodel.error.OBError1;
-import uk.org.openbanking.datamodel.fund.OBFundsConfirmation1;
+import uk.org.openbanking.datamodel.v3.common.OBExternalRequestStatus1Code;
+import uk.org.openbanking.datamodel.v3.error.OBError1;
+import uk.org.openbanking.datamodel.v3.fund.OBFundsConfirmation1;
 
 @Slf4j
 public class FundsConfirmationValidator extends BaseOBValidator<FundsConfirmationValidationContext> {

--- a/secure-api-gateway-ob-uk-rs-validation/secure-api-gateway-ob-uk-rs-validation-obie/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/validation/obie/payment/BasePaymentRequestValidator.java
+++ b/secure-api-gateway-ob-uk-rs-validation/secure-api-gateway-ob-uk-rs-validation-obie/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/validation/obie/payment/BasePaymentRequestValidator.java
@@ -23,8 +23,8 @@ import com.forgerock.sapi.gateway.ob.uk.rs.validation.ValidationResult;
 import com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.BaseOBValidator;
 import com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.payment.BasePaymentRequestValidator.PaymentRequestValidationContext;
 
-import uk.org.openbanking.datamodel.common.OBRisk1;
-import uk.org.openbanking.datamodel.error.OBError1;
+import uk.org.openbanking.datamodel.v3.common.OBRisk1;
+import uk.org.openbanking.datamodel.v3.error.OBError1;
 
 /**
  * Base Validator which provides common validation for Payment Requests.

--- a/secure-api-gateway-ob-uk-rs-validation/secure-api-gateway-ob-uk-rs-validation-obie/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/validation/obie/payment/CurrencyCodeValidator.java
+++ b/secure-api-gateway-ob-uk-rs-validation/secure-api-gateway-ob-uk-rs-validation-obie/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/validation/obie/payment/CurrencyCodeValidator.java
@@ -22,7 +22,7 @@ import com.forgerock.sapi.gateway.ob.uk.common.error.OBRIErrorType;
 import com.forgerock.sapi.gateway.ob.uk.rs.validation.ValidationResult;
 import com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.BaseOBValidator;
 
-import uk.org.openbanking.datamodel.error.OBError1;
+import uk.org.openbanking.datamodel.v3.error.OBError1;
 
 public class CurrencyCodeValidator extends BaseOBValidator<String> {
 

--- a/secure-api-gateway-ob-uk-rs-validation/secure-api-gateway-ob-uk-rs-validation-obie/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/validation/obie/payment/OBDomesticVRPRequestValidator.java
+++ b/secure-api-gateway-ob-uk-rs-validation/secure-api-gateway-ob-uk-rs-validation-obie/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/validation/obie/payment/OBDomesticVRPRequestValidator.java
@@ -21,13 +21,13 @@ import com.forgerock.sapi.gateway.ob.uk.common.error.OBRIErrorType;
 import com.forgerock.sapi.gateway.ob.uk.rs.validation.ValidationResult;
 import com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.payment.OBDomesticVRPRequestValidator.OBDomesticVRPRequestValidationContext;
 
-import uk.org.openbanking.datamodel.common.OBCashAccountCreditor3;
-import uk.org.openbanking.datamodel.error.OBError1;
-import uk.org.openbanking.datamodel.vrp.OBDomesticVRPConsentRequest;
-import uk.org.openbanking.datamodel.vrp.OBDomesticVRPControlParameters;
-import uk.org.openbanking.datamodel.vrp.OBDomesticVRPInitiation;
-import uk.org.openbanking.datamodel.vrp.OBDomesticVRPInstruction;
-import uk.org.openbanking.datamodel.vrp.OBDomesticVRPRequest;
+import uk.org.openbanking.datamodel.v3.common.OBCashAccountCreditor3;
+import uk.org.openbanking.datamodel.v3.error.OBError1;
+import uk.org.openbanking.datamodel.v3.vrp.OBDomesticVRPConsentRequest;
+import uk.org.openbanking.datamodel.v3.vrp.OBDomesticVRPControlParameters;
+import uk.org.openbanking.datamodel.v3.vrp.OBDomesticVRPInitiation;
+import uk.org.openbanking.datamodel.v3.vrp.OBDomesticVRPInstruction;
+import uk.org.openbanking.datamodel.v3.vrp.OBDomesticVRPRequest;
 
 /**
  * Validator of OBDomesticVRPRequest objects (VRP Payment Requests).

--- a/secure-api-gateway-ob-uk-rs-validation/secure-api-gateway-ob-uk-rs-validation-obie/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/validation/obie/payment/OBRisk1Validator.java
+++ b/secure-api-gateway-ob-uk-rs-validation/secure-api-gateway-ob-uk-rs-validation-obie/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/validation/obie/payment/OBRisk1Validator.java
@@ -19,8 +19,8 @@ import com.forgerock.sapi.gateway.ob.uk.common.error.OBRIErrorType;
 import com.forgerock.sapi.gateway.ob.uk.rs.validation.ValidationResult;
 import com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.BaseOBValidator;
 
-import uk.org.openbanking.datamodel.common.OBRisk1;
-import uk.org.openbanking.datamodel.error.OBError1;
+import uk.org.openbanking.datamodel.v3.common.OBRisk1;
+import uk.org.openbanking.datamodel.v3.error.OBError1;
 
 /**
  * Validator of {@link OBRisk1} objects, these objects are sent as part of Payment Consents and Requests.

--- a/secure-api-gateway-ob-uk-rs-validation/secure-api-gateway-ob-uk-rs-validation-obie/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/validation/obie/payment/OBWriteDomestic2DataInitiationInstructedAmountValidator.java
+++ b/secure-api-gateway-ob-uk-rs-validation/secure-api-gateway-ob-uk-rs-validation-obie/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/validation/obie/payment/OBWriteDomestic2DataInitiationInstructedAmountValidator.java
@@ -24,8 +24,8 @@ import com.forgerock.sapi.gateway.ob.uk.common.error.OBRIErrorType;
 import com.forgerock.sapi.gateway.ob.uk.rs.validation.ValidationResult;
 import com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.BaseOBValidator;
 
-import uk.org.openbanking.datamodel.error.OBError1;
-import uk.org.openbanking.datamodel.payment.OBWriteDomestic2DataInitiationInstructedAmount;
+import uk.org.openbanking.datamodel.v3.error.OBError1;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteDomestic2DataInitiationInstructedAmount;
 
 public class OBWriteDomestic2DataInitiationInstructedAmountValidator extends BaseOBValidator<OBWriteDomestic2DataInitiationInstructedAmount> {
 

--- a/secure-api-gateway-ob-uk-rs-validation/secure-api-gateway-ob-uk-rs-validation-obie/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/validation/obie/payment/OBWriteDomestic2Validator.java
+++ b/secure-api-gateway-ob-uk-rs-validation/secure-api-gateway-ob-uk-rs-validation-obie/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/validation/obie/payment/OBWriteDomestic2Validator.java
@@ -18,10 +18,10 @@ package com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.payment;
 import com.forgerock.sapi.gateway.ob.uk.rs.validation.ValidationResult;
 import com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.payment.OBWriteDomestic2Validator.OBWriteDomestic2ValidationContext;
 
-import uk.org.openbanking.datamodel.error.OBError1;
-import uk.org.openbanking.datamodel.payment.OBWriteDomestic2;
-import uk.org.openbanking.datamodel.payment.OBWriteDomestic2DataInitiation;
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticConsent4;
+import uk.org.openbanking.datamodel.v3.error.OBError1;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteDomestic2;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteDomestic2DataInitiation;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteDomesticConsent4;
 
 /**
  * Validator of OBWriteDomestic2 objects (Domestic Payment Requests)

--- a/secure-api-gateway-ob-uk-rs-validation/secure-api-gateway-ob-uk-rs-validation-obie/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/validation/obie/payment/OBWriteDomesticScheduled2Validator.java
+++ b/secure-api-gateway-ob-uk-rs-validation/secure-api-gateway-ob-uk-rs-validation-obie/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/validation/obie/payment/OBWriteDomesticScheduled2Validator.java
@@ -18,10 +18,10 @@ package com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.payment;
 import com.forgerock.sapi.gateway.ob.uk.rs.validation.ValidationResult;
 import com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.payment.OBWriteDomesticScheduled2Validator.OBWriteDomesticScheduled2ValidationContext;
 
-import uk.org.openbanking.datamodel.error.OBError1;
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticScheduled2;
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticScheduled2DataInitiation;
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticScheduledConsent4;
+import uk.org.openbanking.datamodel.v3.error.OBError1;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteDomesticScheduled2;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteDomesticScheduled2DataInitiation;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteDomesticScheduledConsent4;
 
 /**
  * Validator of OBWriteDomesticScheduled2 objects (Domestic Scheduled Payment Requests)

--- a/secure-api-gateway-ob-uk-rs-validation/secure-api-gateway-ob-uk-rs-validation-obie/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/validation/obie/payment/OBWriteDomesticStandingOrder3Validator.java
+++ b/secure-api-gateway-ob-uk-rs-validation/secure-api-gateway-ob-uk-rs-validation-obie/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/validation/obie/payment/OBWriteDomesticStandingOrder3Validator.java
@@ -18,10 +18,10 @@ package com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.payment;
 import com.forgerock.sapi.gateway.ob.uk.rs.validation.ValidationResult;
 import com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.payment.OBWriteDomesticStandingOrder3Validator.OBWriteDomesticStandingOrder3ValidationContext;
 
-import uk.org.openbanking.datamodel.error.OBError1;
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticStandingOrder3;
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticStandingOrder3DataInitiation;
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticStandingOrderConsent5;
+import uk.org.openbanking.datamodel.v3.error.OBError1;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteDomesticStandingOrder3;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteDomesticStandingOrder3DataInitiation;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteDomesticStandingOrderConsent5;
 
 /**
  * Validator of OBWriteDomesticStandingOrder3 objects (Domestic Standing Order Requests)

--- a/secure-api-gateway-ob-uk-rs-validation/secure-api-gateway-ob-uk-rs-validation-obie/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/validation/obie/payment/OBWriteFile2Validator.java
+++ b/secure-api-gateway-ob-uk-rs-validation/secure-api-gateway-ob-uk-rs-validation-obie/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/validation/obie/payment/OBWriteFile2Validator.java
@@ -20,11 +20,11 @@ import java.util.function.Supplier;
 import com.forgerock.sapi.gateway.ob.uk.rs.validation.ValidationResult;
 import com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.payment.OBWriteFile2Validator.OBWriteFile2ValidationContext;
 
-import uk.org.openbanking.datamodel.common.OBRisk1;
-import uk.org.openbanking.datamodel.error.OBError1;
-import uk.org.openbanking.datamodel.payment.OBWriteFile2;
-import uk.org.openbanking.datamodel.payment.OBWriteFile2DataInitiation;
-import uk.org.openbanking.datamodel.payment.OBWriteFileConsent3;
+import uk.org.openbanking.datamodel.v3.common.OBRisk1;
+import uk.org.openbanking.datamodel.v3.error.OBError1;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteFile2;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteFile2DataInitiation;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteFileConsent3;
 
 /**
  * Validator of OBWriteFile2 objects (File Payment Requests)

--- a/secure-api-gateway-ob-uk-rs-validation/secure-api-gateway-ob-uk-rs-validation-obie/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/validation/obie/payment/OBWriteInternational3DataInitiationExchangeRateInformationValidator.java
+++ b/secure-api-gateway-ob-uk-rs-validation/secure-api-gateway-ob-uk-rs-validation-obie/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/validation/obie/payment/OBWriteInternational3DataInitiationExchangeRateInformationValidator.java
@@ -21,9 +21,9 @@ import com.forgerock.sapi.gateway.ob.uk.common.error.OBRIErrorType;
 import com.forgerock.sapi.gateway.ob.uk.rs.validation.ValidationResult;
 import com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.BaseOBValidator;
 
-import uk.org.openbanking.datamodel.error.OBError1;
-import uk.org.openbanking.datamodel.payment.OBExchangeRateType;
-import uk.org.openbanking.datamodel.payment.OBWriteInternational3DataInitiationExchangeRateInformation;
+import uk.org.openbanking.datamodel.v3.error.OBError1;
+import uk.org.openbanking.datamodel.v3.payment.OBExchangeRateType;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteInternational3DataInitiationExchangeRateInformation;
 
 public class OBWriteInternational3DataInitiationExchangeRateInformationValidator extends BaseOBValidator<OBWriteInternational3DataInitiationExchangeRateInformation> {
 

--- a/secure-api-gateway-ob-uk-rs-validation/secure-api-gateway-ob-uk-rs-validation-obie/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/validation/obie/payment/OBWriteInternational3Validator.java
+++ b/secure-api-gateway-ob-uk-rs-validation/secure-api-gateway-ob-uk-rs-validation-obie/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/validation/obie/payment/OBWriteInternational3Validator.java
@@ -18,10 +18,10 @@ package com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.payment;
 import com.forgerock.sapi.gateway.ob.uk.rs.validation.ValidationResult;
 import com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.payment.OBWriteInternational3Validator.OBWriteInternational3ValidationContext;
 
-import uk.org.openbanking.datamodel.error.OBError1;
-import uk.org.openbanking.datamodel.payment.OBWriteInternational3;
-import uk.org.openbanking.datamodel.payment.OBWriteInternational3DataInitiation;
-import uk.org.openbanking.datamodel.payment.OBWriteInternationalConsent5;
+import uk.org.openbanking.datamodel.v3.error.OBError1;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteInternational3;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteInternational3DataInitiation;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteInternationalConsent5;
 
 /**
  * Validator of OBWriteInternational3 objects (International Payment Requests)

--- a/secure-api-gateway-ob-uk-rs-validation/secure-api-gateway-ob-uk-rs-validation-obie/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/validation/obie/payment/OBWriteInternationalScheduled3Validator.java
+++ b/secure-api-gateway-ob-uk-rs-validation/secure-api-gateway-ob-uk-rs-validation-obie/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/validation/obie/payment/OBWriteInternationalScheduled3Validator.java
@@ -18,10 +18,10 @@ package com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.payment;
 import com.forgerock.sapi.gateway.ob.uk.rs.validation.ValidationResult;
 import com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.payment.OBWriteInternationalScheduled3Validator.OBWriteInternationalScheduled3ValidationContext;
 
-import uk.org.openbanking.datamodel.error.OBError1;
-import uk.org.openbanking.datamodel.payment.OBWriteInternationalScheduled3;
-import uk.org.openbanking.datamodel.payment.OBWriteInternationalScheduled3DataInitiation;
-import uk.org.openbanking.datamodel.payment.OBWriteInternationalScheduledConsent5;
+import uk.org.openbanking.datamodel.v3.error.OBError1;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteInternationalScheduled3;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteInternationalScheduled3DataInitiation;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteInternationalScheduledConsent5;
 
 /**
  * Validator of OBWriteInternationalScheduled3 objects (International Scheduled Payment Requests)

--- a/secure-api-gateway-ob-uk-rs-validation/secure-api-gateway-ob-uk-rs-validation-obie/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/validation/obie/payment/OBWriteInternationalStandingOrder4Validator.java
+++ b/secure-api-gateway-ob-uk-rs-validation/secure-api-gateway-ob-uk-rs-validation-obie/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/validation/obie/payment/OBWriteInternationalStandingOrder4Validator.java
@@ -18,10 +18,10 @@ package com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.payment;
 import com.forgerock.sapi.gateway.ob.uk.rs.validation.ValidationResult;
 import com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.payment.OBWriteInternationalStandingOrder4Validator.OBWriteInternationalStandingOrder4ValidationContext;
 
-import uk.org.openbanking.datamodel.error.OBError1;
-import uk.org.openbanking.datamodel.payment.OBWriteInternationalStandingOrder4;
-import uk.org.openbanking.datamodel.payment.OBWriteInternationalStandingOrder4DataInitiation;
-import uk.org.openbanking.datamodel.payment.OBWriteInternationalStandingOrderConsent6;
+import uk.org.openbanking.datamodel.v3.error.OBError1;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteInternationalStandingOrder4;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteInternationalStandingOrder4DataInitiation;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteInternationalStandingOrderConsent6;
 
 /**
  * Validator of OBWriteInternationalStandingOrder4 objects (International Standing Order Requests)

--- a/secure-api-gateway-ob-uk-rs-validation/secure-api-gateway-ob-uk-rs-validation-obie/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/validation/obie/payment/consent/OBDomesticVRPConsentRequestValidator.java
+++ b/secure-api-gateway-ob-uk-rs-validation/secure-api-gateway-ob-uk-rs-validation-obie/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/validation/obie/payment/consent/OBDomesticVRPConsentRequestValidator.java
@@ -22,10 +22,10 @@ import com.forgerock.sapi.gateway.ob.uk.common.error.OBRIErrorType;
 import com.forgerock.sapi.gateway.ob.uk.rs.validation.ValidationResult;
 import com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.BaseOBValidator;
 
-import uk.org.openbanking.datamodel.common.OBRisk1;
-import uk.org.openbanking.datamodel.error.OBError1;
-import uk.org.openbanking.datamodel.vrp.OBDomesticVRPConsentRequest;
-import uk.org.openbanking.datamodel.vrp.OBDomesticVRPControlParameters;
+import uk.org.openbanking.datamodel.v3.common.OBRisk1;
+import uk.org.openbanking.datamodel.v3.error.OBError1;
+import uk.org.openbanking.datamodel.v3.vrp.OBDomesticVRPConsentRequest;
+import uk.org.openbanking.datamodel.v3.vrp.OBDomesticVRPControlParameters;
 
 public class OBDomesticVRPConsentRequestValidator extends BaseOBValidator<OBDomesticVRPConsentRequest> {
 

--- a/secure-api-gateway-ob-uk-rs-validation/secure-api-gateway-ob-uk-rs-validation-obie/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/validation/obie/payment/consent/OBVRPFundsConfirmationRequestValidator.java
+++ b/secure-api-gateway-ob-uk-rs-validation/secure-api-gateway-ob-uk-rs-validation-obie/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/validation/obie/payment/consent/OBVRPFundsConfirmationRequestValidator.java
@@ -20,10 +20,10 @@ import com.forgerock.sapi.gateway.ob.uk.rs.validation.ValidationResult;
 import com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.BaseOBValidator;
 import com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.payment.consent.OBVRPFundsConfirmationRequestValidator.VRPFundsConfirmationValidationContext;
 
-import uk.org.openbanking.datamodel.error.OBError1;
-import uk.org.openbanking.datamodel.vrp.OBDomesticVRPConsentResponseDataStatus;
-import uk.org.openbanking.datamodel.vrp.OBVRPFundsConfirmationRequest;
-import uk.org.openbanking.datamodel.vrp.OBVRPFundsConfirmationRequestData;
+import uk.org.openbanking.datamodel.v3.error.OBError1;
+import uk.org.openbanking.datamodel.v3.vrp.OBDomesticVRPConsentResponseDataStatus;
+import uk.org.openbanking.datamodel.v3.vrp.OBVRPFundsConfirmationRequest;
+import uk.org.openbanking.datamodel.v3.vrp.OBVRPFundsConfirmationRequestData;
 
 /**
  * Validator of OBVRPFundsConfirmationRequest objects.

--- a/secure-api-gateway-ob-uk-rs-validation/secure-api-gateway-ob-uk-rs-validation-obie/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/validation/obie/payment/consent/OBWriteDomesticConsent4Validator.java
+++ b/secure-api-gateway-ob-uk-rs-validation/secure-api-gateway-ob-uk-rs-validation-obie/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/validation/obie/payment/consent/OBWriteDomesticConsent4Validator.java
@@ -20,10 +20,10 @@ import java.util.Objects;
 import com.forgerock.sapi.gateway.ob.uk.rs.validation.ValidationResult;
 import com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.BaseOBValidator;
 
-import uk.org.openbanking.datamodel.common.OBRisk1;
-import uk.org.openbanking.datamodel.error.OBError1;
-import uk.org.openbanking.datamodel.payment.OBWriteDomestic2DataInitiationInstructedAmount;
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticConsent4;
+import uk.org.openbanking.datamodel.v3.common.OBRisk1;
+import uk.org.openbanking.datamodel.v3.error.OBError1;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteDomestic2DataInitiationInstructedAmount;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteDomesticConsent4;
 
 /**
  * Validator of OBWriteDomesticConsent4 objects (Domestic Payment Consents)

--- a/secure-api-gateway-ob-uk-rs-validation/secure-api-gateway-ob-uk-rs-validation-obie/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/validation/obie/payment/consent/OBWriteDomesticScheduledConsent4Validator.java
+++ b/secure-api-gateway-ob-uk-rs-validation/secure-api-gateway-ob-uk-rs-validation-obie/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/validation/obie/payment/consent/OBWriteDomesticScheduledConsent4Validator.java
@@ -23,10 +23,10 @@ import com.forgerock.sapi.gateway.ob.uk.common.error.OBRIErrorType;
 import com.forgerock.sapi.gateway.ob.uk.rs.validation.ValidationResult;
 import com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.BaseOBValidator;
 
-import uk.org.openbanking.datamodel.common.OBRisk1;
-import uk.org.openbanking.datamodel.error.OBError1;
-import uk.org.openbanking.datamodel.payment.OBWriteDomestic2DataInitiationInstructedAmount;
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticScheduledConsent4;
+import uk.org.openbanking.datamodel.v3.common.OBRisk1;
+import uk.org.openbanking.datamodel.v3.error.OBError1;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteDomestic2DataInitiationInstructedAmount;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteDomesticScheduledConsent4;
 
 /**
  * Validator of OBWriteDomesticScheduledConsent4 objects (Domestic Scheduled Payment Consents)

--- a/secure-api-gateway-ob-uk-rs-validation/secure-api-gateway-ob-uk-rs-validation-obie/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/validation/obie/payment/consent/OBWriteDomesticStandingOrderConsent5Validator.java
+++ b/secure-api-gateway-ob-uk-rs-validation/secure-api-gateway-ob-uk-rs-validation-obie/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/validation/obie/payment/consent/OBWriteDomesticStandingOrderConsent5Validator.java
@@ -24,13 +24,13 @@ import com.forgerock.sapi.gateway.ob.uk.common.error.OBRIErrorType;
 import com.forgerock.sapi.gateway.ob.uk.rs.validation.ValidationResult;
 import com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.BaseOBValidator;
 
-import uk.org.openbanking.datamodel.common.OBRisk1;
-import uk.org.openbanking.datamodel.error.OBError1;
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticStandingOrder3DataInitiation;
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticStandingOrder3DataInitiationFinalPaymentAmount;
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticStandingOrder3DataInitiationFirstPaymentAmount;
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticStandingOrder3DataInitiationRecurringPaymentAmount;
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticStandingOrderConsent5;
+import uk.org.openbanking.datamodel.v3.common.OBRisk1;
+import uk.org.openbanking.datamodel.v3.error.OBError1;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteDomesticStandingOrder3DataInitiation;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteDomesticStandingOrder3DataInitiationFinalPaymentAmount;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteDomesticStandingOrder3DataInitiationFirstPaymentAmount;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteDomesticStandingOrder3DataInitiationRecurringPaymentAmount;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteDomesticStandingOrderConsent5;
 
 /**
  * Validator of OBWriteDomesticStandingOrderConsent5 objects (OBIE Domestic Standing Order Consents)

--- a/secure-api-gateway-ob-uk-rs-validation/secure-api-gateway-ob-uk-rs-validation-obie/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/validation/obie/payment/consent/OBWriteFileConsent3Validator.java
+++ b/secure-api-gateway-ob-uk-rs-validation/secure-api-gateway-ob-uk-rs-validation-obie/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/validation/obie/payment/consent/OBWriteFileConsent3Validator.java
@@ -22,8 +22,8 @@ import com.forgerock.sapi.gateway.ob.uk.common.error.OBRIErrorType;
 import com.forgerock.sapi.gateway.ob.uk.rs.validation.ValidationResult;
 import com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.BaseOBValidator;
 
-import uk.org.openbanking.datamodel.error.OBError1;
-import uk.org.openbanking.datamodel.payment.OBWriteFileConsent3;
+import uk.org.openbanking.datamodel.v3.error.OBError1;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteFileConsent3;
 
 /**
  * Validator of OBWriteFileConsent3 objects (OBIE File Payment Consents)

--- a/secure-api-gateway-ob-uk-rs-validation/secure-api-gateway-ob-uk-rs-validation-obie/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/validation/obie/payment/consent/OBWriteInternationalConsent5Validator.java
+++ b/secure-api-gateway-ob-uk-rs-validation/secure-api-gateway-ob-uk-rs-validation-obie/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/validation/obie/payment/consent/OBWriteInternationalConsent5Validator.java
@@ -20,12 +20,12 @@ import java.util.Objects;
 import com.forgerock.sapi.gateway.ob.uk.rs.validation.ValidationResult;
 import com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.BaseOBValidator;
 
-import uk.org.openbanking.datamodel.common.OBRisk1;
-import uk.org.openbanking.datamodel.error.OBError1;
-import uk.org.openbanking.datamodel.payment.OBWriteDomestic2DataInitiationInstructedAmount;
-import uk.org.openbanking.datamodel.payment.OBWriteInternational3DataInitiation;
-import uk.org.openbanking.datamodel.payment.OBWriteInternational3DataInitiationExchangeRateInformation;
-import uk.org.openbanking.datamodel.payment.OBWriteInternationalConsent5;
+import uk.org.openbanking.datamodel.v3.common.OBRisk1;
+import uk.org.openbanking.datamodel.v3.error.OBError1;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteDomestic2DataInitiationInstructedAmount;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteInternational3DataInitiation;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteInternational3DataInitiationExchangeRateInformation;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteInternationalConsent5;
 
 /**
  * Validator of OBWriteInternationalConsent5 objects (OBIE International Payment Consents)

--- a/secure-api-gateway-ob-uk-rs-validation/secure-api-gateway-ob-uk-rs-validation-obie/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/validation/obie/payment/consent/OBWriteInternationalScheduledConsent5Validator.java
+++ b/secure-api-gateway-ob-uk-rs-validation/secure-api-gateway-ob-uk-rs-validation-obie/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/validation/obie/payment/consent/OBWriteInternationalScheduledConsent5Validator.java
@@ -23,12 +23,12 @@ import com.forgerock.sapi.gateway.ob.uk.common.error.OBRIErrorType;
 import com.forgerock.sapi.gateway.ob.uk.rs.validation.ValidationResult;
 import com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.BaseOBValidator;
 
-import uk.org.openbanking.datamodel.common.OBRisk1;
-import uk.org.openbanking.datamodel.error.OBError1;
-import uk.org.openbanking.datamodel.payment.OBWriteDomestic2DataInitiationInstructedAmount;
-import uk.org.openbanking.datamodel.payment.OBWriteInternational3DataInitiationExchangeRateInformation;
-import uk.org.openbanking.datamodel.payment.OBWriteInternationalScheduled3DataInitiation;
-import uk.org.openbanking.datamodel.payment.OBWriteInternationalScheduledConsent5;
+import uk.org.openbanking.datamodel.v3.common.OBRisk1;
+import uk.org.openbanking.datamodel.v3.error.OBError1;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteDomestic2DataInitiationInstructedAmount;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteInternational3DataInitiationExchangeRateInformation;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteInternationalScheduled3DataInitiation;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteInternationalScheduledConsent5;
 
 /**
  * Validator of OBWriteInternationalScheduledConsent5 objects (OBIE International Scheduled Payment Consents)

--- a/secure-api-gateway-ob-uk-rs-validation/secure-api-gateway-ob-uk-rs-validation-obie/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/validation/obie/payment/consent/OBWriteInternationalStandingOrderConsent6Validator.java
+++ b/secure-api-gateway-ob-uk-rs-validation/secure-api-gateway-ob-uk-rs-validation-obie/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/validation/obie/payment/consent/OBWriteInternationalStandingOrderConsent6Validator.java
@@ -20,11 +20,11 @@ import java.util.Objects;
 import com.forgerock.sapi.gateway.ob.uk.rs.validation.ValidationResult;
 import com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.BaseOBValidator;
 
-import uk.org.openbanking.datamodel.common.OBRisk1;
-import uk.org.openbanking.datamodel.error.OBError1;
-import uk.org.openbanking.datamodel.payment.OBWriteDomestic2DataInitiationInstructedAmount;
-import uk.org.openbanking.datamodel.payment.OBWriteInternationalStandingOrder4DataInitiation;
-import uk.org.openbanking.datamodel.payment.OBWriteInternationalStandingOrderConsent6;
+import uk.org.openbanking.datamodel.v3.common.OBRisk1;
+import uk.org.openbanking.datamodel.v3.error.OBError1;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteDomestic2DataInitiationInstructedAmount;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteInternationalStandingOrder4DataInitiation;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteInternationalStandingOrderConsent6;
 
 /**
  * Validator of OBWriteInternationalStandingOrderConsent6V objects (OBIE International Standing Order Consents)

--- a/secure-api-gateway-ob-uk-rs-validation/secure-api-gateway-ob-uk-rs-validation-obie/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/validation/obie/BaseOBValidatorTest.java
+++ b/secure-api-gateway-ob-uk-rs-validation/secure-api-gateway-ob-uk-rs-validation-obie/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/validation/obie/BaseOBValidatorTest.java
@@ -23,7 +23,7 @@ import org.junit.jupiter.api.Test;
 
 import com.forgerock.sapi.gateway.ob.uk.rs.validation.ValidationResult;
 
-import uk.org.openbanking.datamodel.error.OBError1;
+import uk.org.openbanking.datamodel.v3.error.OBError1;
 
 class BaseOBValidatorTest {
 

--- a/secure-api-gateway-ob-uk-rs-validation/secure-api-gateway-ob-uk-rs-validation-obie/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/validation/obie/OBValidationServiceTest.java
+++ b/secure-api-gateway-ob-uk-rs-validation/secure-api-gateway-ob-uk-rs-validation-obie/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/validation/obie/OBValidationServiceTest.java
@@ -31,9 +31,9 @@ import com.forgerock.sapi.gateway.ob.uk.rs.validation.SuccessValidator;
 import com.forgerock.sapi.gateway.ob.uk.rs.validation.Validator;
 import com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.account.consent.OBReadConsent1Validator;
 
-import uk.org.openbanking.datamodel.account.OBReadConsent1;
-import uk.org.openbanking.datamodel.account.OBReadConsent1Data;
-import uk.org.openbanking.datamodel.error.OBError1;
+import uk.org.openbanking.datamodel.v3.account.OBReadConsent1;
+import uk.org.openbanking.datamodel.v3.account.OBReadConsent1Data;
+import uk.org.openbanking.datamodel.v3.error.OBError1;
 
 class OBValidationServiceTest {
 

--- a/secure-api-gateway-ob-uk-rs-validation/secure-api-gateway-ob-uk-rs-validation-obie/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/validation/obie/account/consent/OBReadConsent1ValidatorTest.java
+++ b/secure-api-gateway-ob-uk-rs-validation/secure-api-gateway-ob-uk-rs-validation-obie/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/validation/obie/account/consent/OBReadConsent1ValidatorTest.java
@@ -25,9 +25,9 @@ import org.junit.jupiter.api.Test;
 
 import com.forgerock.sapi.gateway.ob.uk.rs.validation.ValidationResult;
 
-import uk.org.openbanking.datamodel.account.OBReadConsent1;
-import uk.org.openbanking.datamodel.account.OBReadConsent1Data;
-import uk.org.openbanking.datamodel.error.OBError1;
+import uk.org.openbanking.datamodel.v3.account.OBReadConsent1;
+import uk.org.openbanking.datamodel.v3.account.OBReadConsent1Data;
+import uk.org.openbanking.datamodel.v3.error.OBError1;
 
 public class OBReadConsent1ValidatorTest {
 

--- a/secure-api-gateway-ob-uk-rs-validation/secure-api-gateway-ob-uk-rs-validation-obie/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/validation/obie/funds/FundsConfirmationValidatorTest.java
+++ b/secure-api-gateway-ob-uk-rs-validation/secure-api-gateway-ob-uk-rs-validation-obie/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/validation/obie/funds/FundsConfirmationValidatorTest.java
@@ -18,9 +18,9 @@ package com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.funds;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static uk.org.openbanking.datamodel.fund.OBFundsConfirmationConsentResponse1Data.StatusEnum.AUTHORISED;
-import static uk.org.openbanking.datamodel.fund.OBFundsConfirmationConsentResponse1Data.StatusEnum.REJECTED;
-import static uk.org.openbanking.datamodel.fund.OBFundsConfirmationConsentResponse1Data.StatusEnum.REVOKED;
+import static uk.org.openbanking.datamodel.v3.fund.OBFundsConfirmationConsentResponse1Data.StatusEnum.AUTHORISED;
+import static uk.org.openbanking.datamodel.v3.fund.OBFundsConfirmationConsentResponse1Data.StatusEnum.REJECTED;
+import static uk.org.openbanking.datamodel.v3.fund.OBFundsConfirmationConsentResponse1Data.StatusEnum.REVOKED;
 
 import java.util.List;
 import java.util.UUID;
@@ -32,13 +32,13 @@ import org.junit.jupiter.api.Test;
 import com.forgerock.sapi.gateway.ob.uk.common.error.OBRIErrorType;
 import com.forgerock.sapi.gateway.ob.uk.rs.validation.ValidationResult;
 
-import uk.org.openbanking.datamodel.error.OBError1;
-import uk.org.openbanking.datamodel.fund.OBFundsConfirmation1;
-import uk.org.openbanking.datamodel.fund.OBFundsConfirmation1Data;
-import uk.org.openbanking.datamodel.fund.OBFundsConfirmation1DataInstructedAmount;
-import uk.org.openbanking.datamodel.fund.OBFundsConfirmationConsent1;
-import uk.org.openbanking.datamodel.fund.OBFundsConfirmationConsent1Data;
-import uk.org.openbanking.datamodel.fund.OBFundsConfirmationConsent1DataDebtorAccount;
+import uk.org.openbanking.datamodel.v3.error.OBError1;
+import uk.org.openbanking.datamodel.v3.fund.OBFundsConfirmation1;
+import uk.org.openbanking.datamodel.v3.fund.OBFundsConfirmation1Data;
+import uk.org.openbanking.datamodel.v3.fund.OBFundsConfirmation1DataInstructedAmount;
+import uk.org.openbanking.datamodel.v3.fund.OBFundsConfirmationConsent1;
+import uk.org.openbanking.datamodel.v3.fund.OBFundsConfirmationConsent1Data;
+import uk.org.openbanking.datamodel.v3.fund.OBFundsConfirmationConsent1DataDebtorAccount;
 
 public class FundsConfirmationValidatorTest {
 

--- a/secure-api-gateway-ob-uk-rs-validation/secure-api-gateway-ob-uk-rs-validation-obie/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/validation/obie/payment/BasePaymentRequestValidatorTest.java
+++ b/secure-api-gateway-ob-uk-rs-validation/secure-api-gateway-ob-uk-rs-validation-obie/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/validation/obie/payment/BasePaymentRequestValidatorTest.java
@@ -23,12 +23,12 @@ import org.junit.jupiter.api.function.Executable;
 
 import com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.payment.BasePaymentRequestValidator.PaymentRequestValidationContext;
 
-import uk.org.openbanking.datamodel.common.OBRisk1;
-import uk.org.openbanking.datamodel.vrp.OBDomesticVRPConsentRequest;
-import uk.org.openbanking.datamodel.vrp.OBDomesticVRPConsentRequestData;
-import uk.org.openbanking.datamodel.vrp.OBDomesticVRPInitiation;
-import uk.org.openbanking.datamodel.vrp.OBDomesticVRPRequest;
-import uk.org.openbanking.datamodel.vrp.OBDomesticVRPRequestData;
+import uk.org.openbanking.datamodel.v3.common.OBRisk1;
+import uk.org.openbanking.datamodel.v3.vrp.OBDomesticVRPConsentRequest;
+import uk.org.openbanking.datamodel.v3.vrp.OBDomesticVRPConsentRequestData;
+import uk.org.openbanking.datamodel.v3.vrp.OBDomesticVRPInitiation;
+import uk.org.openbanking.datamodel.v3.vrp.OBDomesticVRPRequest;
+import uk.org.openbanking.datamodel.v3.vrp.OBDomesticVRPRequestData;
 
 class BasePaymentRequestValidatorTest {
 

--- a/secure-api-gateway-ob-uk-rs-validation/secure-api-gateway-ob-uk-rs-validation-obie/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/validation/obie/payment/OBDomesticVRPRequestValidatorTest.java
+++ b/secure-api-gateway-ob-uk-rs-validation/secure-api-gateway-ob-uk-rs-validation-obie/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/validation/obie/payment/OBDomesticVRPRequestValidatorTest.java
@@ -28,12 +28,12 @@ import com.forgerock.sapi.gateway.ob.uk.common.error.OBRIErrorType;
 import com.forgerock.sapi.gateway.ob.uk.rs.validation.ValidationResult;
 import com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.payment.OBDomesticVRPRequestValidator.OBDomesticVRPRequestValidationContext;
 
-import uk.org.openbanking.datamodel.common.OBActiveOrHistoricCurrencyAndAmount;
-import uk.org.openbanking.datamodel.error.OBError1;
-import uk.org.openbanking.datamodel.vrp.OBDomesticVRPConsentRequest;
-import uk.org.openbanking.datamodel.vrp.OBDomesticVRPControlParameters;
-import uk.org.openbanking.datamodel.vrp.OBDomesticVRPInstruction;
-import uk.org.openbanking.datamodel.vrp.OBDomesticVRPRequest;
+import uk.org.openbanking.datamodel.v3.common.OBActiveOrHistoricCurrencyAndAmount;
+import uk.org.openbanking.datamodel.v3.error.OBError1;
+import uk.org.openbanking.datamodel.v3.vrp.OBDomesticVRPConsentRequest;
+import uk.org.openbanking.datamodel.v3.vrp.OBDomesticVRPControlParameters;
+import uk.org.openbanking.datamodel.v3.vrp.OBDomesticVRPInstruction;
+import uk.org.openbanking.datamodel.v3.vrp.OBDomesticVRPRequest;
 import uk.org.openbanking.testsupport.vrp.OBDomesticVrpConsentRequestTestDataFactory;
 import uk.org.openbanking.testsupport.vrp.OBDomesticVrpRequestTestDataFactory;
 

--- a/secure-api-gateway-ob-uk-rs-validation/secure-api-gateway-ob-uk-rs-validation-obie/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/validation/obie/payment/OBRisk1ValidatorTest.java
+++ b/secure-api-gateway-ob-uk-rs-validation/secure-api-gateway-ob-uk-rs-validation-obie/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/validation/obie/payment/OBRisk1ValidatorTest.java
@@ -24,8 +24,8 @@ import org.junit.jupiter.api.Test;
 
 import com.forgerock.sapi.gateway.ob.uk.common.error.OBRIErrorType;
 
-import uk.org.openbanking.datamodel.common.OBExternalPaymentContext1Code;
-import uk.org.openbanking.datamodel.common.OBRisk1;
+import uk.org.openbanking.datamodel.v3.common.OBExternalPaymentContext1Code;
+import uk.org.openbanking.datamodel.v3.common.OBRisk1;
 
 public class OBRisk1ValidatorTest {
 

--- a/secure-api-gateway-ob-uk-rs-validation/secure-api-gateway-ob-uk-rs-validation-obie/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/validation/obie/payment/OBWriteDomestic2DataInitiationInstructedAmountValidatorTest.java
+++ b/secure-api-gateway-ob-uk-rs-validation/secure-api-gateway-ob-uk-rs-validation-obie/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/validation/obie/payment/OBWriteDomestic2DataInitiationInstructedAmountValidatorTest.java
@@ -22,8 +22,8 @@ import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
-import uk.org.openbanking.datamodel.error.OBError1;
-import uk.org.openbanking.datamodel.payment.OBWriteDomestic2DataInitiationInstructedAmount;
+import uk.org.openbanking.datamodel.v3.error.OBError1;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteDomestic2DataInitiationInstructedAmount;
 
 public class OBWriteDomestic2DataInitiationInstructedAmountValidatorTest {
 

--- a/secure-api-gateway-ob-uk-rs-validation/secure-api-gateway-ob-uk-rs-validation-obie/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/validation/obie/payment/OBWriteDomestic2ValidatorTest.java
+++ b/secure-api-gateway-ob-uk-rs-validation/secure-api-gateway-ob-uk-rs-validation-obie/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/validation/obie/payment/OBWriteDomestic2ValidatorTest.java
@@ -24,16 +24,16 @@ import org.junit.jupiter.api.Test;
 
 import com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.payment.OBWriteDomestic2Validator.OBWriteDomestic2ValidationContext;
 
-import uk.org.openbanking.datamodel.common.OBExternalPaymentContext1Code;
-import uk.org.openbanking.datamodel.common.OBRisk1;
-import uk.org.openbanking.datamodel.error.OBError1;
-import uk.org.openbanking.datamodel.payment.OBPaymentConsentStatus;
-import uk.org.openbanking.datamodel.payment.OBWriteDomestic2;
-import uk.org.openbanking.datamodel.payment.OBWriteDomestic2Data;
-import uk.org.openbanking.datamodel.payment.OBWriteDomestic2DataInitiation;
-import uk.org.openbanking.datamodel.payment.OBWriteDomestic2DataInitiationInstructedAmount;
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticConsent4;
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticConsent4Data;
+import uk.org.openbanking.datamodel.v3.common.OBExternalPaymentContext1Code;
+import uk.org.openbanking.datamodel.v3.common.OBRisk1;
+import uk.org.openbanking.datamodel.v3.error.OBError1;
+import uk.org.openbanking.datamodel.v3.payment.OBPaymentConsentStatus;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteDomestic2;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteDomestic2Data;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteDomestic2DataInitiation;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteDomestic2DataInitiationInstructedAmount;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteDomesticConsent4;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteDomesticConsent4Data;
 
 class OBWriteDomestic2ValidatorTest {
 

--- a/secure-api-gateway-ob-uk-rs-validation/secure-api-gateway-ob-uk-rs-validation-obie/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/validation/obie/payment/OBWriteFile2ValidatorTest.java
+++ b/secure-api-gateway-ob-uk-rs-validation/secure-api-gateway-ob-uk-rs-validation-obie/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/validation/obie/payment/OBWriteFile2ValidatorTest.java
@@ -27,12 +27,12 @@ import com.forgerock.sapi.gateway.ob.uk.rs.validation.ValidationResult;
 import com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.payment.OBWriteFile2Validator.OBWriteFile2ValidationContext;
 import com.forgerock.sapi.gateway.uk.common.shared.api.meta.share.IntentType;
 
-import uk.org.openbanking.datamodel.error.OBError1;
-import uk.org.openbanking.datamodel.payment.OBWriteFile2;
-import uk.org.openbanking.datamodel.payment.OBWriteFile2Data;
-import uk.org.openbanking.datamodel.payment.OBWriteFile2DataInitiation;
-import uk.org.openbanking.datamodel.payment.OBWriteFileConsent3;
-import uk.org.openbanking.datamodel.payment.OBWriteFileConsentResponse4DataStatus;
+import uk.org.openbanking.datamodel.v3.error.OBError1;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteFile2;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteFile2Data;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteFile2DataInitiation;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteFileConsent3;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteFileConsentResponse4DataStatus;
 import uk.org.openbanking.testsupport.payment.OBWriteFileConsentTestDataFactory;
 
 class OBWriteFile2ValidatorTest {

--- a/secure-api-gateway-ob-uk-rs-validation/secure-api-gateway-ob-uk-rs-validation-obie/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/validation/obie/payment/OBWriteInternational3DataInitiationExchangeRateInformationValidatorTest.java
+++ b/secure-api-gateway-ob-uk-rs-validation/secure-api-gateway-ob-uk-rs-validation-obie/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/validation/obie/payment/OBWriteInternational3DataInitiationExchangeRateInformationValidatorTest.java
@@ -26,8 +26,8 @@ import org.junit.jupiter.api.Test;
 
 import com.forgerock.sapi.gateway.ob.uk.common.error.OBRIErrorType;
 
-import uk.org.openbanking.datamodel.payment.OBExchangeRateType;
-import uk.org.openbanking.datamodel.payment.OBWriteInternational3DataInitiationExchangeRateInformation;
+import uk.org.openbanking.datamodel.v3.payment.OBExchangeRateType;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteInternational3DataInitiationExchangeRateInformation;
 
 
 public class OBWriteInternational3DataInitiationExchangeRateInformationValidatorTest {

--- a/secure-api-gateway-ob-uk-rs-validation/secure-api-gateway-ob-uk-rs-validation-obie/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/validation/obie/payment/OBWriteInternational3ValidatorTest.java
+++ b/secure-api-gateway-ob-uk-rs-validation/secure-api-gateway-ob-uk-rs-validation-obie/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/validation/obie/payment/OBWriteInternational3ValidatorTest.java
@@ -24,16 +24,16 @@ import org.junit.jupiter.api.Test;
 
 import com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.payment.OBWriteInternational3Validator.OBWriteInternational3ValidationContext;
 
-import uk.org.openbanking.datamodel.common.OBExternalPaymentContext1Code;
-import uk.org.openbanking.datamodel.common.OBRisk1;
-import uk.org.openbanking.datamodel.error.OBError1;
-import uk.org.openbanking.datamodel.payment.OBPaymentConsentStatus;
-import uk.org.openbanking.datamodel.payment.OBWriteDomestic2DataInitiationInstructedAmount;
-import uk.org.openbanking.datamodel.payment.OBWriteInternational3;
-import uk.org.openbanking.datamodel.payment.OBWriteInternational3Data;
-import uk.org.openbanking.datamodel.payment.OBWriteInternational3DataInitiation;
-import uk.org.openbanking.datamodel.payment.OBWriteInternationalConsent5;
-import uk.org.openbanking.datamodel.payment.OBWriteInternationalConsent5Data;
+import uk.org.openbanking.datamodel.v3.common.OBExternalPaymentContext1Code;
+import uk.org.openbanking.datamodel.v3.common.OBRisk1;
+import uk.org.openbanking.datamodel.v3.error.OBError1;
+import uk.org.openbanking.datamodel.v3.payment.OBPaymentConsentStatus;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteDomestic2DataInitiationInstructedAmount;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteInternational3;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteInternational3Data;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteInternational3DataInitiation;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteInternationalConsent5;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteInternationalConsent5Data;
 
 class OBWriteInternational3ValidatorTest {
 

--- a/secure-api-gateway-ob-uk-rs-validation/secure-api-gateway-ob-uk-rs-validation-obie/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/validation/obie/payment/OBWriteInternationalScheduled3ValidatorTest.java
+++ b/secure-api-gateway-ob-uk-rs-validation/secure-api-gateway-ob-uk-rs-validation-obie/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/validation/obie/payment/OBWriteInternationalScheduled3ValidatorTest.java
@@ -24,16 +24,16 @@ import org.junit.jupiter.api.Test;
 
 import com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.payment.OBWriteInternationalScheduled3Validator.OBWriteInternationalScheduled3ValidationContext;
 
-import uk.org.openbanking.datamodel.common.OBExternalPaymentContext1Code;
-import uk.org.openbanking.datamodel.common.OBRisk1;
-import uk.org.openbanking.datamodel.error.OBError1;
-import uk.org.openbanking.datamodel.payment.OBPaymentConsentStatus;
-import uk.org.openbanking.datamodel.payment.OBWriteDomestic2DataInitiationInstructedAmount;
-import uk.org.openbanking.datamodel.payment.OBWriteInternationalScheduled3;
-import uk.org.openbanking.datamodel.payment.OBWriteInternationalScheduled3Data;
-import uk.org.openbanking.datamodel.payment.OBWriteInternationalScheduled3DataInitiation;
-import uk.org.openbanking.datamodel.payment.OBWriteInternationalScheduledConsent5;
-import uk.org.openbanking.datamodel.payment.OBWriteInternationalScheduledConsent5Data;
+import uk.org.openbanking.datamodel.v3.common.OBExternalPaymentContext1Code;
+import uk.org.openbanking.datamodel.v3.common.OBRisk1;
+import uk.org.openbanking.datamodel.v3.error.OBError1;
+import uk.org.openbanking.datamodel.v3.payment.OBPaymentConsentStatus;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteDomestic2DataInitiationInstructedAmount;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteInternationalScheduled3;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteInternationalScheduled3Data;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteInternationalScheduled3DataInitiation;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteInternationalScheduledConsent5;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteInternationalScheduledConsent5Data;
 
 class OBWriteInternationalScheduled3ValidatorTest {
 

--- a/secure-api-gateway-ob-uk-rs-validation/secure-api-gateway-ob-uk-rs-validation-obie/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/validation/obie/payment/OBWriteInternationalStandingOrder4ValidatorTest.java
+++ b/secure-api-gateway-ob-uk-rs-validation/secure-api-gateway-ob-uk-rs-validation-obie/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/validation/obie/payment/OBWriteInternationalStandingOrder4ValidatorTest.java
@@ -24,16 +24,16 @@ import org.junit.jupiter.api.Test;
 
 import com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.payment.OBWriteInternationalStandingOrder4Validator.OBWriteInternationalStandingOrder4ValidationContext;
 
-import uk.org.openbanking.datamodel.common.OBExternalPaymentContext1Code;
-import uk.org.openbanking.datamodel.common.OBRisk1;
-import uk.org.openbanking.datamodel.error.OBError1;
-import uk.org.openbanking.datamodel.payment.OBPaymentConsentStatus;
-import uk.org.openbanking.datamodel.payment.OBWriteDomestic2DataInitiationInstructedAmount;
-import uk.org.openbanking.datamodel.payment.OBWriteInternationalStandingOrder4;
-import uk.org.openbanking.datamodel.payment.OBWriteInternationalStandingOrder4Data;
-import uk.org.openbanking.datamodel.payment.OBWriteInternationalStandingOrder4DataInitiation;
-import uk.org.openbanking.datamodel.payment.OBWriteInternationalStandingOrderConsent6;
-import uk.org.openbanking.datamodel.payment.OBWriteInternationalStandingOrderConsent6Data;
+import uk.org.openbanking.datamodel.v3.common.OBExternalPaymentContext1Code;
+import uk.org.openbanking.datamodel.v3.common.OBRisk1;
+import uk.org.openbanking.datamodel.v3.error.OBError1;
+import uk.org.openbanking.datamodel.v3.payment.OBPaymentConsentStatus;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteDomestic2DataInitiationInstructedAmount;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteInternationalStandingOrder4;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteInternationalStandingOrder4Data;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteInternationalStandingOrder4DataInitiation;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteInternationalStandingOrderConsent6;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteInternationalStandingOrderConsent6Data;
 
 class OBWriteInternationalStandingOrder4ValidatorTest {
 

--- a/secure-api-gateway-ob-uk-rs-validation/secure-api-gateway-ob-uk-rs-validation-obie/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/validation/obie/payment/consent/OBDomesticVRPConsentRequestValidatorTest.java
+++ b/secure-api-gateway-ob-uk-rs-validation/secure-api-gateway-ob-uk-rs-validation-obie/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/validation/obie/payment/consent/OBDomesticVRPConsentRequestValidatorTest.java
@@ -25,7 +25,7 @@ import org.junit.jupiter.api.Test;
 
 import com.forgerock.sapi.gateway.ob.uk.common.error.OBRIErrorType;
 
-import uk.org.openbanking.datamodel.vrp.OBDomesticVRPConsentRequest;
+import uk.org.openbanking.datamodel.v3.vrp.OBDomesticVRPConsentRequest;
 import uk.org.openbanking.testsupport.vrp.OBDomesticVrpConsentRequestTestDataFactory;
 
 class OBDomesticVRPConsentRequestValidatorTest {

--- a/secure-api-gateway-ob-uk-rs-validation/secure-api-gateway-ob-uk-rs-validation-obie/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/validation/obie/payment/consent/OBVRPFundsConfirmationRequestValidatorTest.java
+++ b/secure-api-gateway-ob-uk-rs-validation/secure-api-gateway-ob-uk-rs-validation-obie/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/validation/obie/payment/consent/OBVRPFundsConfirmationRequestValidatorTest.java
@@ -27,11 +27,11 @@ import com.forgerock.sapi.gateway.ob.uk.common.error.OBRIErrorType;
 import com.forgerock.sapi.gateway.ob.uk.rs.validation.ValidationResult;
 import com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.payment.consent.OBVRPFundsConfirmationRequestValidator.VRPFundsConfirmationValidationContext;
 
-import uk.org.openbanking.datamodel.common.OBActiveOrHistoricCurrencyAndAmount;
-import uk.org.openbanking.datamodel.error.OBError1;
-import uk.org.openbanking.datamodel.vrp.OBDomesticVRPConsentResponseDataStatus;
-import uk.org.openbanking.datamodel.vrp.OBVRPFundsConfirmationRequest;
-import uk.org.openbanking.datamodel.vrp.OBVRPFundsConfirmationRequestData;
+import uk.org.openbanking.datamodel.v3.common.OBActiveOrHistoricCurrencyAndAmount;
+import uk.org.openbanking.datamodel.v3.error.OBError1;
+import uk.org.openbanking.datamodel.v3.vrp.OBDomesticVRPConsentResponseDataStatus;
+import uk.org.openbanking.datamodel.v3.vrp.OBVRPFundsConfirmationRequest;
+import uk.org.openbanking.datamodel.v3.vrp.OBVRPFundsConfirmationRequestData;
 
 class OBVRPFundsConfirmationRequestValidatorTest {
 

--- a/secure-api-gateway-ob-uk-rs-validation/secure-api-gateway-ob-uk-rs-validation-obie/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/validation/obie/payment/consent/OBWriteDomesticConsent4ValidatorTest.java
+++ b/secure-api-gateway-ob-uk-rs-validation/secure-api-gateway-ob-uk-rs-validation-obie/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/validation/obie/payment/consent/OBWriteDomesticConsent4ValidatorTest.java
@@ -30,13 +30,13 @@ import com.forgerock.sapi.gateway.ob.uk.rs.validation.ValidationResult;
 import com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.BaseOBValidator;
 import com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.payment.OBRisk1Validator;
 
-import uk.org.openbanking.datamodel.common.OBExternalPaymentContext1Code;
-import uk.org.openbanking.datamodel.common.OBRisk1;
-import uk.org.openbanking.datamodel.error.OBError1;
-import uk.org.openbanking.datamodel.payment.OBWriteDomestic2DataInitiation;
-import uk.org.openbanking.datamodel.payment.OBWriteDomestic2DataInitiationInstructedAmount;
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticConsent4;
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticConsent4Data;
+import uk.org.openbanking.datamodel.v3.common.OBExternalPaymentContext1Code;
+import uk.org.openbanking.datamodel.v3.common.OBRisk1;
+import uk.org.openbanking.datamodel.v3.error.OBError1;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteDomestic2DataInitiation;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteDomestic2DataInitiationInstructedAmount;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteDomesticConsent4;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteDomesticConsent4Data;
 
 class OBWriteDomesticConsent4ValidatorTest {
 

--- a/secure-api-gateway-ob-uk-rs-validation/secure-api-gateway-ob-uk-rs-validation-obie/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/validation/obie/payment/consent/OBWriteDomesticScheduledConsent4ValidatorTest.java
+++ b/secure-api-gateway-ob-uk-rs-validation/secure-api-gateway-ob-uk-rs-validation-obie/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/validation/obie/payment/consent/OBWriteDomesticScheduledConsent4ValidatorTest.java
@@ -31,12 +31,12 @@ import com.forgerock.sapi.gateway.ob.uk.rs.validation.ValidationResult;
 import com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.BaseOBValidator;
 import com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.payment.OBRisk1Validator;
 
-import uk.org.openbanking.datamodel.common.OBRisk1;
-import uk.org.openbanking.datamodel.error.OBError1;
-import uk.org.openbanking.datamodel.payment.OBWriteDomestic2DataInitiationInstructedAmount;
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticScheduled2DataInitiation;
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticScheduledConsent4;
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticScheduledConsent4Data;
+import uk.org.openbanking.datamodel.v3.common.OBRisk1;
+import uk.org.openbanking.datamodel.v3.error.OBError1;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteDomestic2DataInitiationInstructedAmount;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteDomesticScheduled2DataInitiation;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteDomesticScheduledConsent4;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteDomesticScheduledConsent4Data;
 
 class OBWriteDomesticScheduledConsent4ValidatorTest {
 

--- a/secure-api-gateway-ob-uk-rs-validation/secure-api-gateway-ob-uk-rs-validation-obie/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/validation/obie/payment/consent/OBWriteDomesticStandingOrderConsent5ValidatorTest.java
+++ b/secure-api-gateway-ob-uk-rs-validation/secure-api-gateway-ob-uk-rs-validation-obie/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/validation/obie/payment/consent/OBWriteDomesticStandingOrderConsent5ValidatorTest.java
@@ -28,14 +28,14 @@ import org.junit.jupiter.api.Test;
 import com.forgerock.sapi.gateway.ob.uk.common.error.OBRIErrorType;
 import com.forgerock.sapi.gateway.ob.uk.rs.validation.ValidationResult;
 
-import uk.org.openbanking.datamodel.common.OBRisk1;
-import uk.org.openbanking.datamodel.error.OBError1;
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticStandingOrder3DataInitiation;
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticStandingOrder3DataInitiationFinalPaymentAmount;
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticStandingOrder3DataInitiationFirstPaymentAmount;
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticStandingOrder3DataInitiationRecurringPaymentAmount;
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticStandingOrderConsent5;
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticStandingOrderConsent5Data;
+import uk.org.openbanking.datamodel.v3.common.OBRisk1;
+import uk.org.openbanking.datamodel.v3.error.OBError1;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteDomesticStandingOrder3DataInitiation;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteDomesticStandingOrder3DataInitiationFinalPaymentAmount;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteDomesticStandingOrder3DataInitiationFirstPaymentAmount;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteDomesticStandingOrder3DataInitiationRecurringPaymentAmount;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteDomesticStandingOrderConsent5;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteDomesticStandingOrderConsent5Data;
 
 class OBWriteDomesticStandingOrderConsent5ValidatorTest {
 

--- a/secure-api-gateway-ob-uk-rs-validation/secure-api-gateway-ob-uk-rs-validation-obie/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/validation/obie/payment/consent/OBWriteFileConsent3ValidatorTest.java
+++ b/secure-api-gateway-ob-uk-rs-validation/secure-api-gateway-ob-uk-rs-validation-obie/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/validation/obie/payment/consent/OBWriteFileConsent3ValidatorTest.java
@@ -27,7 +27,7 @@ import org.junit.jupiter.api.Test;
 
 import com.forgerock.sapi.gateway.ob.uk.common.error.OBRIErrorType;
 
-import uk.org.openbanking.datamodel.payment.OBWriteFileConsent3;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteFileConsent3;
 
 class OBWriteFileConsent3ValidatorTest {
 

--- a/secure-api-gateway-ob-uk-rs-validation/secure-api-gateway-ob-uk-rs-validation-obie/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/validation/obie/payment/consent/OBWriteInternationalConsent5ValidatorTest.java
+++ b/secure-api-gateway-ob-uk-rs-validation/secure-api-gateway-ob-uk-rs-validation-obie/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/validation/obie/payment/consent/OBWriteInternationalConsent5ValidatorTest.java
@@ -31,9 +31,9 @@ import org.junit.jupiter.api.Test;
 import com.forgerock.sapi.gateway.ob.uk.common.error.OBRIErrorType;
 import com.forgerock.sapi.gateway.ob.uk.rs.validation.ValidationResult;
 
-import uk.org.openbanking.datamodel.error.OBError1;
-import uk.org.openbanking.datamodel.payment.OBExchangeRateType;
-import uk.org.openbanking.datamodel.payment.OBWriteInternationalConsent5;
+import uk.org.openbanking.datamodel.v3.error.OBError1;
+import uk.org.openbanking.datamodel.v3.payment.OBExchangeRateType;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteInternationalConsent5;
 import uk.org.openbanking.testsupport.payment.OBWriteInternationalConsentTestDataFactory;
 
 class OBWriteInternationalConsent5ValidatorTest {

--- a/secure-api-gateway-ob-uk-rs-validation/secure-api-gateway-ob-uk-rs-validation-obie/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/validation/obie/payment/consent/OBWriteInternationalScheduledConsent5ValidatorTest.java
+++ b/secure-api-gateway-ob-uk-rs-validation/secure-api-gateway-ob-uk-rs-validation-obie/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/validation/obie/payment/consent/OBWriteInternationalScheduledConsent5ValidatorTest.java
@@ -32,9 +32,9 @@ import org.junit.jupiter.api.Test;
 import com.forgerock.sapi.gateway.ob.uk.common.error.OBRIErrorType;
 import com.forgerock.sapi.gateway.ob.uk.rs.validation.ValidationResult;
 
-import uk.org.openbanking.datamodel.error.OBError1;
-import uk.org.openbanking.datamodel.payment.OBExchangeRateType;
-import uk.org.openbanking.datamodel.payment.OBWriteInternationalScheduledConsent5;
+import uk.org.openbanking.datamodel.v3.error.OBError1;
+import uk.org.openbanking.datamodel.v3.payment.OBExchangeRateType;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteInternationalScheduledConsent5;
 import uk.org.openbanking.testsupport.payment.OBWriteInternationalScheduledConsentTestDataFactory;
 
 class OBWriteInternationalScheduledConsent5ValidatorTest {

--- a/secure-api-gateway-ob-uk-rs-validation/secure-api-gateway-ob-uk-rs-validation-obie/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/validation/obie/payment/consent/OBWriteInternationalStandingOrderConsent6ValidatorTest.java
+++ b/secure-api-gateway-ob-uk-rs-validation/secure-api-gateway-ob-uk-rs-validation-obie/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/validation/obie/payment/consent/OBWriteInternationalStandingOrderConsent6ValidatorTest.java
@@ -29,8 +29,8 @@ import org.junit.jupiter.api.Test;
 import com.forgerock.sapi.gateway.ob.uk.common.error.OBRIErrorType;
 import com.forgerock.sapi.gateway.ob.uk.rs.validation.ValidationResult;
 
-import uk.org.openbanking.datamodel.error.OBError1;
-import uk.org.openbanking.datamodel.payment.OBWriteInternationalStandingOrderConsent6;
+import uk.org.openbanking.datamodel.v3.error.OBError1;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteInternationalStandingOrderConsent6;
 import uk.org.openbanking.testsupport.payment.OBWriteInternationalStandingOrderConsentTestDataFactory;
 
 class OBWriteInternationalStandingOrderConsent6ValidatorTest {


### PR DESCRIPTION
OB datamodel classes have been moved under a v3 pkg in the latest version of common.

https://github.com/SecureApiGateway/SecureApiGateway/issues/1477