### PR TITLE
1504: Use v3.1.10 Domestic Standing Order Consent Store Client

### DIFF
--- a/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/v3_1_10/domesticstandingorders/DomesticStandingOrderConsentsApiController.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/v3_1_10/domesticstandingorders/DomesticStandingOrderConsentsApiController.java
@@ -23,9 +23,9 @@ import java.util.List;
 
 import jakarta.servlet.http.HttpServletRequest;
 
-import org.joda.time.DateTime;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
@@ -35,7 +35,7 @@ import com.forgerock.sapi.gateway.ob.uk.common.error.OBErrorResponseException;
 import com.forgerock.sapi.gateway.ob.uk.rs.obie.api.payment.v3_1_10.domesticstandingorders.DomesticStandingOrderConsentsApi;
 import com.forgerock.sapi.gateway.ob.uk.rs.server.api.obie.payment.factories.OBWriteDomesticStandingOrderConsentResponse6Factory;
 import com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.OBValidationService;
-import com.forgerock.sapi.gateway.rcs.consent.store.client.payment.domesticstandingorder.v3_1_10.DomesticStandingOrderConsentStoreClient;
+import com.forgerock.sapi.gateway.rcs.consent.store.client.payment.domesticstandingorder.DomesticStandingOrderConsentStoreClient;
 import com.forgerock.sapi.gateway.rcs.consent.store.datamodel.payment.domesticstandingorder.v3_1_10.CreateDomesticStandingOrderConsentRequest;
 import com.forgerock.sapi.gateway.rcs.consent.store.datamodel.payment.domesticstandingorder.v3_1_10.DomesticStandingOrderConsent;
 
@@ -53,7 +53,8 @@ public class DomesticStandingOrderConsentsApiController implements DomesticStand
 
     private final OBWriteDomesticStandingOrderConsentResponse6Factory consentResponseFactory;
 
