### PR TITLE
1605: Make sure dev branches are not using latest snapshots for artifacts

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,12 +46,12 @@
     <parent>
         <groupId>com.forgerock.sapi.gateway</groupId>
         <artifactId>secure-api-gateway-parent</artifactId>
-        <version>4.0.0</version>
+        <version>4.0.1-SNAPSHOT</version>
     </parent>
 
     <properties>
-        <uk.bom.version>4.0.0</uk.bom.version>
-        <consent.api.version>4.0.0</consent.api.version>
+        <uk.bom.version>4.0.1-SNAPSHOT</uk.bom.version>
+        <consent.api.version>4.0.1-SNAPSHOT</consent.api.version>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
Bump Parent, Common & RCS to snapshot version

Issue: https://github.com/SecureApiGateway/SecureApiGateway/issues/1605