### PR TITLE
OPENIG-10460 fix logback core versions after ig bom change

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -110,6 +110,12 @@
                 <artifactId>jaxb-impl</artifactId>
                 <version>4.0.6</version>
             </dependency>
+            <!-- IG BOM upgrades logback-classic to 1.5.34 but not logback-core; align them -->
+            <dependency>
+              <groupId>ch.qos.logback</groupId>
+              <artifactId>logback-core</artifactId>
+              <version>1.5.34</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -21,10 +21,10 @@
     <parent>
         <groupId>com.forgerock.sapi.gateway</groupId>
         <artifactId>secure-api-gateway-parent</artifactId>
-        <version>5.2.0-SNAPSHOT</version>
+        <version>5.3.0-SNAPSHOT</version>
     </parent>
     <artifactId>secure-api-gateway-ob-uk-rs</artifactId>
-    <version>5.2.0-SNAPSHOT</version>
+    <version>5.3.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>secure-api-gateway-ob-uk-rs</name>
     <description>A UK Open Banking Resource Server for the Secure API Gateway</description>
@@ -80,8 +80,8 @@
     </repositories>
 
     <properties>
-        <uk.bom.version>5.2.0-SNAPSHOT</uk.bom.version>
-        <consent.api.version>5.2.0-SNAPSHOT</consent.api.version>
+        <uk.bom.version>5.3.0-SNAPSHOT</uk.bom.version>
+        <consent.api.version>5.3.0-SNAPSHOT</consent.api.version>
     </properties>
 
     <dependencyManagement>

--- a/secure-api-gateway-ob-uk-rs-backoffice-api/pom.xml
+++ b/secure-api-gateway-ob-uk-rs-backoffice-api/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.forgerock.sapi.gateway</groupId>
         <artifactId>secure-api-gateway-ob-uk-rs</artifactId>
-        <version>5.2.0-SNAPSHOT</version>
+        <version>5.3.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>secure-api-gateway-ob-uk-rs-backoffice-api</artifactId>

--- a/secure-api-gateway-ob-uk-rs-cloud-client/pom.xml
+++ b/secure-api-gateway-ob-uk-rs-cloud-client/pom.xml
@@ -32,7 +32,6 @@
     <properties>
         <!-- property to run individually the module with no license issues -->
         <legal.path.header>../legal/LICENSE-HEADER.txt</legal.path.header>
-        <logback.version>1.5.25</logback.version>
     </properties>
 
     <dependencies>
