### PR TITLE
OPENIG-10328 Bump SAPIG versions for dev after release of SAPIG 5.2.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,10 +21,10 @@
     <parent>
         <groupId>com.forgerock.sapi.gateway</groupId>
         <artifactId>secure-api-gateway-parent</artifactId>
-        <version>5.2.0-SNAPSHOT</version>
+        <version>5.3.0-SNAPSHOT</version>
     </parent>
     <artifactId>secure-api-gateway-ob-uk-rs</artifactId>
-    <version>5.2.0-SNAPSHOT</version>
+    <version>5.3.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>secure-api-gateway-ob-uk-rs</name>
     <description>A UK Open Banking Resource Server for the Secure API Gateway</description>
@@ -80,8 +80,8 @@
     </repositories>
 
     <properties>
-        <uk.bom.version>5.2.0-SNAPSHOT</uk.bom.version>
-        <consent.api.version>5.2.0-SNAPSHOT</consent.api.version>
+        <uk.bom.version>5.3.0-SNAPSHOT</uk.bom.version>
+        <consent.api.version>5.3.0-SNAPSHOT</consent.api.version>
     </properties>
 
     <dependencyManagement>

--- a/secure-api-gateway-ob-uk-rs-backoffice-api/pom.xml
+++ b/secure-api-gateway-ob-uk-rs-backoffice-api/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.forgerock.sapi.gateway</groupId>
         <artifactId>secure-api-gateway-ob-uk-rs</artifactId>
-        <version>5.2.0-SNAPSHOT</version>
+        <version>5.3.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>secure-api-gateway-ob-uk-rs-backoffice-api</artifactId>

--- a/secure-api-gateway-ob-uk-rs-cloud-client/pom.xml
+++ b/secure-api-gateway-ob-uk-rs-cloud-client/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.forgerock.sapi.gateway</groupId>
         <artifactId>secure-api-gateway-ob-uk-rs</artifactId>
-        <version>5.2.0-SNAPSHOT</version>
+        <version>5.3.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>secure-api-gateway-ob-uk-rs-cloud-client</artifactId>

--- a/secure-api-gateway-ob-uk-rs-obie-api/pom.xml
+++ b/secure-api-gateway-ob-uk-rs-obie-api/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.forgerock.sapi.gateway</groupId>
         <artifactId>secure-api-gateway-ob-uk-rs</artifactId>
-        <version>5.2.0-SNAPSHOT</version>
+        <version>5.3.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>secure-api-gateway-ob-uk-rs-obie-api</artifactId>

--- a/secure-api-gateway-ob-uk-rs-resource-store/pom.xml
+++ b/secure-api-gateway-ob-uk-rs-resource-store/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.forgerock.sapi.gateway</groupId>
         <artifactId>secure-api-gateway-ob-uk-rs</artifactId>
-        <version>5.2.0-SNAPSHOT</version>
+        <version>5.3.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>secure-api-gateway-ob-uk-rs-resource-store</artifactId>

--- a/secure-api-gateway-ob-uk-rs-resource-store/secure-api-gateway-ob-uk-rs-resource-store-api/pom.xml
+++ b/secure-api-gateway-ob-uk-rs-resource-store/secure-api-gateway-ob-uk-rs-resource-store-api/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.forgerock.sapi.gateway</groupId>
         <artifactId>secure-api-gateway-ob-uk-rs-resource-store</artifactId>
-        <version>5.2.0-SNAPSHOT</version>
+        <version>5.3.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>secure-api-gateway-ob-uk-rs-resource-store-api</artifactId>

--- a/secure-api-gateway-ob-uk-rs-resource-store/secure-api-gateway-ob-uk-rs-resource-store-datamodel/pom.xml
+++ b/secure-api-gateway-ob-uk-rs-resource-store/secure-api-gateway-ob-uk-rs-resource-store-datamodel/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.forgerock.sapi.gateway</groupId>
         <artifactId>secure-api-gateway-ob-uk-rs-resource-store</artifactId>
-        <version>5.2.0-SNAPSHOT</version>
+        <version>5.3.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>secure-api-gateway-ob-uk-rs-resource-store-datamodel</artifactId>

--- a/secure-api-gateway-ob-uk-rs-resource-store/secure-api-gateway-ob-uk-rs-resource-store-repo/pom.xml
+++ b/secure-api-gateway-ob-uk-rs-resource-store/secure-api-gateway-ob-uk-rs-resource-store-repo/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.forgerock.sapi.gateway</groupId>
         <artifactId>secure-api-gateway-ob-uk-rs-resource-store</artifactId>
-        <version>5.2.0-SNAPSHOT</version>
+        <version>5.3.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>secure-api-gateway-ob-uk-rs-resource-store-repo</artifactId>

--- a/secure-api-gateway-ob-uk-rs-server/pom.xml
+++ b/secure-api-gateway-ob-uk-rs-server/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.forgerock.sapi.gateway</groupId>
         <artifactId>secure-api-gateway-ob-uk-rs</artifactId>
-        <version>5.2.0-SNAPSHOT</version>
+        <version>5.3.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>secure-api-gateway-ob-uk-rs-server</artifactId>

--- a/secure-api-gateway-ob-uk-rs-validation/pom.xml
+++ b/secure-api-gateway-ob-uk-rs-validation/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.forgerock.sapi.gateway</groupId>
         <artifactId>secure-api-gateway-ob-uk-rs</artifactId>
-        <version>5.2.0-SNAPSHOT</version>
+        <version>5.3.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>secure-api-gateway-ob-uk-rs-validation</artifactId>

--- a/secure-api-gateway-ob-uk-rs-validation/secure-api-gateway-ob-uk-rs-validation-core/pom.xml
+++ b/secure-api-gateway-ob-uk-rs-validation/secure-api-gateway-ob-uk-rs-validation-core/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.forgerock.sapi.gateway</groupId>
         <artifactId>secure-api-gateway-ob-uk-rs-validation</artifactId>
-        <version>5.2.0-SNAPSHOT</version>
+        <version>5.3.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>secure-api-gateway-ob-uk-rs-validation-core</artifactId>

--- a/secure-api-gateway-ob-uk-rs-validation/secure-api-gateway-ob-uk-rs-validation-obie/pom.xml
+++ b/secure-api-gateway-ob-uk-rs-validation/secure-api-gateway-ob-uk-rs-validation-obie/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.forgerock.sapi.gateway</groupId>
         <artifactId>secure-api-gateway-ob-uk-rs-validation</artifactId>
-        <version>5.2.0-SNAPSHOT</version>
+        <version>5.3.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 


### PR DESCRIPTION
Post-release version bump to 5.3.0-SNAPSHOT / IG 2026.6.0-SNAPSHOT. Part of SAPIG 5.2.0 release.