-    public DomesticStandingOrderConsentsApiController(DomesticStandingOrderConsentStoreClient consentStoreApiClient,
+    public DomesticStandingOrderConsentsApiController(
+            @Qualifier("v3.1.10RestDomesticStandingOrderConsentStoreClient")DomesticStandingOrderConsentStoreClient consentStoreApiClient,
             OBValidationService<OBWriteDomesticStandingOrderConsent5> consentValidator,
             OBWriteDomesticStandingOrderConsentResponse6Factory consentResponseFactory) {
 

--- a/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/v3_1_10/domesticstandingorders/DomesticStandingOrdersApiController.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/main/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/v3_1_10/domesticstandingorders/DomesticStandingOrdersApiController.java
@@ -36,6 +36,7 @@ import java.util.UUID;
 import org.joda.time.DateTime;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 
@@ -59,7 +60,7 @@ import com.forgerock.sapi.gateway.ob.uk.rs.server.validator.PaymentSubmissionVal
 import com.forgerock.sapi.gateway.ob.uk.rs.server.validator.ResourceVersionValidator;
 import com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.OBValidationService;
 import com.forgerock.sapi.gateway.ob.uk.rs.validation.obie.payment.OBWriteDomesticStandingOrder3Validator.OBWriteDomesticStandingOrder3ValidationContext;
-import com.forgerock.sapi.gateway.rcs.consent.store.client.payment.domesticstandingorder.v3_1_10.DomesticStandingOrderConsentStoreClient;
+import com.forgerock.sapi.gateway.rcs.consent.store.client.payment.domesticstandingorder.DomesticStandingOrderConsentStoreClient;
 import com.forgerock.sapi.gateway.rcs.consent.store.datamodel.payment.ConsumePaymentConsentRequest;
 import com.forgerock.sapi.gateway.rcs.consent.store.datamodel.payment.domesticstandingorder.v3_1_10.DomesticStandingOrderConsent;
 import com.forgerock.sapi.gateway.rs.resource.store.repo.entity.payment.FRDomesticStandingOrderPaymentSubmission;
@@ -94,7 +95,7 @@ public class DomesticStandingOrdersApiController implements DomesticStandingOrde
     public DomesticStandingOrdersApiController(
             DomesticStandingOrderPaymentSubmissionRepository standingOrderPaymentSubmissionRepository,
             PaymentSubmissionValidator paymentSubmissionValidator,
-            DomesticStandingOrderConsentStoreClient consentStoreClient,
+            @Qualifier("v3.1.10RestDomesticStandingOrderConsentStoreClient") DomesticStandingOrderConsentStoreClient consentStoreClient,
             OBValidationService<OBWriteDomesticStandingOrder3ValidationContext> paymentValidator,
             RefundAccountService refundAccountService) {
         this.standingOrderPaymentSubmissionRepository = standingOrderPaymentSubmissionRepository;

--- a/secure-api-gateway-ob-uk-rs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/v3_1_10/domesticstandingorders/DomesticStandingOrderConsentsApiControllerTest.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/v3_1_10/domesticstandingorders/DomesticStandingOrderConsentsApiControllerTest.java
@@ -32,6 +32,7 @@ import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.test.web.client.TestRestTemplate;
@@ -48,7 +49,7 @@ import com.forgerock.sapi.gateway.ob.uk.common.error.ErrorCode;
 import com.forgerock.sapi.gateway.ob.uk.rs.server.testsupport.api.HttpHeadersTestDataFactory;
 import com.forgerock.sapi.gateway.rcs.consent.store.client.ConsentStoreClientException;
 import com.forgerock.sapi.gateway.rcs.consent.store.client.ConsentStoreClientException.ErrorType;
-import com.forgerock.sapi.gateway.rcs.consent.store.client.payment.domesticstandingorder.v3_1_10.DomesticStandingOrderConsentStoreClient;
+import com.forgerock.sapi.gateway.rcs.consent.store.client.payment.domesticstandingorder.DomesticStandingOrderConsentStoreClient;
 import com.forgerock.sapi.gateway.rcs.consent.store.datamodel.payment.domesticstandingorder.v3_1_10.CreateDomesticStandingOrderConsentRequest;
 import com.forgerock.sapi.gateway.rcs.consent.store.datamodel.payment.domesticstandingorder.v3_1_10.DomesticStandingOrderConsent;
 import com.forgerock.sapi.gateway.uk.common.shared.api.meta.share.IntentType;
@@ -67,7 +68,6 @@ import uk.org.openbanking.testsupport.payment.OBWriteDomesticStandingOrderConsen
 @ActiveProfiles("test")
 public class DomesticStandingOrderConsentsApiControllerTest {
 
-
     private static final String TEST_API_CLIENT_ID = "client_234093-49";
 
     private static final HttpHeaders HTTP_HEADERS = HttpHeadersTestDataFactory.requiredPaymentHttpHeaders(TEST_API_CLIENT_ID);
@@ -79,6 +79,7 @@ public class DomesticStandingOrderConsentsApiControllerTest {
     private TestRestTemplate restTemplate;
 
     @MockBean
+    @Qualifier("v3.1.10RestDomesticStandingOrderConsentStoreClient")
     private DomesticStandingOrderConsentStoreClient consentStoreClient;
 
     private String controllerBaseUri;
@@ -87,7 +88,6 @@ public class DomesticStandingOrderConsentsApiControllerTest {
     public void postConstruct() {
         controllerBaseUri = "http://localhost:" + port + "/open-banking/v3.1.10/pisp/domestic-standing-order-consents";
     }
-
 
     @Test
     public void testCreateConsent() {

--- a/secure-api-gateway-ob-uk-rs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/v3_1_10/domesticstandingorders/DomesticStandingOrdersApiControllerTest.java
+++ b/secure-api-gateway-ob-uk-rs-server/src/test/java/com/forgerock/sapi/gateway/ob/uk/rs/server/api/obie/payment/v3_1_10/domesticstandingorders/DomesticStandingOrdersApiControllerTest.java
@@ -38,6 +38,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.test.web.client.TestRestTemplate;
@@ -56,7 +57,7 @@ import com.forgerock.sapi.gateway.ob.uk.common.datamodel.converter.payment.FRWri
 import com.forgerock.sapi.gateway.ob.uk.common.error.OBRIErrorType;
 import com.forgerock.sapi.gateway.ob.uk.rs.server.common.util.PaymentsUtils;
 import com.forgerock.sapi.gateway.ob.uk.rs.server.testsupport.api.HttpHeadersTestDataFactory;
-import com.forgerock.sapi.gateway.rcs.consent.store.client.payment.domesticstandingorder.v3_1_10.DomesticStandingOrderConsentStoreClient;
+import com.forgerock.sapi.gateway.rcs.consent.store.client.payment.domesticstandingorder.DomesticStandingOrderConsentStoreClient;
 import com.forgerock.sapi.gateway.rcs.consent.store.datamodel.payment.ConsumePaymentConsentRequest;
 import com.forgerock.sapi.gateway.rcs.consent.store.datamodel.payment.domesticstandingorder.v3_1_10.DomesticStandingOrderConsent;
 import com.forgerock.sapi.gateway.rs.resource.store.repo.entity.account.FRAccount;
@@ -103,6 +104,7 @@ public class DomesticStandingOrdersApiControllerTest {
     private TestRestTemplate restTemplate;
 
     @MockBean
+    @Qualifier("v3.1.10RestDomesticStandingOrderConsentStoreClient")
     private DomesticStandingOrderConsentStoreClient consentStoreClient;
 
     @MockBean


### PR DESCRIPTION
RCS Consent Store client provides beans for v3.1.10 and v4.0.0 DomesticStandingOrderConsentStoreClient. Updating existing controllers to use bean: v3.1.10RestDomesticStandingOrderConsentStoreClient

Related RCS PR:
https://github.com/SecureApiGateway/secure-api-gateway-ob-uk-rcs/pull/243

https://github.com/SecureApiGateway/SecureApiGateway/issues/1504