@@ -71,12 +70,6 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>ch.qos.logback</groupId>
-            <artifactId>logback-core</artifactId>
-            <version>${logback.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/secure-api-gateway-ob-uk-rs-cloud-client/pom.xml
+++ b/secure-api-gateway-ob-uk-rs-cloud-client/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.forgerock.sapi.gateway</groupId>
         <artifactId>secure-api-gateway-ob-uk-rs</artifactId>
-        <version>5.2.0-SNAPSHOT</version>
+        <version>5.3.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>secure-api-gateway-ob-uk-rs-cloud-client</artifactId>

--- a/secure-api-gateway-ob-uk-rs-obie-api/pom.xml
+++ b/secure-api-gateway-ob-uk-rs-obie-api/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.forgerock.sapi.gateway</groupId>
         <artifactId>secure-api-gateway-ob-uk-rs</artifactId>
-        <version>5.2.0-SNAPSHOT</version>
+        <version>5.3.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>secure-api-gateway-ob-uk-rs-obie-api</artifactId>

--- a/secure-api-gateway-ob-uk-rs-resource-store/pom.xml
+++ b/secure-api-gateway-ob-uk-rs-resource-store/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.forgerock.sapi.gateway</groupId>
         <artifactId>secure-api-gateway-ob-uk-rs</artifactId>
-        <version>5.2.0-SNAPSHOT</version>
+        <version>5.3.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>secure-api-gateway-ob-uk-rs-resource-store</artifactId>

--- a/secure-api-gateway-ob-uk-rs-resource-store/secure-api-gateway-ob-uk-rs-resource-store-api/pom.xml
+++ b/secure-api-gateway-ob-uk-rs-resource-store/secure-api-gateway-ob-uk-rs-resource-store-api/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.forgerock.sapi.gateway</groupId>
         <artifactId>secure-api-gateway-ob-uk-rs-resource-store</artifactId>
-        <version>5.2.0-SNAPSHOT</version>
+        <version>5.3.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>secure-api-gateway-ob-uk-rs-resource-store-api</artifactId>

--- a/secure-api-gateway-ob-uk-rs-resource-store/secure-api-gateway-ob-uk-rs-resource-store-datamodel/pom.xml
+++ b/secure-api-gateway-ob-uk-rs-resource-store/secure-api-gateway-ob-uk-rs-resource-store-datamodel/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.forgerock.sapi.gateway</groupId>
         <artifactId>secure-api-gateway-ob-uk-rs-resource-store</artifactId>
-        <version>5.2.0-SNAPSHOT</version>
+        <version>5.3.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>secure-api-gateway-ob-uk-rs-resource-store-datamodel</artifactId>

--- a/secure-api-gateway-ob-uk-rs-resource-store/secure-api-gateway-ob-uk-rs-resource-store-repo/pom.xml
+++ b/secure-api-gateway-ob-uk-rs-resource-store/secure-api-gateway-ob-uk-rs-resource-store-repo/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.forgerock.sapi.gateway</groupId>
         <artifactId>secure-api-gateway-ob-uk-rs-resource-store</artifactId>
-        <version>5.2.0-SNAPSHOT</version>
+        <version>5.3.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>secure-api-gateway-ob-uk-rs-resource-store-repo</artifactId>

--- a/secure-api-gateway-ob-uk-rs-server/pom.xml
+++ b/secure-api-gateway-ob-uk-rs-server/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.forgerock.sapi.gateway</groupId>
         <artifactId>secure-api-gateway-ob-uk-rs</artifactId>
-        <version>5.2.0-SNAPSHOT</version>
+        <version>5.3.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>secure-api-gateway-ob-uk-rs-server</artifactId>

--- a/secure-api-gateway-ob-uk-rs-server/pom.xml
+++ b/secure-api-gateway-ob-uk-rs-server/pom.xml
@@ -34,7 +34,6 @@
         <gcrRepo>europe-west4-docker.pkg.dev/sbat-gcr-develop/sapig-docker-artifact</gcrRepo>
         <!-- property to run individually the module with no license issues -->
         <legal.path.header>../legal/LICENSE-HEADER.txt</legal.path.header>
-        <logback.version>1.5.25</logback.version>
     </properties>
 
     <dependencies>
@@ -149,12 +148,6 @@
         <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-joda</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>ch.qos.logback</groupId>
-            <artifactId>logback-core</artifactId>
-            <version>${logback.version}</version>
-            <scope>test</scope>
         </dependency>
 
         <!-- ForgeRock Test dependencies -->

--- a/secure-api-gateway-ob-uk-rs-validation/pom.xml
+++ b/secure-api-gateway-ob-uk-rs-validation/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.forgerock.sapi.gateway</groupId>
         <artifactId>secure-api-gateway-ob-uk-rs</artifactId>
-        <version>5.2.0-SNAPSHOT</version>
+        <version>5.3.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>secure-api-gateway-ob-uk-rs-validation</artifactId>

--- a/secure-api-gateway-ob-uk-rs-validation/secure-api-gateway-ob-uk-rs-validation-core/pom.xml
+++ b/secure-api-gateway-ob-uk-rs-validation/secure-api-gateway-ob-uk-rs-validation-core/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.forgerock.sapi.gateway</groupId>
         <artifactId>secure-api-gateway-ob-uk-rs-validation</artifactId>
-        <version>5.2.0-SNAPSHOT</version>
+        <version>5.3.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>secure-api-gateway-ob-uk-rs-validation-core</artifactId>

--- a/secure-api-gateway-ob-uk-rs-validation/secure-api-gateway-ob-uk-rs-validation-obie/pom.xml
+++ b/secure-api-gateway-ob-uk-rs-validation/secure-api-gateway-ob-uk-rs-validation-obie/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.forgerock.sapi.gateway</groupId>
         <artifactId>secure-api-gateway-ob-uk-rs-validation</artifactId>
-        <version>5.2.0-SNAPSHOT</version>
+        <version>5.3.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 


### PR DESCRIPTION
- Change required following upversion to logback-classic in IG BOM to 1.5.34.
- If not set, we'd pick up the older (1.5.21) version from the Spring Boot BOM, causing breakages