### PR TITLE
OPENIG-10460 Fix logback-core version

### DIFF
--- a/secure-api-gateway-ob-uk-rs-cloud-client/pom.xml
+++ b/secure-api-gateway-ob-uk-rs-cloud-client/pom.xml
@@ -32,7 +32,6 @@
     <properties>
         <!-- property to run individually the module with no license issues -->
         <legal.path.header>../legal/LICENSE-HEADER.txt</legal.path.header>
-        <logback.version>1.5.25</logback.version>
     </properties>
 
     <dependencies>
@@ -71,12 +70,6 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>ch.qos.logback</groupId>
-            <artifactId>logback-core</artifactId>
-            <version>${logback.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/secure-api-gateway-ob-uk-rs-server/pom.xml
+++ b/secure-api-gateway-ob-uk-rs-server/pom.xml
@@ -34,7 +34,6 @@
         <gcrRepo>europe-west4-docker.pkg.dev/sbat-gcr-develop/sapig-docker-artifact</gcrRepo>
         <!-- property to run individually the module with no license issues -->
         <legal.path.header>../legal/LICENSE-HEADER.txt</legal.path.header>
-        <logback.version>1.5.25</logback.version>
     </properties>
 
     <dependencies>
@@ -149,12 +148,6 @@
         <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-joda</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>ch.qos.logback</groupId>
-            <artifactId>logback-core</artifactId>
-            <version>${logback.version}</version>
-            <scope>test</scope>
         </dependency>
 
         <!-- ForgeRock Test dependencies -->


### PR DESCRIPTION
- No longer any need of pinned logback versions. Stick with version now set in IG BOM (corrected to include logback-core).