### PR TITLE
1626: Prepare repos for Post 4.0.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,12 +46,12 @@
     <parent>
         <groupId>com.forgerock.sapi.gateway</groupId>
         <artifactId>secure-api-gateway-parent</artifactId>
-        <version>4.0.0</version>
+        <version>4.0.4-SNAPSHOT</version>
     </parent>
 
     <properties>
-        <uk.bom.version>4.0.3</uk.bom.version>
-        <consent.api.version>4.0.3</consent.api.version>
+        <uk.bom.version>4.0.4-SNAPSHOT</uk.bom.version>
+        <consent.api.version>4.0.4-SNAPSHOT</consent.api.version>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
Bump parent, common and RCS version to 4.0.4-SNAPSHOT

Issue: https://github.com/SecureApiGateway/SecureApiGateway/issues/1626